### PR TITLE
Fix Small Build Error

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -14,7 +14,7 @@ nccdoc_DATA = 					\
 	COPYRIGHT				\
 	INDEX					\
 	OVERVIEW				\
-	../README				\
+	../README.md				\
 	mica-debugging.html			\
 	envtarget.html				\
 	nesc-debugging.html			\


### PR DESCRIPTION
The file README was replaced with README.md when switching to github,
but the doc/Makefile.am reference wasn't updated.
