### PR TITLE
Added a flag for warnings for implicit connections

### DIFF
--- a/doc/nescc.1
+++ b/doc/nescc.1
@@ -174,6 +174,9 @@ type does not have a combining function defined.
 Warn when unexpected documentation strings (starting with \fB/**\fR) are
 seen.
 .TP
+\fB-Wnesc-implicit-conn\fR
+Warn when implicit connections between components are used.
+.TP
 \fB-Wnesc-all\fR
 Turns on \fB-Wnesc-fnptr\fR, \fB-Wnesc-async\fR, \fB-Wnesc-combine\fR 
 and\fB-Wnesc-data-race\fR.

--- a/src/flags.c
+++ b/src/flags.c
@@ -240,6 +240,9 @@ int warn_async;
 /* Warn when no combiner function and multiple fns called */
 int warn_no_combiner;
 
+/* Warn when an implicit connection between components is used */
+int warn_implicit_connection;
+
 /* If true, warn_fnptr, warn_data_race, warn_async and warn_no_combiner
    are treated as errors */
 int nesc_error;

--- a/src/flags.h
+++ b/src/flags.h
@@ -237,6 +237,9 @@ extern int warn_async;
 /* Warn when no combiner function and multiple fns called */
 extern int warn_no_combiner;
 
+/* Warn when an implicit connection between components is used */
+extern int warn_implicit_connection;
+
 /* If true, warn_fnptr, warn_data_race, warn_async and warn_no_combiner
    are treated as errors */
 extern int nesc_error;

--- a/src/nesc-configuration.c
+++ b/src/nesc-configuration.c
@@ -486,7 +486,11 @@ static void process_connection(cgraph cg, cgraph userg, connection conn,
       else if (p2.interface) /* f X i */
 	matches = match_function_interface(eqconnection, p1, p2, &p2);
       else /* f X c */
+        {
+          if (warn_implicit_connection)
+            warning_with_location(conn->location, "Implicit connection used.");
 	matches = match_function_component(eqconnection, p1, p2, &p2);
+    }
     }
   else if (p1.interface) /* i X ... */
     {
@@ -495,10 +499,16 @@ static void process_connection(cgraph cg, cgraph userg, connection conn,
       else if (p2.interface) /* i X i */
 	matches = match_endpoints(&p1, &p2, NULL);
       else /* i X c */
+        {
+          if (warn_implicit_connection)
+            warning_with_location(conn->location, "Implicit connection used with external interface.");
 	matches = match_interface_component(eqconnection, p1, p2, &p2);
+    }
     }
   else /* c X ... */
     {
+      if (warn_implicit_connection)
+        warning_with_location(conn->location, "Implicit connection between two components.");
       if (p2.function) /* c X f */
 	matches = match_function_component(eqconnection, p2, p1, &p1);
       else /* c X i */

--- a/src/nesc-main.c
+++ b/src/nesc-main.c
@@ -289,6 +289,10 @@ int nesc_option(char *p)
     warn_no_combiner = 1;
   else if (!strcmp (p, "Wno-nesc-combine"))
     warn_no_combiner = 0;
+  else if (!strcmp (p, "Wnesc-implicit-conn"))
+    warn_implicit_connection = 1;
+  else if (!strcmp (p, "Wno-nesc-implicit-conn"))
+    warn_implicit_connection = 0;
   else if (!strcmp (p, "Wnesc-all"))
     warn_data_race = warn_fnptr = warn_async = warn_no_combiner = 1;
   else if (!strcmp (p, "Wnesc-error"))


### PR DESCRIPTION
-Wnesc-implicit-conn displays a warning when an implicit connection
between components is used.

This is for half of issue #8.
