### PR TITLE
Converted tabs to spaces

### DIFF
--- a/src/AST.c
+++ b/src/AST.c
@@ -44,7 +44,7 @@ unary newkind_unary(region r, AST_kind kind, location location, expression arg1)
 }
 
 binary newkind_binary(region r, AST_kind kind, location location,
-		      expression arg1, expression arg2)
+                      expression arg1, expression arg2)
 {
   binary obj;
 

--- a/src/AST.h
+++ b/src/AST.h
@@ -69,7 +69,7 @@ typedef enum {
 
 unary newkind_unary(region r, AST_kind kind, location location, expression arg1);
 binary newkind_binary(region r, AST_kind kind, location location,
-		      expression arg1, expression arg2);
+                      expression arg1, expression arg2);
 tag_ref newkind_tag_ref(region r, AST_kind kind, location location, word word1, attribute attributes, declaration fields, bool defined);
 void insert_before(node sameregion *list, node before, node n);
 

--- a/src/AST_utils.c
+++ b/src/AST_utils.c
@@ -53,13 +53,13 @@ function_declarator get_fdeclarator(declarator d)
     switch (d->kind)
       {
       case kind_identifier_declarator:
-	return fd;
+        return fd;
       case kind_function_declarator:
-	fd = CAST(function_declarator, d);
-	/* fallthrough */
+        fd = CAST(function_declarator, d);
+        /* fallthrough */
       default:
-	d = CAST(nested_declarator, d)->declarator;
-	break;
+        d = CAST(nested_declarator, d)->declarator;
+        break;
       }
 
   return fd;
@@ -165,11 +165,11 @@ bool expression_used(expression e)
   for (;;)
     {
       if (is_expression_stmt(p1))
-	return FALSE;
+        return FALSE;
       if (!is_comma(p1))
-	return TRUE;
+        return TRUE;
       if (n1)
-	return FALSE; /* Not last in a comma */
+        return FALSE; /* Not last in a comma */
       n1 = p1->next;
       p1 = p1->parent;
     }
@@ -182,20 +182,20 @@ bool zero_expression(expression e)
   for (;;)
     {
       if (is_assign(e))
-	{
-	  e = CAST(assign, e)->arg2;
-	  continue;
-	}
+        {
+          e = CAST(assign, e)->arg2;
+          continue;
+        }
       if (is_cast(e))
-	{
-	  e = CAST(cast, e)->arg1;
-	  continue;
-	}
+        {
+          e = CAST(cast, e)->arg1;
+          continue;
+        }
       if (is_comma(e))
-	{
-	  e = CAST(expression, last_node(CAST(node, CAST(comma, e)->arg1)));
-	  continue;
-	}
+        {
+          e = CAST(expression, last_node(CAST(node, CAST(comma, e)->arg1)));
+          continue;
+        }
       break;
     }
 
@@ -244,7 +244,7 @@ expression build_identifier(region r, location loc, data_declaration id)
   identifier e = new_identifier(r, loc, str2cstring(r, id->name), id);
 
   assert(id->kind == decl_variable || id->kind == decl_function ||
-	 id->kind == decl_constant || id->kind == decl_magic_function);
+         id->kind == decl_constant || id->kind == decl_magic_function);
   e->type = id->type;
   e->cst = fold_identifier(CAST(expression, e), id, 0);
 
@@ -311,15 +311,15 @@ conditional conditional_lvalue(expression e)
   for (;;)
     {
       if (is_cast(e))
-	{
-	  e = CAST(cast, e)->arg1;
-	  continue;
-	}
+        {
+          e = CAST(cast, e)->arg1;
+          continue;
+        }
       if (is_comma(e))
-	{
-	  e = CAST(expression, last_node(CAST(node, CAST(comma, e)->arg1)));
-	  continue;
-	}
+        {
+          e = CAST(expression, last_node(CAST(node, CAST(comma, e)->arg1)));
+          continue;
+        }
       break;
     }
 
@@ -337,8 +337,8 @@ data_declaration string_ddecl(expression s)
 
       /* Must be an offsetless string */
       if (sdecl && sdecl->kind == decl_magic_string &&
-	  cval_knownbool(s->cst->cval))
-	return sdecl;
+          cval_knownbool(s->cst->cval))
+        return sdecl;
     }
   return NULL;
 }

--- a/src/AST_walk.c
+++ b/src/AST_walk.c
@@ -25,7 +25,7 @@ struct AST_walker
 };
 
 static AST_walker_result default_walker(AST_walker spec, void *data,
-					node *n)
+                                        node *n)
 {
   return aw_walk;
 }
@@ -87,16 +87,16 @@ void AST_walk(AST_walker spec, void *data, node *n)
       AST_kind k = (*n)->kind;
 
       switch (AST_walker_call(spec, k, data, n))
-	{
-	case aw_done: return;
-	case aw_call_parent:
-	  k = AST_parent_kind[k - kind_node];
-	  if (!k)
-	    return;
-	  break;
-	case aw_walk:
-	  AST_walk_children(spec, data, *n);
-	  return;
-	}
+        {
+        case aw_done: return;
+        case aw_call_parent:
+          k = AST_parent_kind[k - kind_node];
+          if (!k)
+            return;
+          break;
+        case aw_walk:
+          AST_walk_children(spec, data, *n);
+          return;
+        }
     }
 }

--- a/src/AST_walk.h
+++ b/src/AST_walk.h
@@ -27,7 +27,7 @@ Boston, MA 02111-1307, USA. */
 
 /* Untyped to make declaration easier. Actual signature is
      AST_walker_result AST_walker_fn(AST_walker spec, void *data,
-  				     <your node type> *n);
+                                       <your node type> *n);
    Note: the aw_walk and aw_call_parent results will be applied to
    *n after the walker function returns, not to the orignal node.
 */
@@ -64,6 +64,6 @@ void AST_walk_children(AST_walker spec, void *data, node n);
 
 /* Just execute the walker function for node-type 'kind' */
 AST_walker_result AST_walker_call(AST_walker spec, AST_kind kind,
-				  void *data, node *n);
+                                  void *data, node *n);
 
 #endif

--- a/src/array.c
+++ b/src/array.c
@@ -33,7 +33,7 @@ struct array {
 };
 
 struct array *new_array(region r, size_t initialsize,
-			size_t typesize, type_t typeinfo)
+                        size_t typesize, type_t typeinfo)
 {
   struct array *a = ralloc(r, struct array);
 
@@ -59,7 +59,7 @@ void *array_extend(struct array *a, int by)
       void *newdata = typed_rarrayalloc(a->r, newsize, a->elemsize, a->elemtype);
 
       /* XXX: could work harder to support really large array sizes
-	 (this code will fail for a->nalloc >= (max(size_t)-by)/2) */
+         (this code will fail for a->nalloc >= (max(size_t)-by)/2) */
       assert(newsize > a->nalloc); /* die when we get really big */
       typed_rarraycopy(newdata, a->data, a->nelems, a->elemsize, a->elemtype);
       a->data = newdata;

--- a/src/array.h
+++ b/src/array.h
@@ -29,7 +29,7 @@ Boston, MA 02111-1307, USA. */
 struct array;
 
 struct array *new_array(region r, size_t initialsize,
-			size_t typesize, type_t typeinfo);
+                        size_t typesize, type_t typeinfo);
 void *array_extend(struct array *a, int by);
 void array_reset(struct array *a);
 size_t array_length(struct array *a);

--- a/src/attributes.c
+++ b/src/attributes.c
@@ -13,7 +13,7 @@
 void ignored_attribute(attribute attr)
 {
   warning_with_location(attr->location, "`%s' attribute directive ignored",
-			attr->word1->cstring.data);
+                        attr->word1->cstring.data);
 }
 
 void ignored_gcc_attribute(gcc_attribute attr)
@@ -55,7 +55,7 @@ const char *gcc_attr_get_word(gcc_attribute attr)
     return CAST(identifier, attr->args)->cstring.data;
 
   error_with_location(attr->location, "wrong number of arguments specified for `%s' attribute",
-		      attr->word1->cstring.data);
+                      attr->word1->cstring.data);
 
   return NULL;
 }
@@ -131,7 +131,7 @@ bool handle_gcc_type_attribute(gcc_attribute attr, type *t)
       const char *word = gcc_attr_get_word(attr);
 
       if (word)
-	handle_combine_attribute(attr->location, word, t);
+        handle_combine_attribute(attr->location, word, t);
       return TRUE;
     }
   else if (is_attr_name(name, "aligned"))
@@ -139,7 +139,7 @@ bool handle_gcc_type_attribute(gcc_attribute attr, type *t)
       cval arg = get_alignment(attr);
 
       if (cval_isinteger(arg))
-	*t = align_type(*t, arg);
+        *t = align_type(*t, arg);
       return TRUE;
     }
   else 
@@ -153,67 +153,67 @@ void handle_gcc_decl_attribute(gcc_attribute attr, data_declaration ddecl)
   if (is_attr_name(name, "transparent_union"))
     {
       if (attr->args)
-	error_with_location(attr->location, "wrong number of arguments specified for `transparent_union' attribute");
+        error_with_location(attr->location, "wrong number of arguments specified for `transparent_union' attribute");
 
       if (ddecl->kind == decl_variable && ddecl->isparameter &&
-	  type_union(ddecl->type))
-	transparent_union_argument(ddecl);
+          type_union(ddecl->type))
+        transparent_union_argument(ddecl);
       else if (ddecl->kind == decl_typedef && type_union(ddecl->type))
-	transparent_union_argument(ddecl);
+        transparent_union_argument(ddecl);
       else
-	ignored_gcc_attribute(attr);
+        ignored_gcc_attribute(attr);
     }
   else if (is_attr_name(name, "aligned"))
     {
       cval arg = get_alignment(attr);
 
       if (cval_isinteger(arg))
-	{
-	  if (ddecl->kind == decl_variable || ddecl->kind == decl_typedef)
-	    ddecl->type = align_type(ddecl->type, arg);
-	  else
-	    ignored_gcc_attribute(attr);
-	}
+        {
+          if (ddecl->kind == decl_variable || ddecl->kind == decl_typedef)
+            ddecl->type = align_type(ddecl->type, arg);
+          else
+            ignored_gcc_attribute(attr);
+        }
     }
   else if (is_attr_name(name, "mode"))
     {
       const char *word = gcc_attr_get_word(attr);
 
       if (word)
-	if (!handle_mode_attribute(attr->location, ddecl, word))
-	  ignored_gcc_attribute(attr);
+        if (!handle_mode_attribute(attr->location, ddecl, word))
+          ignored_gcc_attribute(attr);
     }
   else if (is_attr_name(name, "C"))
     {
       if (!ddecl->isexternalscope)
-	error_with_location(attr->location, "`C' attribute is for symbols with external scope only");
+        error_with_location(attr->location, "`C' attribute is for symbols with external scope only");
       else
-	ddecl->Cname = TRUE;
+        ddecl->Cname = TRUE;
     }
   else if (is_attr_name(name, "spontaneous"))
     {
       if (require_function(attr, ddecl))
-	{
-	  /* The test avoids overriding the effect of atomic_hwevent */
-	  if (!ddecl->spontaneous)
-	    ddecl->spontaneous = c_call_nonatomic;
-	}
+        {
+          /* The test avoids overriding the effect of atomic_hwevent */
+          if (!ddecl->spontaneous)
+            ddecl->spontaneous = c_call_nonatomic;
+        }
     }
   else if (is_attr_name(name, "atomic_hwevent"))
     {
       if (require_function(attr, ddecl))
-	{
-	  ddecl->async = TRUE;
-	  ddecl->spontaneous = c_call_atomic;
-	}
+        {
+          ddecl->async = TRUE;
+          ddecl->spontaneous = c_call_atomic;
+        }
     }
   else if (is_attr_name(name, "hwevent"))
     {
       if (require_function(attr, ddecl))
-	{
-	  ddecl->async = TRUE;
-	  ddecl->spontaneous = c_call_nonatomic;
-	}
+        {
+          ddecl->async = TRUE;
+          ddecl->spontaneous = c_call_nonatomic;
+        }
     }
   else if (is_attr_name(name, "noinline"))
     {
@@ -224,13 +224,13 @@ void handle_gcc_decl_attribute(gcc_attribute attr, data_declaration ddecl)
       const char *word = gcc_attr_get_word(attr);
 
       if (ddecl->kind != decl_typedef)
-	error_with_location(attr->location, "`%s' attribute can only be applied to typedefs", name);
+        error_with_location(attr->location, "`%s' attribute can only be applied to typedefs", name);
       else if (word)
-	handle_nxbase_attribute(attr->location, is_attr_name(name, "nx_base_be"), TRUE, word, ddecl);
+        handle_nxbase_attribute(attr->location, is_attr_name(name, "nx_base_be"), TRUE, word, ddecl);
     }
   else if (!(target->decl_attribute &&
-	     target->decl_attribute(attr, ddecl)) &&
-	   !handle_gcc_type_attribute(attr, &ddecl->type))
+             target->decl_attribute(attr, ddecl)) &&
+           !handle_gcc_type_attribute(attr, &ddecl->type))
     /*ignored_gcc_attribute(attr)*/;
 }
 
@@ -246,10 +246,10 @@ void handle_gcc_field_attribute(gcc_attribute attr, field_declaration fdecl)
       cval arg = get_alignment(attr);
 
       if (cval_isinteger(arg))
-	fdecl->type = align_type(fdecl->type, arg);
+        fdecl->type = align_type(fdecl->type, arg);
     }
   else if (!(target->field_attribute &&
-	     target->field_attribute(attr, fdecl)))
+             target->field_attribute(attr, fdecl)))
     /*ignored_gcc_attribute(attr)*/;
 }
 
@@ -260,15 +260,15 @@ void handle_gcc_tag_attribute(gcc_attribute attr, tag_declaration tdecl)
   if (is_attr_name(name, "transparent_union"))
     {
       if (attr->args)
-	error_with_location(attr->location, "wrong number of arguments specified for `transparent_union' attribute");
+        error_with_location(attr->location, "wrong number of arguments specified for `transparent_union' attribute");
 
       if (tdecl->kind == kind_union_ref)
-	{
-	  tdecl->transparent_union = TRUE;
-	  /* XXX: Missing validity checks (need cst folding I think) */
-	}
+        {
+          tdecl->transparent_union = TRUE;
+          /* XXX: Missing validity checks (need cst folding I think) */
+        }
       else
-	ignored_gcc_attribute(attr);
+        ignored_gcc_attribute(attr);
     }
   else if (is_attr_name(name, "packed"))
     tdecl->packed = TRUE;
@@ -277,17 +277,17 @@ void handle_gcc_tag_attribute(gcc_attribute attr, tag_declaration tdecl)
       cval arg = get_alignment(attr);
 
       if (cval_isinteger(arg))
-	tdecl->user_alignment = arg;
+        tdecl->user_alignment = arg;
     }
   else if (is_attr_name(name, "C"))
     {
       if (tdecl->container_function)
-	error_with_location(attr->location, "`C' attribute is for symbols with external scope only");
+        error_with_location(attr->location, "`C' attribute is for symbols with external scope only");
       else
-	tdecl->Cname = TRUE;
+        tdecl->Cname = TRUE;
     }
   else if (!(target->tag_attribute &&
-	     target->tag_attribute(attr, tdecl)))
+             target->tag_attribute(attr, tdecl)))
     /*ignored_gcc_attribute(attr)*/;
 }
 
@@ -327,7 +327,7 @@ bool handle_type_attribute(attribute attr, type *t)
   else
     {
       /* nesC attributes don't have a broken syntax, so don't need
-	 to flow up to the declaration */
+         to flow up to the declaration */
       handle_nesc_type_attribute(CAST(nesc_attribute, attr), t);
       return TRUE;
     }

--- a/src/c-lex-state.h
+++ b/src/c-lex-state.h
@@ -13,12 +13,12 @@ struct file_stack
 
 struct cpp_print
 {
-  FILE *outf;			/* Stream to write to.  */
-  const struct cpp_token *prev;	/* Previous token.  */
-  const struct cpp_token *source;	/* Source token for spacing.  */
-  int src_line;			/* Line number currently being written.  */
-  unsigned char printed;	/* Nonzero if something output at line.  */
-  bool first_time;		/* pp_file_change hasn't been called yet.  */
+  FILE *outf;                        /* Stream to write to.  */
+  const struct cpp_token *prev;        /* Previous token.  */
+  const struct cpp_token *source;        /* Source token for spacing.  */
+  int src_line;                        /* Line number currently being written.  */
+  unsigned char printed;        /* Nonzero if something output at line.  */
+  bool first_time;                /* pp_file_change hasn't been called yet.  */
   bool avoid_paste;
 };
 

--- a/src/c-lex.c
+++ b/src/c-lex.c
@@ -84,7 +84,7 @@ void set_lex_location(location loc)
   const struct line_map *new_line;
 
   new_line = linemap_add(current.lex.line_map, LC_RENAME, 0,
-			 loc->filename, loc->lineno);
+                         loc->filename, loc->lineno);
   current.lex.input->l = *loc;
 }
 
@@ -123,10 +123,10 @@ static void cb_file_change(cpp_reader *reader, const struct line_map *new_map)
   if (new_map->reason == LC_ENTER)
     {
       if (!MAIN_FILE_P(new_map))
-	{
-	  int included_at = LAST_SOURCE_LINE(new_map - 1);
-	  current.lex.input->l.lineno = included_at;
-	}
+        {
+          int included_at = LAST_SOURCE_LINE(new_map - 1);
+          current.lex.input->l.lineno = included_at;
+        }
       push_input();
     }
   else if (new_map->reason == LC_LEAVE)
@@ -139,7 +139,7 @@ static void cb_file_change(cpp_reader *reader, const struct line_map *new_map)
 }
 
 static void cb_line_change(cpp_reader *reader, const cpp_token *token,
-			   int parsing_args)
+                           int parsing_args)
 {
   if (token->type != CPP_EOF && !parsing_args)
     {
@@ -251,11 +251,11 @@ static void start_lex_common(source_language l)
 static void setup_macros(void)
 {
   cb_file_change(current_reader(),
-		 linemap_add(current.lex.line_map, LC_ENTER, 0, "<built-in>", 0));
+                 linemap_add(current.lex.line_map, LC_ENTER, 0, "<built-in>", 0));
 
   start_macro_saving();
   cb_file_change(current_reader(),
-		 linemap_add(current.lex.line_map, LC_LEAVE, 0, NULL, 0));
+                 linemap_add(current.lex.line_map, LC_LEAVE, 0, NULL, 0));
 }
 
 bool start_lex(source_language l, const char *path)
@@ -297,7 +297,7 @@ static cstring make_token_cstring(const cpp_token *token)
   unsigned char *end;
 
   end = cpp_spell_token(current_reader(), token,
-			(unsigned char *)tokcs.data, FALSE);
+                        (unsigned char *)tokcs.data, FALSE);
   end[0] = '\0';
   tokcs.length = (char *)end - tokcs.data;
 
@@ -314,21 +314,21 @@ static void handle_comment(const cpp_token *token)
   else if (!strncmp((char *)comment->text, "///", 3))
     {
       if (doc_location && last_location()->filename == doc_location->filename &&
-	  last_location()->lineno + 1 == doc_location->lineno)
-	memcpy(char_array_extend(doc_string, comment->len), comment->text,
-	       comment->len);
+          last_location()->lineno + 1 == doc_location->lineno)
+        memcpy(char_array_extend(doc_string, comment->len), comment->text,
+               comment->len);
       else
-	new_docstring = TRUE;
+        new_docstring = TRUE;
     }
 
   if (new_docstring)
     {
       if (warn_unexpected_docstring && char_array_length(doc_string))
-	warning_with_location(doc_location, "discarding unexpected docstring");
+        warning_with_location(doc_location, "discarding unexpected docstring");
 
       char_array_reset(doc_string);
       memcpy(char_array_extend(doc_string, comment->len), comment->text,
-	     comment->len);
+             comment->len);
       doc_location = last_location();
     }
 }
@@ -375,7 +375,7 @@ static void lex_string(const cpp_token *tok, struct yystype *lvalp)
   do
     {
       string_cst one_string =
-	new_string_cst(parse_region, last_location(), make_token_cstring(tok));
+        new_string_cst(parse_region, last_location(), make_token_cstring(tok));
 
       *next_sc = one_string;
       next_sc = CASTPTR(string_cst, &one_string->next);
@@ -383,19 +383,19 @@ static void lex_string(const cpp_token *tok, struct yystype *lvalp)
       *string_array_extend(string_sequence, 1) = tok->val.str;
 
       if (tok->type == CPP_WSTRING)
-	wide = true;
+        wide = true;
 
     retry:
       if (tok != first)
-	save_pp_token(tok);
+        save_pp_token(tok);
       tok = cpp_get_token(current_reader());
       if (tok->type == CPP_PADDING)
-	goto retry;
+        goto retry;
       if (tok->type == CPP_COMMENT)
-	{
-	  handle_comment(tok);
-	  goto retry;
-	}
+        {
+          handle_comment(tok);
+          goto retry;
+        }
     }
   while (tok->type == CPP_STRING || tok->type == CPP_WSTRING);
 
@@ -403,9 +403,9 @@ static void lex_string(const cpp_token *tok, struct yystype *lvalp)
   _cpp_backup_tokens(current_reader(), 1);
 
   if (cpp_interpret_string(current_reader(),
-			   string_array_data(string_sequence),
-			   string_array_length(string_sequence),
-			   &istr, wide))
+                           string_array_data(string_sequence),
+                           string_array_length(string_sequence),
+                           &istr, wide))
     {
       cstr = make_cstring(parse_region, (char *)istr.text, istr.len - 1);
       free((char *)istr.text);
@@ -413,9 +413,9 @@ static void lex_string(const cpp_token *tok, struct yystype *lvalp)
   else
     {
       /* Use empty string as the value in case of error. Assumes the
-	 widest supported wchar_t is 32 bits */
+         widest supported wchar_t is 32 bits */
       cstr = make_cstring(parse_region, "\0\0\0",
-			  wide ? type_size_int(wchar_type) : 1);
+                          wide ? type_size_int(wchar_type) : 1);
     }
 
   lvalp->u.string = fold_lexical_string(first_loc, string_components, cstr, wide);
@@ -428,9 +428,9 @@ static void lex_charconst(const cpp_token *token, struct yystype *lvalp)
   int unsignedp;
 
   result = cpp_interpret_charconst(current_reader(), token,
-				   &chars_seen, &unsignedp);
+                                   &chars_seen, &unsignedp);
   lvalp->u.constant = fold_lexical_char(last_location(), make_token_cstring(token),
-					token->type == CPP_WCHAR, result);
+                                        token->type == CPP_WCHAR, result);
 }
 
 /* Interpret TOKEN, an integer with FLAGS as classified by cpplib.  */
@@ -445,8 +445,8 @@ static lexical_cst interpret_integer(const cpp_token *token, unsigned int flags)
 
   if (flags & CPP_N_UNSIGNED ||
       /* what earlier nesC versions did, not correct as per C89/C99:
-	 In both C89 and C99, octal and hex constants may be signed or
-	 unsigned, whichever fits tighter.  */
+         In both C89 and C99, octal and hex constants may be signed or
+         unsigned, whichever fits tighter.  */
       (flags & CPP_N_RADIX) != CPP_N_DECIMAL) 
     if ((flags & CPP_N_WIDTH) == CPP_N_SMALL)
       t = unsigned_int_type;
@@ -467,9 +467,9 @@ static lexical_cst interpret_integer(const cpp_token *token, unsigned int flags)
      values that fit in largest_uint anyway */
   assert(sizeof(HOST_WIDE_INT) == sizeof(largest_uint));
   return fold_lexical_int(t, last_location(), make_token_cstring(token),
-			  (flags & CPP_N_IMAGINARY) != 0,
-			  integer.low,
-			  integer.overflow);
+                          (flags & CPP_N_IMAGINARY) != 0,
+                          integer.low,
+                          integer.overflow);
 }
 
 /* Interpret TOKEN, a floating point number with FLAGS as classified
@@ -516,16 +516,16 @@ static int interpret_name(const cpp_token *token, struct yystype *lvalp)
       !(is_nesc_keyword(ptr) && current.language == l_c))
     {
       if (ptr->token == TYPE_QUAL)
-	lvalp->u.itoken.i = ptr->rid;
+        lvalp->u.itoken.i = ptr->rid;
       else
-	lvalp->u.itoken.i = ptr->rid & ~RID_NESC;
+        lvalp->u.itoken.i = ptr->rid & ~RID_NESC;
 
       /* Even if we decided to recognize asm, still perhaps warn.  */
       if (pedantic &&
-	  (ptr->token == ASM_KEYWORD || ptr->token == TYPEOF ||
-	   ptr->rid == RID_INLINE) &&
-	  id->str[0] != '_')
-	pedwarn ("ANSI does not permit the keyword `%s'", id->str);
+          (ptr->token == ASM_KEYWORD || ptr->token == TYPEOF ||
+           ptr->rid == RID_INLINE) &&
+          id->str[0] != '_')
+        pedwarn ("ANSI does not permit the keyword `%s'", id->str);
 
       return ptr->token;
     }
@@ -542,13 +542,13 @@ static int interpret_name(const cpp_token *token, struct yystype *lvalp)
       lvalp->idtoken.decl = decl;
 
       if (decl)
-	switch (decl->kind)
-	  {
-	  case decl_typedef: kind = TYPENAME; break;
-	  case decl_magic_string: kind = MAGIC_STRING; break;
-	  case decl_component_ref: kind = COMPONENTREF; break;
-	  default: break;
-	  }
+        switch (decl->kind)
+          {
+          case decl_typedef: kind = TYPENAME; break;
+          case decl_magic_string: kind = MAGIC_STRING; break;
+          case decl_component_ref: kind = COMPONENTREF; break;
+          default: break;
+          }
     }
   return kind;
 }
@@ -582,27 +582,27 @@ static int lex_token(struct yystype *lvalp)
 
     case CPP_NUMBER:
       {
-	unsigned int flags = cpp_classify_number(current_reader(), tok);
-	lexical_cst num = NULL;
+        unsigned int flags = cpp_classify_number(current_reader(), tok);
+        lexical_cst num = NULL;
 
-	switch (flags & CPP_N_CATEGORY)
-	  {
-	  case CPP_N_INTEGER:
-	    num = interpret_integer(tok, flags);
-	    break;
-	  case CPP_N_FLOATING:
-	    num = interpret_float (tok, flags);
-	    break;
-	  }
-	/* cpplib has issued an error or we ran into something we don't
-	   support (e.g. fixed point), pretend the constant was 0  */
-	if (num == NULL)
-	    num = fold_lexical_int(int_type, last_location(),
-				   make_token_cstring(tok),
-				   FALSE, 0, FALSE);
+        switch (flags & CPP_N_CATEGORY)
+          {
+          case CPP_N_INTEGER:
+            num = interpret_integer(tok, flags);
+            break;
+          case CPP_N_FLOATING:
+            num = interpret_float (tok, flags);
+            break;
+          }
+        /* cpplib has issued an error or we ran into something we don't
+           support (e.g. fixed point), pretend the constant was 0  */
+        if (num == NULL)
+            num = fold_lexical_int(int_type, last_location(),
+                                   make_token_cstring(tok),
+                                   FALSE, 0, FALSE);
 
-	lvalp->u.constant = num;
-	return CONSTANT;
+        lvalp->u.constant = num;
+        return CONSTANT;
       }
 
     case CPP_HASH:
@@ -611,24 +611,24 @@ static int lex_token(struct yystype *lvalp)
     case CPP_DEREF_STAR:
     case CPP_DOT_STAR:
       {
-	unsigned char name[4];
+        unsigned char name[4];
 
-	*cpp_spell_token(current_reader(), tok, name, true) = 0;
+        *cpp_spell_token(current_reader(), tok, name, true) = 0;
 
-	error("stray %qs in program", name);
+        error("stray %qs in program", name);
       }
       goto retry;
 
     case CPP_OTHER:
       {
-	cppchar_t c = tok->val.str.text[0];
+        cppchar_t c = tok->val.str.text[0];
 
-	if (c == '"' || c == '\'')
-	  error("missing terminating %c character", (int) c);
-	else if (ISGRAPH (c))
-	  error("stray %qc in program", (int) c);
-	else
-	  error("stray %<\\%o%> in program", (int) c);
+        if (c == '"' || c == '\'')
+          error("missing terminating %c character", (int) c);
+        else if (ISGRAPH (c))
+          error("stray %qc in program", (int) c);
+        else
+          error("stray %<\\%o%> in program", (int) c);
       }
       goto retry;
 
@@ -646,7 +646,7 @@ static int lex_token(struct yystype *lvalp)
       goto retry;
 
       /* Translate to the parser's symbols - somewhat of a legacy effect,
-	 but having the characters does make the parser more readable... */
+         but having the characters does make the parser more readable... */
     case CPP_EQ: return '=';
     case CPP_NOT: return '!';
     case CPP_GREATER: return '>';
@@ -770,29 +770,29 @@ yylex(struct yystype *lvalp)
 
       token = IDENTIFIER; /* default to regular identifier */
       if (token1 == '.')
-	{
-	  struct yystype val2;
-	  int token2 = poptoken(&val2);
+        {
+          struct yystype val2;
+          int token2 = poptoken(&val2);
 
-	  if (token2 == IDENTIFIER || token2 == TYPENAME ||
-	      token2 == MAGIC_STRING)
-	    {
-	      data_declaration cref = lvalp->idtoken.decl;
-	      data_declaration fdecl = env_lookup(cref->ctype->env->id_env, val2.idtoken.id.data, TRUE);
+          if (token2 == IDENTIFIER || token2 == TYPENAME ||
+              token2 == MAGIC_STRING)
+            {
+              data_declaration cref = lvalp->idtoken.decl;
+              data_declaration fdecl = env_lookup(cref->ctype->env->id_env, val2.idtoken.id.data, TRUE);
 
-	      if (fdecl && fdecl->kind == decl_typedef)
-		{
-		  /* The special typedef reference case. Fix the tokens */
-		  token = COMPONENTREF;
-		  token2 = IDENTIFIER;
-		  val2.idtoken.decl = fdecl;
-		}
-	    }
-	  pushtoken(token1, &val1);
-	  pushtoken(token2, &val2);
-	}
+              if (fdecl && fdecl->kind == decl_typedef)
+                {
+                  /* The special typedef reference case. Fix the tokens */
+                  token = COMPONENTREF;
+                  token2 = IDENTIFIER;
+                  val2.idtoken.decl = fdecl;
+                }
+            }
+          pushtoken(token1, &val1);
+          pushtoken(token2, &val2);
+        }
       else
-	pushtoken(token1, &val1);
+        pushtoken(token1, &val1);
     }
 
   return token;

--- a/src/c-lex.h
+++ b/src/c-lex.h
@@ -24,7 +24,7 @@ Boston, MA 02111-1307, USA. */
 #define C_LEX_H
 
 typedef enum { l_c, l_interface, l_component, l_implementation,
-	       l_parameter, l_type, l_any } source_language;
+               l_parameter, l_type, l_any } source_language;
 
 typedef struct location
 { 

--- a/src/constants.c
+++ b/src/constants.c
@@ -23,7 +23,7 @@ Boston, MA 02111-1307, USA. */
            (double)(long double)d == d
 */
 /* XXX: overflow detection (signed ints only, gcc doesn't do reals)
-	initialised arrays are missing their size
+        initialised arrays are missing their size
 */
 
 /* Note: legal ops on complex are:
@@ -71,7 +71,7 @@ known_cst make_cst(cval c, type t)
 }
 
 known_cst make_address_cst(data_declaration ddecl, label_declaration ldecl,
-			   largest_int offset, type t)
+                           largest_int offset, type t)
 {
   return make_cst(make_cval_address(ddecl, ldecl, offset), t);
 }
@@ -136,40 +136,40 @@ known_cst fold_unary(expression e)
   if (arg)
     {
       switch (u->kind)
-	{
-	case kind_unary_plus:
-	  /* Note that this allows +(int)&x to be a constant... 
-	     This is consistent with gcc */
-	  return cast_constant(arg, t); /* essentially a no-op */
+        {
+        case kind_unary_plus:
+          /* Note that this allows +(int)&x to be a constant... 
+             This is consistent with gcc */
+          return cast_constant(arg, t); /* essentially a no-op */
 
-	case kind_unary_minus:
-	  return make_cst(cval_negate(cval_cast(arg->cval, t)), t);
+        case kind_unary_minus:
+          return make_cst(cval_negate(cval_cast(arg->cval, t)), t);
 
-	case kind_not:
-	  return make_cst(cval_not(cval_cast(arg->cval, t)), t);
+        case kind_not:
+          return make_cst(cval_not(cval_cast(arg->cval, t)), t);
 
-	case kind_bitnot:
-	  return make_cst(cval_bitnot(cval_cast(arg->cval, t)), t);
+        case kind_bitnot:
+          return make_cst(cval_bitnot(cval_cast(arg->cval, t)), t);
 
-	case kind_conjugate:
-	  return make_cst(cval_conjugate(cval_cast(arg->cval, t)), t);
+        case kind_conjugate:
+          return make_cst(cval_conjugate(cval_cast(arg->cval, t)), t);
 
-	case kind_realpart:
-	  if (!type_complex(u->arg1->type))
-	    return cast_constant(arg, t);
-	  else
-	    return make_cst(cval_realpart(cval_cast(arg->cval, t)), t);
+        case kind_realpart:
+          if (!type_complex(u->arg1->type))
+            return cast_constant(arg, t);
+          else
+            return make_cst(cval_realpart(cval_cast(arg->cval, t)), t);
 
-	case kind_imagpart:
-	  if (!type_complex(u->arg1->type))
-	    return make_cst(cval_cast(cval_zero, t), t);
-	  else
-	    return make_cst(cval_imagpart(cval_cast(arg->cval, t)), t);
+        case kind_imagpart:
+          if (!type_complex(u->arg1->type))
+            return make_cst(cval_cast(cval_zero, t), t);
+          else
+            return make_cst(cval_imagpart(cval_cast(arg->cval, t)), t);
 
-	default:
-	  assert(0);
-	  break;
-	}
+        default:
+          assert(0);
+          break;
+        }
     }
   return NULL;
 }
@@ -186,7 +186,7 @@ static known_cst fold_sub(type restype, known_cst c1, known_cst c2)
       basetype = type_points_to(basetype);
 
       if (!type_size_cc(basetype))
-	return NULL;
+        return NULL;
 
       s = cval_cast(type_size(basetype), size_t_type);
       ct = intptr_type;
@@ -197,10 +197,10 @@ static known_cst fold_sub(type restype, known_cst c1, known_cst c2)
   s = cval_cast(s, ct);
   if (type_pointer(t1) && type_pointer(t2))
     res = cval_divide(cval_cast(cval_sub(cval_cast(c1->cval, ct), cval_cast(c2->cval, ct)), ct),
-		      s);
+                      s);
   else
     res = cval_sub(cval_cast(c1->cval, ct),
-		   cval_divide(cval_cast(c2->cval, ct), s));
+                   cval_divide(cval_cast(c2->cval, ct), s));
 
   return make_cst(res, restype);
 }
@@ -225,7 +225,7 @@ known_cst fold_add(type restype, known_cst c1, known_cst c2)
       type basetype = type_points_to(t1);
 
       if (!type_size_cc(basetype))
-	return NULL;
+        return NULL;
 
       s = cval_cast(type_size(basetype), size_t_type);
       ct = intptr_type;
@@ -234,8 +234,8 @@ known_cst fold_add(type restype, known_cst c1, known_cst c2)
     ct = restype;
 
   return make_cst(cval_add(cval_cast(c1->cval, ct),
-			   cval_times(cval_cast(c2->cval, ct), cval_cast(s, ct))),
-		  restype);
+                           cval_times(cval_cast(c2->cval, ct), cval_cast(s, ct))),
+                  restype);
 }
 
 known_cst fold_binary(type t, expression e)
@@ -248,92 +248,92 @@ known_cst fold_binary(type t, expression e)
   if (b->kind == kind_andand || b->kind == kind_oror)
     {
       if (c1)
-	{
-	  if (constant_knownbool(c1))
-	    {
-	      bool c1val = constant_boolvalue(c1);
+        {
+          if (constant_knownbool(c1))
+            {
+              bool c1val = constant_boolvalue(c1);
 
-	      if (b->kind == kind_andand ? !c1val : c1val)
-		return make_signed_cst(c1val, t);
-	    }
-	  if (constant_unknown_number(c1))
-	    return make_unknown_cst(cval_unknown_number, t);
-	}
+              if (b->kind == kind_andand ? !c1val : c1val)
+                return make_signed_cst(c1val, t);
+            }
+          if (constant_unknown_number(c1))
+            return make_unknown_cst(cval_unknown_number, t);
+        }
 
       if (c1 && c2)
-	{
-	  if (constant_knownbool(c2))
-	    {
-	      bool c2val = constant_boolvalue(c2);
-	      if (b->kind == kind_andand ? !c2val : c2val)
-		return make_signed_cst(c2val, t);
-	    }
+        {
+          if (constant_knownbool(c2))
+            {
+              bool c2val = constant_boolvalue(c2);
+              if (b->kind == kind_andand ? !c2val : c2val)
+                return make_signed_cst(c2val, t);
+            }
 
-	  if (constant_unknown_number(c2))
-	    return make_unknown_cst(cval_unknown_number, t);
-	}
+          if (constant_unknown_number(c2))
+            return make_unknown_cst(cval_unknown_number, t);
+        }
     }
   else if (c1 && c2)
     {
       cval cv1 = c1->cval, cv2 = c2->cval;
 
       switch (b->kind)
-	{
-	case kind_plus: case kind_array_ref:
-	  return fold_add(t, c1, c2);
+        {
+        case kind_plus: case kind_array_ref:
+          return fold_add(t, c1, c2);
 
-	case kind_minus:
-	  return fold_sub(t, c1, c2);
+        case kind_minus:
+          return fold_sub(t, c1, c2);
 
-	case kind_times: case kind_divide: case kind_modulo:
-	case kind_lshift: case kind_rshift:
-	case kind_bitand: case kind_bitor: case kind_bitxor: {
-	  cval res;
+        case kind_times: case kind_divide: case kind_modulo:
+        case kind_lshift: case kind_rshift:
+        case kind_bitand: case kind_bitor: case kind_bitxor: {
+          cval res;
 
-	  cv1 = cval_cast(cv1, t);
-	  cv2 = cval_cast(cv2, t);
+          cv1 = cval_cast(cv1, t);
+          cv2 = cval_cast(cv2, t);
 
-	  switch (b->kind) {
-	  case kind_times: res = cval_times(cv1, cv2); break;
-	  case kind_divide: res = cval_divide(cv1, cv2); break;
-	  case kind_modulo: res = cval_modulo(cv1, cv2); break;
-	  case kind_lshift: res = cval_lshift(cv1, cv2); break;
-	  case kind_rshift: res = cval_rshift(cv1, cv2); break;
-	  case kind_bitand: res = cval_bitand(cv1, cv2); break;
-	  case kind_bitor: res = cval_bitor(cv1, cv2); break;
-	  case kind_bitxor: res = cval_bitxor(cv1, cv2); break;
-	  default: abort(); return NULL;
-	  }
-	  return make_cst(res, t);
-	}
-	case kind_eq: case kind_ne:
-	case kind_leq: case kind_geq: case kind_lt: case kind_gt: {
-	  cval res;
-	  type ct;
+          switch (b->kind) {
+          case kind_times: res = cval_times(cv1, cv2); break;
+          case kind_divide: res = cval_divide(cv1, cv2); break;
+          case kind_modulo: res = cval_modulo(cv1, cv2); break;
+          case kind_lshift: res = cval_lshift(cv1, cv2); break;
+          case kind_rshift: res = cval_rshift(cv1, cv2); break;
+          case kind_bitand: res = cval_bitand(cv1, cv2); break;
+          case kind_bitor: res = cval_bitor(cv1, cv2); break;
+          case kind_bitxor: res = cval_bitxor(cv1, cv2); break;
+          default: abort(); return NULL;
+          }
+          return make_cst(res, t);
+        }
+        case kind_eq: case kind_ne:
+        case kind_leq: case kind_geq: case kind_lt: case kind_gt: {
+          cval res;
+          type ct;
 
-	  /* Pointers win. */
-	  if (type_pointer(t1) || type_pointer(t2))
-	    ct = intptr_type; 
-	  else
-	    ct = common_type(t1, t2);
+          /* Pointers win. */
+          if (type_pointer(t1) || type_pointer(t2))
+            ct = intptr_type; 
+          else
+            ct = common_type(t1, t2);
 
-	  cv1 = cval_cast(cv1, ct);
-	  cv2 = cval_cast(cv2, ct);
+          cv1 = cval_cast(cv1, ct);
+          cv2 = cval_cast(cv2, ct);
 
-	  switch (b->kind) {
-	  case kind_eq: res = cval_eq(cv1, cv2); break;
-	  case kind_ne: res = cval_ne(cv1, cv2); break;
-	  case kind_leq: res = cval_leq(cv1, cv2); break;
-	  case kind_geq: res = cval_geq(cv1, cv2); break;
-	  case kind_lt: res = cval_lt(cv1, cv2); break;
-	  case kind_gt: res = cval_gt(cv1, cv2); break;
-	  default: abort(); return NULL;
-	  }
-	  return make_cst(res, t);
-	}
-	default:
-	  assert(0); return NULL;
-	}
+          switch (b->kind) {
+          case kind_eq: res = cval_eq(cv1, cv2); break;
+          case kind_ne: res = cval_ne(cv1, cv2); break;
+          case kind_leq: res = cval_leq(cv1, cv2); break;
+          case kind_geq: res = cval_geq(cv1, cv2); break;
+          case kind_lt: res = cval_lt(cv1, cv2); break;
+          case kind_gt: res = cval_gt(cv1, cv2); break;
+          default: abort(); return NULL;
+          }
+          return make_cst(res, t);
+        }
+        default:
+          assert(0); return NULL;
+        }
       }
 
   return NULL;
@@ -350,21 +350,21 @@ known_cst fold_conditional(expression e)
       known_cst kc1 = arg1->cst, kc2 = c->arg2->cst;
 
       if (constant_knownbool(cond))
-	{
-	  expression value = constant_boolvalue(cond) ? arg1 : c->arg2;
+        {
+          expression value = constant_boolvalue(cond) ? arg1 : c->arg2;
 
-	  e->static_address = value->static_address;
-	  if (value->cst)
-	    return cast_constant(value->cst, e->type);
-	  else
-	    return NULL;
-	}
+          e->static_address = value->static_address;
+          if (value->cst)
+            return cast_constant(value->cst, e->type);
+          else
+            return NULL;
+        }
       else if (constant_unknown_number(cond) && kc1 && kc2)
-	/* Faced with an unknown condition and two constant arguments, we
-	   return an unknown constant. Unknown number if both arg1 and arg2
-	   are unknown numbers, an unknown address otherwise */
-	return make_unknown_cst(cval_isaddress(kc1->cval) ?
-				kc1->cval : kc2->cval, e->type);
+        /* Faced with an unknown condition and two constant arguments, we
+           return an unknown constant. Unknown number if both arg1 and arg2
+           are unknown numbers, an unknown address otherwise */
+        return make_unknown_cst(cval_isaddress(kc1->cval) ?
+                                kc1->cval : kc2->cval, e->type);
     }
 
   return NULL;
@@ -386,7 +386,7 @@ known_cst fold_identifier(expression e, data_declaration decl, int pass)
     // We don't know template arg values at parse time
     return pass == 0 && decl->substitute ?
       make_unknown_cst(type_real(e->type) ? cval_unknown_number :
-		       cval_unknown_address, e->type) :
+                       cval_unknown_address, e->type) :
       decl->value;
   else
     return NULL;
@@ -428,7 +428,7 @@ known_cst foldaddress_field_ref(expression e)
      the offset to the pointer-to-field type (we are assuming that is
      the same size as the pointer to base-struct type) */
   return make_cst(cval_add(object->cval, cval_cast(field_offset, pftype)),
-		  pftype);
+                  pftype);
 }
 
 #ifndef HAVE_STRTOLD
@@ -448,21 +448,21 @@ lexical_cst fold_lexical_real(type realtype, location loc, cstring tok)
 }
 
 lexical_cst fold_lexical_char(location loc, cstring tok,
-			      bool wide_flag, int charvalue)
+                              bool wide_flag, int charvalue)
 {
   lexical_cst c = new_lexical_cst(parse_region, loc, tok);
   type ctype = wide_flag ? wchar_type : int_type;
 
   c->type = ctype;
   c->cst = make_cst(type_unsigned(ctype) ?
-		    make_cval_unsigned(charvalue, ctype) :
-		    make_cval_signed(charvalue, ctype),
-		    ctype);
+                    make_cval_unsigned(charvalue, ctype) :
+                    make_cval_signed(charvalue, ctype),
+                    ctype);
   return c;
 }
 
 string fold_lexical_string(location loc, string_cst components, cstring value,
-			   bool wide_flag)
+                           bool wide_flag)
 {
   data_declaration sdecl = declare_string(NULL, value, wide_flag);
   string s = new_string(parse_region, loc, components, sdecl);
@@ -475,7 +475,7 @@ string fold_lexical_string(location loc, string_cst components, cstring value,
 }
 
 lexical_cst fold_lexical_int(type itype, location loc, cstring tok,
-			     bool iscomplex, largest_uint intvalue, bool overflow)
+                             bool iscomplex, largest_uint intvalue, bool overflow)
 {
   lexical_cst c = new_lexical_cst(parse_region, loc, tok);
   cval cv;
@@ -489,22 +489,22 @@ lexical_cst fold_lexical_int(type itype, location loc, cstring tok,
     {
       /* Do some range checks */
       if (!uint_inrange(intvalue, itype))
-	{
-	  if (uint_inrange(intvalue, unsigned_int_type))
-	    {
-	      warning_with_location(loc, "decimal constant is so large that it is unsigned");
-	      itype = unsigned_int_type;
-	    }
-	  /* These other cases cause no warnings */
-	  else if (uint_inrange(intvalue, long_type))
-	    itype = long_type;
-	  else if (uint_inrange(intvalue, unsigned_long_type))
-	    itype = unsigned_long_type;
-	  else if (uint_inrange(intvalue, long_long_type))
-	    itype = long_long_type;
-	  else if (uint_inrange(intvalue, unsigned_long_long_type))
-	    itype = unsigned_long_long_type;
-	}
+        {
+          if (uint_inrange(intvalue, unsigned_int_type))
+            {
+              warning_with_location(loc, "decimal constant is so large that it is unsigned");
+              itype = unsigned_int_type;
+            }
+          /* These other cases cause no warnings */
+          else if (uint_inrange(intvalue, long_type))
+            itype = long_type;
+          else if (uint_inrange(intvalue, unsigned_long_type))
+            itype = unsigned_long_type;
+          else if (uint_inrange(intvalue, long_long_type))
+            itype = long_long_type;
+          else if (uint_inrange(intvalue, unsigned_long_long_type))
+            itype = unsigned_long_long_type;
+        }
     }
 
   cv = type_unsigned(itype) ? make_cval_unsigned(intvalue, itype) :
@@ -577,8 +577,8 @@ bool check_constant_once(expression e, cst_kind k)
   if (e->cst && constant_unknown(e->cst))
     /* Unknown constant. We can't check yet it if matches k */
     if (k == cst_any ||
-	(k == cst_numerical && constant_unknown_number(e->cst)) ||
-	(k == cst_address && constant_address(e->cst)))
+        (k == cst_numerical && constant_unknown_number(e->cst)) ||
+        (k == cst_address && constant_address(e->cst)))
       return FALSE;
 
   e->cst_checked = TRUE;

--- a/src/constants.h
+++ b/src/constants.h
@@ -36,20 +36,20 @@ struct known_cst {
 known_cst make_unknown_cst(cval c, type t);
 known_cst make_cst(cval c, type t);
 known_cst make_address_cst(data_declaration ddecl, label_declaration ldecl,
-			   largest_int offset, type t);
+                           largest_int offset, type t);
 known_cst make_signed_cst(largest_int x, type t);
 known_cst make_unsigned_cst(largest_uint x, type t);
 
 known_cst cast_constant(known_cst c, type to);
 
 lexical_cst fold_lexical_int(type itype, location loc, cstring tok,
-			     bool iscomplex, largest_uint intvalue, bool overflow);
+                             bool iscomplex, largest_uint intvalue, bool overflow);
 lexical_cst fold_lexical_real(type realtype, location loc, cstring tok);
 /* XXX: What's the right type for charvalue ? (must hold wchar_t or int) */
 lexical_cst fold_lexical_char(location loc, cstring tok,
-			      bool wide_flag, int charvalue);
+                              bool wide_flag, int charvalue);
 string fold_lexical_string(location loc, string_cst components, cstring value,
-			   bool wide_flag);
+                           bool wide_flag);
 
 known_cst fold_label_address(expression e);
 known_cst fold_sizeof(expression e, type stype);

--- a/src/cval.c
+++ b/src/cval.c
@@ -34,9 +34,9 @@ cval cval_top; /* The non-constant value */
 cval cval_unknown_number; /* The unknown number value */
 cval cval_unknown_address; /* The unknown address value */
 cval cval_zero; /* A zero value. Use cval_cast to make the desired kind of
-		   constant */
+                   constant */
 cval cval_one; /* A one value. Use cval_cast to make the desired kind of
-		   constant */
+                   constant */
 cval cval_bitsperbyte; /* BITSPERBYTE, unsigned */
 
 /* We use cval_invalid_address to mark those places where a constant
@@ -140,7 +140,7 @@ cval make_cval_complex(cval r, cval i)
 }
 
 cval make_cval_address(data_declaration ddecl, label_declaration ldecl,
-		       largest_int offset)
+                       largest_int offset)
 {
   cval c = make_cval_signed(offset, ptrdiff_t_type);
 
@@ -354,18 +354,18 @@ cval cval_cast(cval c, type to)
       type base = make_base_type(to);
 
       switch (c.kind)
-	{
-	case cval_unk_address: case cval_address_unk_offset: case cval_address:
-	  return cval_top;
-	case cval_sint: case cval_uint: case cval_float:
-	  return make_cval_complex(cval_cast(c, base),
-				   cval_cast(cval_zero, base));
-	  return c;
-	case cval_sint_complex: case cval_uint_complex: case cval_float_complex:
-	  return make_cval_complex(cval_cast(cval_realpart(c), base),
-				   cval_cast(cval_imagpart(c), base));
-	default:assert(0); return c;
-	}
+        {
+        case cval_unk_address: case cval_address_unk_offset: case cval_address:
+          return cval_top;
+        case cval_sint: case cval_uint: case cval_float:
+          return make_cval_complex(cval_cast(c, base),
+                                   cval_cast(cval_zero, base));
+          return c;
+        case cval_sint_complex: case cval_uint_complex: case cval_float_complex:
+          return make_cval_complex(cval_cast(cval_realpart(c), base),
+                                   cval_cast(cval_imagpart(c), base));
+        default:assert(0); return c;
+        }
     }
 
   if (cval_iscomplex(c))
@@ -374,24 +374,24 @@ cval cval_cast(cval c, type to)
   if (type_floating(to))
     {
       switch (c.kind)
-	{
-	case cval_unk_address: case cval_address_unk_offset: case cval_address:
-	  return cval_top; /* And not cval_invalid_address for some reason */
-	case cval_sint: case cval_uint:
-	  c.kind = cval_float;
-	  /* Note that the cast is necessary otherwise it would cast to the common
-	     type of largest_int/largest_uint (largest_uint), so c.si would be
-	     cast to unsigned. */
-	  c.d = c.kind == cval_sint ? (long double)c.si : (long double)c.ui;
-	  return c;
-	case cval_float:
-	  if (type_float(to))
-	    c.d = (float)c.d;
-	  else if (type_double(to))
-	    c.d = (double)c.d;
-	  return c;
-	default:assert(0); return c;
-	}
+        {
+        case cval_unk_address: case cval_address_unk_offset: case cval_address:
+          return cval_top; /* And not cval_invalid_address for some reason */
+        case cval_sint: case cval_uint:
+          c.kind = cval_float;
+          /* Note that the cast is necessary otherwise it would cast to the common
+             type of largest_int/largest_uint (largest_uint), so c.si would be
+             cast to unsigned. */
+          c.d = c.kind == cval_sint ? (long double)c.si : (long double)c.ui;
+          return c;
+        case cval_float:
+          if (type_float(to))
+            c.d = (float)c.d;
+          else if (type_double(to))
+            c.d = (double)c.d;
+          return c;
+        default:assert(0); return c;
+        }
     }
   else
     {
@@ -400,64 +400,64 @@ cval cval_cast(cval c, type to)
 
       // Cast to int of unknown size produces unknown value
       if (cval_isunknown_number(tosize_cval))
-	switch (c.kind)
-	  {
-	  case cval_unk_address: case cval_address_unk_offset:
-	  case cval_address:
-	    return cval_unknown_address;
-	  default:
-	    return cval_unknown_number;
-	  }
+        switch (c.kind)
+          {
+          case cval_unk_address: case cval_address_unk_offset:
+          case cval_address:
+            return cval_unknown_address;
+          default:
+            return cval_unknown_number;
+          }
 
       tosize = cval_uint_value(tosize_cval);
       switch (c.kind)
-	{
-	case cval_float:
-	  /* If it's floating, make it an integer */
-	  /* Note: can't cast floating point number to a pointer */
-	  assert(!type_pointer(to));
-	  if (type_unsigned(to))
-	    {
-	      c.kind = cval_uint;
-	      c.ui = c.d;
-	      c.isize = tosize;
-	    }
-	  else
-	    {
-	      c.kind = cval_sint;
-	      c.si = c.d;
-	      c.isize = tosize;
-	    }
-	  return c;
+        {
+        case cval_float:
+          /* If it's floating, make it an integer */
+          /* Note: can't cast floating point number to a pointer */
+          assert(!type_pointer(to));
+          if (type_unsigned(to))
+            {
+              c.kind = cval_uint;
+              c.ui = c.d;
+              c.isize = tosize;
+            }
+          else
+            {
+              c.kind = cval_sint;
+              c.si = c.d;
+              c.isize = tosize;
+            }
+          return c;
 
-	case cval_unk_address: case cval_address_unk_offset: case cval_address:
-	  /* Lose value if cast address of symbol to too-narrow a type */
-	  if (!type_array(to) && tosize < type_size_int(intptr_type))
-	    return cval_invalid_address;
-	  /* Otherwise nothing happens (the offset is already restricted to
-	     the range of intptr_type). */
-	  return c;
+        case cval_unk_address: case cval_address_unk_offset: case cval_address:
+          /* Lose value if cast address of symbol to too-narrow a type */
+          if (!type_array(to) && tosize < type_size_int(intptr_type))
+            return cval_invalid_address;
+          /* Otherwise nothing happens (the offset is already restricted to
+             the range of intptr_type). */
+          return c;
 
-	case cval_uint: case cval_sint:
-	  c.isize = tosize;
-	  if (type_unsigned(to) || type_pointer(to))
-	    {
-	      if (c.kind == cval_sint)
-		c.ui = c.si;
-	      c.ui = truncate_unsigned(c.ui, tosize);
-	      c.kind = cval_uint;
-	    }
-	  else
-	    {
-	      if (c.kind == cval_uint)
-		c.si = c.ui;
-	      c.si = truncate_signed(c.si, tosize);
-	      c.kind = cval_sint;
-	    }
-	  return c;
+        case cval_uint: case cval_sint:
+          c.isize = tosize;
+          if (type_unsigned(to) || type_pointer(to))
+            {
+              if (c.kind == cval_sint)
+                c.ui = c.si;
+              c.ui = truncate_unsigned(c.ui, tosize);
+              c.kind = cval_uint;
+            }
+          else
+            {
+              if (c.kind == cval_uint)
+                c.si = c.ui;
+              c.si = truncate_signed(c.si, tosize);
+              c.kind = cval_sint;
+            }
+          return c;
 
-	default: assert(0); return c;
-	}
+        default: assert(0); return c;
+        }
     }
 }
 
@@ -575,7 +575,7 @@ cval cval_add(cval c1, cval c2)
       {
       case cval_unk_number: return make_cval_address_unknown_offset(c1);
       case cval_address: case cval_unk_address: case cval_address_unk_offset:
-	return cval_invalid_address;
+        return cval_invalid_address;
       case cval_sint: c1.si = truncate_signed(c1.si + c2.si, c1.isize); return c1;
       case cval_uint: c1.si = truncate_signed(c1.si + c2.ui, c1.isize); return c1;
       default: assert(0); return c1;
@@ -635,17 +635,17 @@ cval cval_sub(cval c1, cval c2)
   if (cval_isaddress(c2))
     {
       if (cval_isaddress(c1) &&
-	  !cval_isunknown_address(c1) && !cval_isunknown_address(c2) &&
-	  c1.ddecl == c2.ddecl && c1.ldecl == c2.ldecl)
-	{
-	  if (c1.kind == cval_address_unk_offset ||
-	      c2.kind == cval_address_unk_offset)
-	    return cval_unknown_number;
+          !cval_isunknown_address(c1) && !cval_isunknown_address(c2) &&
+          c1.ddecl == c2.ddecl && c1.ldecl == c2.ldecl)
+        {
+          if (c1.kind == cval_address_unk_offset ||
+              c2.kind == cval_address_unk_offset)
+            return cval_unknown_number;
 
-	  c1.kind = cval_sint;
-	  c1.si = truncate_signed(c1.si - c2.si, c1.isize);
-	  return c1;
-	}
+          c1.kind = cval_sint;
+          c1.si = truncate_signed(c1.si - c2.si, c1.isize);
+          return c1;
+        }
       return cval_invalid_address;
     }
   // <address> - <x>
@@ -712,9 +712,9 @@ cval cval_times(cval c1, cval c2)
   if (cval_isaddress(c1) || cval_isaddress(c2))
     {
       if (cval_isone(c1))
-	return c2;
+        return c2;
       if (cval_isone(c2))
-	return c1;
+        return c1;
       return cval_invalid_address;
     }
 
@@ -724,16 +724,16 @@ cval cval_times(cval c1, cval c2)
   if (cval_iscomplex(c1))
     {
       cval c1r = cval_realpart(c1), c1i = cval_imagpart(c1),
-	c2r = cval_realpart(c2), c2i = cval_imagpart(c2);
+        c2r = cval_realpart(c2), c2i = cval_imagpart(c2);
 
       assert(cval_iscomplex(c2));
       /* Note: this is what gcc does. The C99 standard appears to
-	 require something rather more complicated (aka "do the right
-	 thing") */
+         require something rather more complicated (aka "do the right
+         thing") */
       return make_cval_complex(cval_sub(cval_times(c1r, c2r),
-					cval_times(c1i, c2i)),
-			       cval_add(cval_times(c1r, c2i),
-					cval_times(c1i, c2r)));
+                                        cval_times(c1i, c2i)),
+                               cval_add(cval_times(c1r, c2i),
+                                        cval_times(c1i, c2r)));
     }
 
   switch (c1.kind)
@@ -774,19 +774,19 @@ cval cval_divide(cval c1, cval c2)
   if (cval_iscomplex(c1))
     {
       cval c1r = cval_realpart(c1), c1i = cval_imagpart(c1),
-	c2r = cval_realpart(c2), c2i = cval_imagpart(c2);
+        c2r = cval_realpart(c2), c2i = cval_imagpart(c2);
       cval mag = cval_add(cval_times(c1r, c2r), cval_times(c1i, c2i));
 
       assert(cval_iscomplex(c2));
       /* Note: this is what gcc does. The C99 standard appears to
-	 require something rather more complicated (aka "do the right
-	 thing") */
+         require something rather more complicated (aka "do the right
+         thing") */
       return make_cval_complex(cval_divide(cval_add(cval_times(c1r, c2r),
-						    cval_times(c1i, c2i)),
-					   mag),
-			       cval_divide(cval_sub(cval_times(c1i, c2r),
-						    cval_times(c1r, c2i)),
-					   mag));
+                                                    cval_times(c1i, c2i)),
+                                           mag),
+                               cval_divide(cval_sub(cval_times(c1i, c2r),
+                                                    cval_times(c1r, c2i)),
+                                           mag));
     }
 
   switch (c1.kind)
@@ -799,7 +799,7 @@ cval cval_divide(cval c1, cval c2)
     case cval_sint:
       assert(c2.kind == cval_sint && c1.isize == c2.isize);
       if (c2.si == 0)
-	return cval_top;
+        return cval_top;
       /* Note that signed division can overflow (MININT / -1). */
       c1.si = truncate_signed(c1.si / c2.si, c1.isize);
       return c1;
@@ -807,7 +807,7 @@ cval cval_divide(cval c1, cval c2)
     case cval_uint:
       assert(c2.kind == cval_uint && c1.isize == c2.isize);
       if (c2.ui == 0)
-	return cval_top;
+        return cval_top;
       c1.ui /= c2.ui;
       return c1;
       
@@ -841,14 +841,14 @@ cval cval_modulo(cval c1, cval c2)
     case cval_sint:
       assert(c2.kind == cval_sint && c1.isize == c2.isize);
       if (c2.si == 0)
-	return cval_top;
+        return cval_top;
       c1.si = truncate_signed(c1.si % c2.si, c1.isize);
       return c1;
       
     case cval_uint:
       assert(c2.kind == cval_uint && c1.isize == c2.isize);
       if (c2.ui == 0)
-	return cval_top;
+        return cval_top;
       c1.ui %= c2.ui;
       return c1;
       
@@ -1002,34 +1002,34 @@ largest_int cval_intcompare(cval c1, cval c2)
     {
     case cval_sint:
       switch (c2.kind)
-	{
-	case cval_sint:
-	  return c1.si - c2.si;
-	case cval_uint:
-	  /* can't use c1.si < c2.ui because of implicit conversion */
-	  if (c1.si < 0 || c1.si < c2.ui)
-	    return -1;
-	  return c1.si - c2.ui; /* common type is largest_uint */
-	default: abort(); return 0;
-	}
+        {
+        case cval_sint:
+          return c1.si - c2.si;
+        case cval_uint:
+          /* can't use c1.si < c2.ui because of implicit conversion */
+          if (c1.si < 0 || c1.si < c2.ui)
+            return -1;
+          return c1.si - c2.ui; /* common type is largest_uint */
+        default: abort(); return 0;
+        }
     case cval_uint:
       switch (c2.kind)
-	{
-	case cval_sint:
-	  if (c2.si < 0 || c1.ui < c2.si)
-	    return 1;
-	  /* result might overflow so compare with 0 */
-	  return (c1.ui - c2.si) > 0; /* common type is largest_uint */
-	case cval_uint:
-	  /* We do the cases because the result might overflow
-	     largest_int */
-	  if (c1.ui < c2.ui)
-	    return -1;
-	  if (c1.ui > c2.ui)
-	    return 1;
-	  return 0;
-	default: abort(); return 0;
-	}
+        {
+        case cval_sint:
+          if (c2.si < 0 || c1.ui < c2.si)
+            return 1;
+          /* result might overflow so compare with 0 */
+          return (c1.ui - c2.si) > 0; /* common type is largest_uint */
+        case cval_uint:
+          /* We do the cases because the result might overflow
+             largest_int */
+          if (c1.ui < c2.ui)
+            return -1;
+          if (c1.ui > c2.ui)
+            return 1;
+          return 0;
+        default: abort(); return 0;
+        }
     default: abort(); return 0;
     }
 }
@@ -1061,15 +1061,15 @@ void cval_debug(cval c)
     case cval_unk_address: printf("<address>"); break;
     case cval_address: case cval_address_unk_offset:
       if (c.ldecl)
-	printf("<address label=%s(%p)", c.ldecl->name, c.ldecl);
+        printf("<address label=%s(%p)", c.ldecl->name, c.ldecl);
       else
-	printf("<address sym=%s(%p)", c.ddecl->name, c.ddecl);
+        printf("<address sym=%s(%p)", c.ddecl->name, c.ddecl);
       if (c.kind == cval_address_unk_offset)
-	printf(" + <number>");
+        printf(" + <number>");
       else if (c.si > 0)
-	printf(" + %lld", c.si);
+        printf(" + %lld", c.si);
       else
-	printf(" - %lld", -c.si);
+        printf(" - %lld", -c.si);
       printf(">");
     default:
       printf("[size: %u]", (unsigned)c.isize);
@@ -1081,8 +1081,8 @@ void cval_debug(cval c)
 cval cval_align_to(cval n, cval alignment)
 {
   cval count = cval_divide(cval_sub(cval_add(n, alignment),
-				    make_type_cval(1)),
-			   alignment);
+                                    make_type_cval(1)),
+                           alignment);
 
   return cval_times(count, alignment);
 }
@@ -1100,7 +1100,7 @@ cval cval_gcd(cval x, cval y)
   for (;;)
     {
       if (!cval_boolvalue(y)) /* ie 0 */
-	return x;
+        return x;
       
       z = cval_modulo(x, y); x = y; y = z;
     }

--- a/src/cval.h
+++ b/src/cval.h
@@ -27,11 +27,11 @@ Boston, MA 02111-1307, USA. */
 */
 typedef struct {
   enum {
-    cval_variable,		    /* not a constant */
-    cval_unk_number,		    /* some unknown number */
-    cval_unk_address,		    /* an unknown symbol with unknown offset */
+    cval_variable,                    /* not a constant */
+    cval_unk_number,                    /* some unknown number */
+    cval_unk_address,                    /* an unknown symbol with unknown offset */
     cval_address_unk_offset,        /* known symbol with unknown offset */
-    cval_address,		    /* symbol with offset */
+    cval_address,                    /* symbol with offset */
     cval_float, cval_float_complex, /* a (complex) floating point number */
     cval_uint, cval_uint_complex,   /* a (complex) unsigned number */
     cval_sint, cval_sint_complex    /* a (complex) signed number */
@@ -44,16 +44,16 @@ typedef struct {
     struct {
       size_t isize;
       union {
-	largest_int si;
-	largest_uint ui;
+        largest_int si;
+        largest_uint ui;
       };
       union {
-	largest_int si_i;
-	largest_uint ui_i;
-	struct { /* for cval_address, cval_address_unk_offset */
-	  struct data_declaration *ddecl;
-	  struct label_declaration *ldecl;
-	};
+        largest_int si_i;
+        largest_uint ui_i;
+        struct { /* for cval_address, cval_address_unk_offset */
+          struct data_declaration *ddecl;
+          struct label_declaration *ldecl;
+        };
       };
     };
   };
@@ -71,9 +71,9 @@ extern cval cval_top; /* The non-constant value */
 extern cval cval_unknown_number; /* The unknown number value */
 extern cval cval_unknown_address; /* The unknown address value */
 extern cval cval_zero; /* A zero value. Use cval_cast to make the desired 
-			  kind of constant */
+                          kind of constant */
 extern cval cval_one; /* A one value. Use cval_cast to make the desired 
-			  kind of constant */
+                          kind of constant */
 extern cval cval_bitsperbyte; /* BITSPERBYTE, unsigned */
 
 void cval_init(void);
@@ -91,7 +91,7 @@ cval make_type_cval(size_t s);
 cval make_cval_float(long double d);
 cval make_cval_complex(cval r, cval i);
 cval make_cval_address(data_declaration ddecl, label_declaration ldecl,
-		       largest_int offset);
+                       largest_int offset);
 
 cval make_cval_address_unknown_offset(cval c);
 /* Requires: cval_isaddress(c)

--- a/src/dd_list.h
+++ b/src/dd_list.h
@@ -32,7 +32,7 @@ Boston, MA 02111-1307, USA. */
  */
 
 typedef struct dd_list *dd_list; /* A list */
-typedef struct dd_list_pos	 /* A position in a list */
+typedef struct dd_list_pos         /* A position in a list */
 {
   /* PRIVATE! Do not use the fields directly */
   struct dd_list_pos *next;

--- a/src/decls.h
+++ b/src/decls.h
@@ -39,18 +39,18 @@ typedef struct label_declaration *label_declaration;
 typedef struct field_declaration {
   struct tag_declaration *containing_tag;
   struct field_declaration *next; /* Next field in struct/union */
-  const char *name;		/* May be NULL for bitfields (if NULL, bitwidth == 0) */
+  const char *name;                /* May be NULL for bitfields (if NULL, bitwidth == 0) */
   type type;
 
   /* All '@'-style attributes attached to this declaration */
   dd_list/*nesc_attribute*/ attributes;
 
-  field_decl ast;		/* May be null if copied from anonymous 
-				   struct/union */
-  cval bitwidth;		/* for bitfields, cval_top otherwise */
-  cval offset;			/* in bits, not bytes. Can be cval_top if
-				   offset is not a compile-time constant */
-  bool packed;			/* if packed attribute specified */
+  field_decl ast;                /* May be null if copied from anonymous 
+                                   struct/union */
+  cval bitwidth;                /* for bitfields, cval_top otherwise */
+  cval offset;                        /* in bits, not bytes. Can be cval_top if
+                                   offset is not a compile-time constant */
+  bool packed;                        /* if packed attribute specified */
 
   /* In abstract configurations or modules: The latest instantiation
      of this declaration */
@@ -62,7 +62,7 @@ typedef struct tag_declaration {
   int kind; /* One of kind_{struct/union/enum/attribute}_ref */
   const char *name; /* NULL for anonynous struct/union/enum */
   type reptype; /* The type used to represent an enum, NULL for struct
-		   and unions */
+                   and unions */
   /* All '@'-style attributes attached to this declaration */
   dd_list/*nesc_attribute*/ attributes;
 
@@ -73,18 +73,18 @@ typedef struct tag_declaration {
   struct tag_declaration *shadowed; /* Any struct with the same tag defined in enclosing scope */
   bool defined, being_defined;
   bool fields_const, fields_volatile;
-  bool transparent_union;	/* transparent_union attribute is present */
-  bool collapsed;		/* TRUE if this struct/union was collapsed
-				   into its parent. */
+  bool transparent_union;        /* transparent_union attribute is present */
+  bool collapsed;                /* TRUE if this struct/union was collapsed
+                                   into its parent. */
 
-  cval size;			/* Can be cval_top if not compile-time constant
-				   (due to variable-size arrays in struct) */
+  cval size;                        /* Can be cval_top if not compile-time constant
+                                   (due to variable-size arrays in struct) */
   cval alignment, user_alignment;
-  bool packed;			/* if packed attribute specified */
-  bool dumped;			/* TRUE if already added to dump list */
-  bool Cname;			/* TRUE if has @C() attribute */
+  bool packed;                        /* if packed attribute specified */
+  bool dumped;                        /* TRUE if already added to dump list */
+  bool Cname;                        /* TRUE if has @C() attribute */
 
-  nesc_declaration container;	/* as in data_declarations */
+  nesc_declaration container;        /* as in data_declarations */
 
   /* Function this declaration occurs in (NULL if outside a function) */
   struct data_declaration *container_function;
@@ -97,17 +97,17 @@ typedef struct tag_declaration {
   /* Name of a macro to use in nesC's output for instances of this attribute - 
      if this is NULL, attributes are not printed */
   const char *macro_name;
-  bool deputy_scope;		/* TRUE for deputy attributes (@deputy_scope()) */
+  bool deputy_scope;                /* TRUE for deputy attributes (@deputy_scope()) */
 } *tag_declaration;
 
 typedef enum { decl_variable, decl_constant, decl_function,
-	       decl_typedef, decl_error, decl_magic_string,	
-	       decl_magic_function,
-	       decl_interface_ref, decl_component_ref } data_kind;
+               decl_typedef, decl_error, decl_magic_string,        
+               decl_magic_function,
+               decl_interface_ref, decl_component_ref } data_kind;
 
 typedef enum  {
-  c_call_atomic = 1,		/* bit set if atomic calls to this fn */
-  c_call_nonatomic = 2	/* bit set if non-atomic calls to this fn */
+  c_call_atomic = 1,                /* bit set if atomic calls to this fn */
+  c_call_nonatomic = 2        /* bit set if non-atomic calls to this fn */
 } call_contexts;
 
 struct data_declaration {
@@ -141,12 +141,12 @@ struct data_declaration {
   declaration definition; /* Pointer to actual definition, if any */
   declaration ast; /* Last declaration */
   expression initialiser; /* NULL if none. For type arguments, this gets set
-			     to the argument type (type_argument node) */
+                             to the argument type (type_argument node) */
 
-  bool printed;			/* symbol info already printed */
-  bool dumped;			/* TRUE if already added to dump list */
+  bool printed;                        /* symbol info already printed */
+  bool dumped;                        /* TRUE if already added to dump list */
   bool islimbo; /* TRUE if comes from an extern declaration in an inner scope
-		   (also true for implicit function declarations) */
+                   (also true for implicit function declarations) */
   bool isexternalscope; /* == TREE_PUBLIC   */
   bool isfilescoperef; /* == DECL_EXTERNAL */
   bool needsmemory;   /* == TREE_STATIC   */
@@ -160,16 +160,16 @@ struct data_declaration {
          set to FALSE */
   bool isused;
   bool in_system_header;
-  bool Cname;			/* name is in C name space (don't rename!)
-				   Set by the `C' attribute. */
-  bool safe;			/* True if deputy safety checks should
-				   be enabled */
-  call_contexts spontaneous;	/* Call contexts for environmental calls
-				   (main, interrupt handlers, e.g.). Set by
-				   the `spontaneous', `interrupt' and
-				   `signal' attributes */
+  bool Cname;                        /* name is in C name space (don't rename!)
+                                   Set by the `C' attribute. */
+  bool safe;                        /* True if deputy safety checks should
+                                   be enabled */
+  call_contexts spontaneous;        /* Call contexts for environmental calls
+                                   (main, interrupt handlers, e.g.). Set by
+                                   the `spontaneous', `interrupt' and
+                                   `signal' attributes */
 
-  dd_list/*use*/ nuses;		/* List of uses of this identifier */
+  dd_list/*use*/ nuses;                /* List of uses of this identifier */
 
   /* For functions */
   enum { function_implicit, function_normal, function_static, function_nested,
@@ -178,27 +178,27 @@ struct data_declaration {
   bool isinline;
   bool noinlinep;
   bool isexterninline;
-  bool defined;			/* nesC: true if defined, false if used */
-  bool suppress_definition;	/* Prevent code generation */
-  bool uncallable;		/* Error if called */
-  bool async;			/* True if async declared (cmd/event) or
-				   inferred (C function) */
-  bool actual_async;		/* Inferred value for async */
+  bool defined;                        /* nesC: true if defined, false if used */
+  bool suppress_definition;        /* Prevent code generation */
+  bool uncallable;                /* Error if called */
+  bool async;                        /* True if async declared (cmd/event) or
+                                   inferred (C function) */
+  bool actual_async;                /* Inferred value for async */
   /* The call_contexts summarise the runtime contexts in which this fn
      might be called. So if all calls to f are in atomic statements,
      and f calls g outside an atomic statement, then 
       g->call_contexts == c_call_atomic
   */
   call_contexts call_contexts;
-  call_contexts extra_contexts;	/* Some extra, hidden call contexts (used to
-				   support __nesc_enable_interrupt) */
-  bool makeinline;		/* Mark this function inline when generating code */
-  gnode ig_node;		/* inline-graph node for this function */
-  struct data_declaration *interface;	/* nesC: interface this cmd/event belongs to */
+  call_contexts extra_contexts;        /* Some extra, hidden call contexts (used to
+                                   support __nesc_enable_interrupt) */
+  bool makeinline;                /* Mark this function inline when generating code */
+  gnode ig_node;                /* inline-graph node for this function */
+  struct data_declaration *interface;        /* nesC: interface this cmd/event belongs to */
   typelist oldstyle_args; /* Type of arguments from old-style declaration */
-  dd_list/*iduse*/ fn_uses;	/* list of uses of identifiers in this fn */
+  dd_list/*iduse*/ fn_uses;        /* list of uses of identifiers in this fn */
   struct connections *connections; /* See nesc-generate.c: what this command
-				      or event is connected to. */
+                                      or event is connected to. */
   /* folding function for magic functions. pass is 0 when constant
      folding during parsing, and goes from 1 to n for each final
      constant folding pass (after all components loaded) */
@@ -206,15 +206,15 @@ struct data_declaration {
 
   /* For variables */
   enum { variable_register, variable_static, variable_normal } vtype;
-  bool islocal;			/* True for non-static local vars */
-  bool isparameter; 		/* implies islocal */
-  bool async_access;		/* Some kind of access in an async context */
-  bool async_write;		/* A write in async context */
+  bool islocal;                        /* True for non-static local vars */
+  bool isparameter;                 /* implies islocal */
+  bool async_access;                /* Some kind of access in an async context */
+  bool async_write;                /* A write in async context */
   bool norace;
 
   /* For constants */
   known_cst value;
-  bool substitute;		/* Substitute value when unparsing */
+  bool substitute;                /* Substitute value when unparsing */
 
   /* For magic_strings */
   cstring schars;
@@ -234,13 +234,13 @@ struct data_declaration {
   /* For typedefs of network base types */
   data_declaration encoder, decoder; /* encoder and decoder functions */
   data_declaration bf_encoder, bf_decoder; /* bitfield encoder and decoder functions */
-  bool isbe;				   /* TRUE for big-endian types */
-  type basetype;		/* underlying non-network type (e.g., uint8_t) */
+  bool isbe;                                   /* TRUE for big-endian types */
+  type basetype;                /* underlying non-network type (e.g., uint8_t) */
 
   /* For type variables (some decl_typedefs). Regular typedefs (not type
      variables) have typevar_none here. */
   enum { typevar_none,
-	 typevar_normal, typevar_integer, typevar_number } typevar_kind;
+         typevar_normal, typevar_integer, typevar_number } typevar_kind;
 };
 
 struct label_declaration {
@@ -258,7 +258,7 @@ struct environment
   struct environment *sameregion parent;
   function_decl fdecl;
   bool parm_level : 1;
-  bool global_level : 1;	/* Both system and component */
+  bool global_level : 1;        /* Both system and component */
   bool deputy_scope : 1;
   env sameregion id_env;
   env sameregion tag_env;

--- a/src/dhash.c
+++ b/src/dhash.c
@@ -56,8 +56,8 @@ struct dhash_table
 };
 
 dhash_table new_dhash_table(region r, unsigned long initial_size,
-			    int (*compare)(void *key, void *y),
-			    unsigned long (*hash)(void *x))
+                            int (*compare)(void *key, void *y),
+                            unsigned long (*hash)(void *x))
 {
   dhash_table h = ralloc(r, struct dhash_table);
 
@@ -103,12 +103,12 @@ void *dhlookup(dhash_table h, void *x)
       void *bucket = h->elements[i];
 
       if (!bucket)
-	return NULL;
+        return NULL;
       if (h->compare(x, bucket))
-	return bucket;
+        return bucket;
 
       if (++i >= h->size)
-	i = 0;
+        i = 0;
     }
 }
 
@@ -129,20 +129,20 @@ void dhadd(dhash_table h, void *x)
 
       /* Rehash old entries */
       for (j = 0; j < oldsize; j++)
-	if (oldelements[j])
-	  {
-	    unsigned long newi = dhash(h, oldelements[j]);
-		    
-	    while (h->elements[newi])
-	      {
-		newi++;
-		if (newi >= h->size)
-		  newi = 0;
-	      }
-	    h->elements[newi] = oldelements[j];
-	    if (j == i)
-	      i = newi;
-	  }
+        if (oldelements[j])
+          {
+            unsigned long newi = dhash(h, oldelements[j]);
+                    
+            while (h->elements[newi])
+              {
+                newi++;
+                if (newi >= h->size)
+                  newi = 0;
+              }
+            h->elements[newi] = oldelements[j];
+            if (j == i)
+              i = newi;
+          }
     }
 
   i = dhash(h, x);
@@ -150,13 +150,13 @@ void dhadd(dhash_table h, void *x)
   for (;;)
     {
       if (!h->elements[i])
-	{
-	  h->elements[i] = x;
-	  return;
-	}
+        {
+          h->elements[i] = x;
+          return;
+        }
 
       if (++i >= h->size)
-	i = 0;
+        i = 0;
     }
 }
 
@@ -191,10 +191,10 @@ void *dhnext(dhash_scan *iterator)
       void *x;
 
       if (iterator->index >= h->size)
-	return NULL;
+        return NULL;
       x = h->elements[iterator->index++];
       if (x)
-	return x;
+        return x;
     }
 }
 

--- a/src/dhash.h
+++ b/src/dhash.h
@@ -38,8 +38,8 @@
 typedef struct dhash_table *dhash_table;
 
 dhash_table new_dhash_table(region r, unsigned long initial_size,
-			    int (*compare)(void *entry1, void *entry2),
-			    unsigned long (*hash)(void *entry));
+                            int (*compare)(void *entry1, void *entry2),
+                            unsigned long (*hash)(void *entry));
 /* Returns: new hash table created in region r, with specified initial size,
      comparison and hashing functions
 */

--- a/src/edit.c
+++ b/src/edit.c
@@ -33,8 +33,8 @@ Boston, MA 02111-1307, USA. */
    this approach.
    Return it's declaration */
 data_decl build_declaration(region r, struct environment *e,
-			    type t, const char *name, expression init,
-			    data_declaration *oddecl)
+                            type t, const char *name, expression init,
+                            data_declaration *oddecl)
 {
   struct data_declaration tempdecl;
   identifier_declarator id;
@@ -136,7 +136,7 @@ expression build_string(region r, location loc, const char *str)
 }
 
 expression build_function_call(region r, location loc,
-			       expression fn, expression arglist)
+                               expression fn, expression arglist)
 {
   expression result = CAST(expression, new_function_call(r, loc, fn, arglist, NULL, normal_call));
   type fntype = type_default_conversion(fn->type), rettype;

--- a/src/edit.h
+++ b/src/edit.h
@@ -28,8 +28,8 @@ Boston, MA 02111-1307, USA. */
    this approach.
    Return it's declaration */
 data_decl build_declaration(region r, struct environment *e,
-			    type t, const char *name, expression init,
-			    data_declaration *oddecl);
+                            type t, const char *name, expression init,
+                            data_declaration *oddecl);
 
 /* Declare a new temporary that can be assigned a value of type t.
    Place the declaration at the start of block. 
@@ -40,6 +40,6 @@ word build_word(region r, const char *cword);
 
 expression build_string(region r, location loc, const char *s);
 expression build_function_call(region r, location loc,
-			       expression fn, expression arglist);
+                               expression fn, expression arglist);
 
 #endif

--- a/src/env.c
+++ b/src/env.c
@@ -93,9 +93,9 @@ void *env_lookup(env e, const char *s, bool this_level_only)
     {
       found = dhlookup(e->table, &lookup);
       if (found)
-	return found->value;
+        return found->value;
       if (this_level_only || !e->parent) 
-	return NULL;
+        return NULL;
       e = e->parent;
     }
 }

--- a/src/errors.c
+++ b/src/errors.c
@@ -71,10 +71,10 @@ int count_error(int warningp)
       static int warning_message = 0;
 
       if (warningp && !warning_message)
-	{
-	  fprintf (stderr, "%s: warnings being treated as errors\n", progname);
-	  warning_message = 1;
-	}
+        {
+          fprintf (stderr, "%s: warnings being treated as errors\n", progname);
+          warning_message = 1;
+        }
       errorcount++;
     }
 
@@ -98,18 +98,18 @@ void print_error_function(const char *file)
   if (last_error_function != current.function_decl)
     {
       if (file)
-	fprintf (stderr, "%s: ", file);
+        fprintf (stderr, "%s: ", file);
 
       if (current.function_decl == NULL)
-	fprintf (stderr, "At top level:\n");
+        fprintf (stderr, "At top level:\n");
       else
-	{
-	  const char *name, *iname;
+        {
+          const char *name, *iname;
 
-	  declarator_name(current.function_decl->declarator, &name, &iname);
-	  fprintf (stderr, "In function `%s%s%s':\n",
-		   iname ? iname : "", iname ? "." : "", name);
-	}
+          declarator_name(current.function_decl->declarator, &name, &iname);
+          fprintf (stderr, "In function `%s%s%s':\n",
+                   iname ? iname : "", iname ? "." : "", name);
+        }
 
       last_error_function = current.function_decl;
     }
@@ -123,11 +123,11 @@ void print_current_nesc_instance(void)
   if (last_container != current.container)
     {
       if (current.container)
-	fprintf(stderr, "In %s `%s':\n", 
-		language_name(current.container->kind),
-		current.container->instance_name);
+        fprintf(stderr, "In %s `%s':\n", 
+                language_name(current.container->kind),
+                current.container->instance_name);
       else
-	fprintf(stderr, "In C file:\n");
+        fprintf(stderr, "In C file:\n");
       last_container = current.container;
     }
 }
@@ -146,11 +146,11 @@ void report_error_function(const char *file)
     {
       fprintf (stderr, "In file included");
       for (p = current.lex.input->next; p; p = p->next)
-	{
-	  fprintf (stderr, " from %s:%lu", p->l.filename, p->l.lineno);
-	  if (p->next)
-	    fprintf (stderr, ",\n                ");
-	}
+        {
+          fprintf (stderr, " from %s:%lu", p->l.filename, p->l.lineno);
+          if (p->next)
+            fprintf (stderr, ",\n                ");
+        }
       fprintf (stderr, ":\n");
       last_error_tick = input_file_stack_tick;
     }
@@ -329,7 +329,7 @@ void warning_or_error(bool iswarning, const char *format, ...)
 
 /* Report warning msg at decl */
 void warning_or_error_with_decl(bool iswarning, declaration d,
-				const char *format, ...)
+                                const char *format, ...)
 {
   va_list args;
 
@@ -343,7 +343,7 @@ void warning_or_error_with_decl(bool iswarning, declaration d,
 
 /* Report warning msg at l */
 void warning_or_error_with_location(bool iswarning, location l,
-				    const char *format, ...)
+                                    const char *format, ...)
 {
   va_list args;
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -83,11 +83,11 @@ void warning_or_error(bool iswarning, const char *format, ...);
 
 /* Report warning msg at decl */
 void warning_or_error_with_decl(bool iswarning, declaration d,
-				const char *format, ...);
+                                const char *format, ...);
 
 /* Report warning msg at l */
 void warning_or_error_with_location(bool iswarning, location l,
-				    const char *format, ...);
+                                    const char *format, ...);
 
 /* Report pedantic warning or error msg at current filename, lineno */
 void pedwarn(const char *format, ...);

--- a/src/expr.c
+++ b/src/expr.c
@@ -50,7 +50,7 @@ static bool compatible_pointer_targets(type ttl, type ttr, bool pedantic)
 static bool compatible_pointer_types(type tl, type tr)
 {
   return compatible_pointer_targets(type_points_to(tl), type_points_to(tr),
-				    pedantic);
+                                    pedantic);
 }
 
 /* Function arguments are positive, interface parameters are negative.
@@ -66,7 +66,7 @@ static const char *argtype(int *parmnum)
 }
 
 static void warn_for_assignment(const char *msg, const char *opname,
-				data_declaration fdecl, int argnum)
+                                data_declaration fdecl, int argnum)
 {
   static char argstring[] = "passing %s %d of `%s'";
   static char argnofun[] =  "passing %s %d";
@@ -77,19 +77,19 @@ static void warn_for_assignment(const char *msg, const char *opname,
       const char *argname = argtype(&argnum);
 
       if (fdecl)
-	{
-	  const char *function = decl_printname(fdecl);
+        {
+          const char *function = decl_printname(fdecl);
 
-	  /* Function name is known; supply it.  */
-	  tmpname = (char *)alloca(strlen(function) + sizeof(argstring) + 25 /*%d*/ + 1);
-	  sprintf(tmpname, argstring, argname, argnum, function);
-	}
+          /* Function name is known; supply it.  */
+          tmpname = (char *)alloca(strlen(function) + sizeof(argstring) + 25 /*%d*/ + 1);
+          sprintf(tmpname, argstring, argname, argnum, function);
+        }
       else
-	{
-	  /* Function name unknown (call through ptr); just give arg number.  */
-	  tmpname = (char *)alloca(sizeof(argnofun) + 25 /*%d*/ + 1);
-	  sprintf(tmpname, argnofun, argname, argnum);
-	}
+        {
+          /* Function name unknown (call through ptr); just give arg number.  */
+          tmpname = (char *)alloca(sizeof(argnofun) + 25 /*%d*/ + 1);
+          sprintf(tmpname, argnofun, argname, argnum);
+        }
       opname = tmpname;
     }
   pedwarn(msg, opname);
@@ -106,21 +106,21 @@ static void incomplete_type_error(expression e, type t)
   else
     {
       while (type_array(t) && type_array_size(t))
-	t = type_array_of(t);
+        t = type_array_of(t);
 
       if (type_tagged(t))
-	{
-	  tag_declaration tag = type_tag(t);
+        {
+          tag_declaration tag = type_tag(t);
 
-	  error("invalid use of undefined type `%s %s'",
-		tagkind_name(tag->kind), tag->name);
-	}
+          error("invalid use of undefined type `%s %s'",
+                tagkind_name(tag->kind), tag->name);
+        }
       else if (type_void(t))
-	error("invalid use of void expression");
+        error("invalid use of void expression");
       else if (type_array(t))
-	error("invalid use of array with unspecified bounds");
+        error("invalid use of array with unspecified bounds");
       else
-	assert(0);
+        assert(0);
       /* XXX: Missing special message for typedef's */
     }
 }
@@ -146,9 +146,9 @@ type default_conversion(expression e)
     {
       /* Traditionally, unsignedness is preserved in default promotions. */
       if (flag_traditional && type_unsigned(from))
-	return unsigned_int_type;
+        return unsigned_int_type;
       else
-	return int_type;
+        return int_type;
     }
 
   if (flag_traditional && !flag_allow_single_precision && type_float(from))
@@ -175,10 +175,10 @@ type default_conversion(expression e)
   if (type_array(from))
     {
       if (!e->lvalue)
-	{
-	  error("invalid use of non-lvalue array");
-	  return error_type;
-	}
+        {
+          error("invalid use of non-lvalue array");
+          return error_type;
+        }
       assert(!e->cst);
       e->cst = e->static_address;
       e->converted_to_pointer = TRUE;
@@ -192,11 +192,11 @@ type default_conversion(expression e)
       data_declaration vdecl = type_variable_decl(from);
 
       switch (vdecl->typevar_kind)
-	{
-	case typevar_integer: return unknown_int_type;
-	case typevar_number: return unknown_number_type;
-	default: break;
-	}
+        {
+        case typevar_integer: return unknown_int_type;
+        case typevar_number: return unknown_number_type;
+        default: break;
+        }
     }
 
   return from;
@@ -222,12 +222,12 @@ static void readonly_warning(expression e, char *context)
       field_ref field = CAST(field_ref, e);
 
       if (type_readonly(field->arg1->type))
-	readonly_warning(field->arg1, context);
+        readonly_warning(field->arg1, context);
       else
-	{
-	  strcat(buf, " of read-only member `%s'");
-	  pedwarn(buf, field->cstring.data);
-	}
+        {
+          strcat(buf, " of read-only member `%s'");
+          pedwarn(buf, field->cstring.data);
+        }
     }
   else if (is_identifier(e))
     {
@@ -270,44 +270,44 @@ bool check_conversion(type to, type from)
   if (type_integer(to))
     {
       if (!type_scalar(from))
-	{
-	  error("aggregate value used where an integer was expected");
-	  return FALSE;
-	}
+        {
+          error("aggregate value used where an integer was expected");
+          return FALSE;
+        }
     }
   else if (type_pointer(to))
     {
       if (!(type_integer(from) || type_pointer(from)))
-	{
-	  error("cannot convert to a pointer type");
-	  return FALSE;
-	}
+        {
+          error("cannot convert to a pointer type");
+          return FALSE;
+        }
     }
   else if (type_floating(to))
     {
       if (type_pointer(from))
-	{
-	  error("pointer value used where a floating point value was expected");
-	  return FALSE;
-	}
+        {
+          error("pointer value used where a floating point value was expected");
+          return FALSE;
+        }
       else if (!type_arithmetic(from))
-	{
-	  error("aggregate value used where a float was expected");
-	  return FALSE;
-	}
+        {
+          error("aggregate value used where a float was expected");
+          return FALSE;
+        }
     }
   else if (type_complex(to))
     {
       if (type_pointer(from))
-	{
-	  error("pointer value used where a complex was expected");
-	  return FALSE;
-	}
+        {
+          error("pointer value used where a complex was expected");
+          return FALSE;
+        }
       else if (!type_arithmetic(from))
-	{
-	  error("aggregate value used where a complex was expected");
-	  return FALSE;
-	}
+        {
+          error("aggregate value used where a complex was expected");
+          return FALSE;
+        }
     }
   else
     {
@@ -324,54 +324,54 @@ static bool assignable_pointer_targets(type tt1, type tt2, bool pedantic)
 }
 
 static void ptrconversion_warnings(type ttl, type ttr, expression rhs,
-				   const char *context,
-				   data_declaration fdecl, int parmnum,
-				   bool pedantic)
+                                   const char *context,
+                                   data_declaration fdecl, int parmnum,
+                                   bool pedantic)
 {
   if (pedantic
       && ((type_void(ttl) && type_function(ttr)) ||
-	  (type_function(ttl) && type_void(ttr) &&
-	   !(rhs && definite_null(rhs)))))
+          (type_function(ttl) && type_void(ttr) &&
+           !(rhs && definite_null(rhs)))))
     warn_for_assignment("ANSI forbids %s between function pointer and `void *'",
-			context, fdecl, parmnum);
+                        context, fdecl, parmnum);
 
   /* Const and volatile mean something different for function
      types, so the usual warnings are not appropriate.  */
   else if (type_function(ttl) && type_function(ttr))
     {
       /* Because const and volatile on functions are
-	 restrictions that say the function will not do
-	 certain things, it is okay to use a const or volatile
-	 function where an ordinary one is wanted, but not
-	 vice-versa.  */
+         restrictions that say the function will not do
+         certain things, it is okay to use a const or volatile
+         function where an ordinary one is wanted, but not
+         vice-versa.  */
       if (type_const(ttl) && !type_const(ttr))
-	warn_for_assignment("%s makes `const *' function pointer from non-const",
-			    context, fdecl, parmnum);
+        warn_for_assignment("%s makes `const *' function pointer from non-const",
+                            context, fdecl, parmnum);
       if (type_volatile(ttl) && !type_volatile(ttr))
-	warn_for_assignment("%s makes `volatile *' function pointer from non-volatile",
-			    context, fdecl, parmnum);
+        warn_for_assignment("%s makes `volatile *' function pointer from non-volatile",
+                            context, fdecl, parmnum);
     }
   else if (!type_function(ttl) && !type_function(ttr))
     {
       if (!type_const(ttl) && type_const(ttr))
-	warn_for_assignment("%s discards `const' from pointer target type",
-			    context, fdecl, parmnum);
+        warn_for_assignment("%s discards `const' from pointer target type",
+                            context, fdecl, parmnum);
       if (!type_volatile(ttl) && type_volatile(ttr))
-	warn_for_assignment("%s discards `volatile' from pointer target type",
-			    context, fdecl, parmnum);
+        warn_for_assignment("%s discards `volatile' from pointer target type",
+                            context, fdecl, parmnum);
 
       /* If this is not a case of ignoring a mismatch in signedness,
-	 no warning.  */
+         no warning.  */
       if (!assignable_pointer_targets(ttl, ttr, FALSE) && pedantic)
-	warn_for_assignment("pointer targets in %s differ in signedness",
-			    context, fdecl, parmnum);
+        warn_for_assignment("pointer targets in %s differ in signedness",
+                            context, fdecl, parmnum);
     }
 }
 
 /* Return TRUE if no error and lhstype and rhstype are not error_type */
 bool check_assignment(type lhstype, type rhstype, expression rhs,
-		      const char *context, data_declaration fundecl,
-		      int parmnum)
+                      const char *context, data_declaration fundecl,
+                      int parmnum)
 {
   bool zerorhs = rhs && definite_zero(rhs);
 
@@ -390,7 +390,7 @@ bool check_assignment(type lhstype, type rhstype, expression rhs,
   if (type_arithmetic(lhstype) && type_arithmetic(rhstype))
     {
       if (rhs)
-	constant_overflow_warning(rhs->cst);
+        constant_overflow_warning(rhs->cst);
       return check_conversion(lhstype, rhstype);
     }
   if (parmnum && (type_qualifiers(lhstype) & transparent_qualifier))
@@ -400,68 +400,68 @@ bool check_assignment(type lhstype, type rhstype, expression rhs,
       field_declaration fields, marginal_field = NULL;
 
       /* I blame gcc for this horrible mess (and it's minor inconsistencies
-	 with the regular rules) */
+         with the regular rules) */
       /* pedantic warnings are skipped in here because we're already
-	 issuing a warning for the use of this construct */
+         issuing a warning for the use of this construct */
       for (fields = tag->fieldlist; fields; fields = fields->next)
-	{
-	  type ft = fields->type;
+        {
+          type ft = fields->type;
 
-	  if (type_compatible(ft, rhstype))
-	    break;
+          if (type_compatible(ft, rhstype))
+            break;
 
-	  if (!type_pointer(ft))
-	    continue;
+          if (!type_pointer(ft))
+            continue;
 
-	  if (type_pointer(rhstype))
-	    {
-	      type ttl = type_points_to(ft), ttr = type_points_to(rhstype);
-	      bool goodmatch = assignable_pointer_targets(ttl, ttr, FALSE);
+          if (type_pointer(rhstype))
+            {
+              type ttl = type_points_to(ft), ttr = type_points_to(rhstype);
+              bool goodmatch = assignable_pointer_targets(ttl, ttr, FALSE);
 
-	      /* Any non-function converts to a [const][volatile] void *
-		 and vice versa; otherwise, targets must be the same.
-		 Meanwhile, the lhs target must have all the qualifiers of
-		 the rhs.  */
-	      if (goodmatch)
-		{
-		  /* If this type won't generate any warnings, use it.  */
-		  if ((type_function(ttr) && type_function(ttl))
-		      ? ((!type_const(ttl) | type_const(ttr))
-			 & (!type_volatile(ttl) | type_volatile(ttr)))
-		      : ((type_const(ttl) | !type_const(ttr))
-			 & (type_volatile(ttl) | !type_volatile(ttr))))
-		    break;
+              /* Any non-function converts to a [const][volatile] void *
+                 and vice versa; otherwise, targets must be the same.
+                 Meanwhile, the lhs target must have all the qualifiers of
+                 the rhs.  */
+              if (goodmatch)
+                {
+                  /* If this type won't generate any warnings, use it.  */
+                  if ((type_function(ttr) && type_function(ttl))
+                      ? ((!type_const(ttl) | type_const(ttr))
+                         & (!type_volatile(ttl) | type_volatile(ttr)))
+                      : ((type_const(ttl) | !type_const(ttr))
+                         & (type_volatile(ttl) | !type_volatile(ttr))))
+                    break;
 
-		  /* Keep looking for a better type, but remember this one.  */
-		  if (!marginal_field)
-		    marginal_field = fields;
-		}
-	    }
+                  /* Keep looking for a better type, but remember this one.  */
+                  if (!marginal_field)
+                    marginal_field = fields;
+                }
+            }
 
-	  /* Can convert integer zero to any pointer type.  */
-	  /* Note that this allows passing *any* null pointer (gcc bug?) */
-	  if (zerorhs)
-	    break;
-	}
+          /* Can convert integer zero to any pointer type.  */
+          /* Note that this allows passing *any* null pointer (gcc bug?) */
+          if (zerorhs)
+            break;
+        }
 
       if (fields || marginal_field)
-	{
-	  if (!fields)
-	    {
-	      /* We have only a marginally acceptable member type;
-		 it needs a warning.  */
-	      type ttl = type_points_to(marginal_field->type),
-		ttr = type_points_to(rhstype);
+        {
+          if (!fields)
+            {
+              /* We have only a marginally acceptable member type;
+                 it needs a warning.  */
+              type ttl = type_points_to(marginal_field->type),
+                ttr = type_points_to(rhstype);
 
-	      ptrconversion_warnings(ttl, ttr, rhs, context, fundecl, parmnum,
-				     FALSE);
-	    }
-	  
-	  if (pedantic && !(fundecl && fundecl->in_system_header))
-	    pedwarn("ANSI C prohibits argument conversion to union type");
+              ptrconversion_warnings(ttl, ttr, rhs, context, fundecl, parmnum,
+                                     FALSE);
+            }
+          
+          if (pedantic && !(fundecl && fundecl->in_system_header))
+            pedwarn("ANSI C prohibits argument conversion to union type");
 
-	  return TRUE;
-	}
+          return TRUE;
+        }
     }
 
   if (type_pointer(lhstype) && type_pointer(rhstype))
@@ -470,15 +470,15 @@ bool check_assignment(type lhstype, type rhstype, expression rhs,
       bool goodmatch = assignable_pointer_targets(ttl, ttr, pedantic);
 
       /* Any non-function converts to a [const][volatile] void *
-	 and vice versa; otherwise, targets must be the same.
-	 Meanwhile, the lhs target must have all the qualifiers of the rhs.  */
+         and vice versa; otherwise, targets must be the same.
+         Meanwhile, the lhs target must have all the qualifiers of the rhs.  */
       if (goodmatch || (type_equal_unqualified(make_unsigned_type(ttl),
-					       make_unsigned_type(ttr))))
-	ptrconversion_warnings(ttl, ttr, rhs, context, fundecl, parmnum,
-			       pedantic);
+                                               make_unsigned_type(ttr))))
+        ptrconversion_warnings(ttl, ttr, rhs, context, fundecl, parmnum,
+                               pedantic);
       else
-	warn_for_assignment("%s from incompatible pointer type",
-			    context, fundecl, parmnum);
+        warn_for_assignment("%s from incompatible pointer type",
+                            context, fundecl, parmnum);
 
       return check_conversion(lhstype, rhstype);
     }
@@ -486,14 +486,14 @@ bool check_assignment(type lhstype, type rhstype, expression rhs,
   else if (type_pointer(lhstype) && type_integral(rhstype))
     {
       if (!zerorhs)
-	warn_for_assignment("%s makes pointer from integer without a cast",
-			    context, fundecl, parmnum);
+        warn_for_assignment("%s makes pointer from integer without a cast",
+                            context, fundecl, parmnum);
       return check_conversion(lhstype, rhstype);
     }
   else if (type_integral(lhstype) && type_pointer(rhstype))
     {
       warn_for_assignment("%s makes integer from pointer without a cast",
-			  context, fundecl, parmnum);
+                          context, fundecl, parmnum);
       return check_conversion(lhstype, rhstype);
     }
 
@@ -502,11 +502,11 @@ bool check_assignment(type lhstype, type rhstype, expression rhs,
       const char *argname = argtype(&parmnum);
 
       if (fundecl)
-	error("incompatible type for %s %d of `%s'", argname, parmnum,
-	      decl_printname(fundecl));
+        error("incompatible type for %s %d of `%s'", argname, parmnum,
+              decl_printname(fundecl));
       else
-	error("incompatible type for %s %d of indirect function call",
-	      argname, parmnum);
+        error("incompatible type for %s %d of indirect function call",
+              argname, parmnum);
     }
   else
     error("incompatible types in %s", context);
@@ -532,47 +532,47 @@ expression make_comma(location loc, expression elist)
   scan_expression (e, elist)
     if (e->next) /* Not last */
       {
-	if (!e->cst)
-	  all_cst = FALSE;
+        if (!e->cst)
+          all_cst = FALSE;
 #if 0
-	if (!e->side_effects)
-	  {
-	    /* The left-hand operand of a comma expression is like an expression
-	       statement: with -W or -Wunused, we should warn if it doesn't have
-	       any side-effects, unless it was explicitly cast to (void).  */
-	    if ((extra_warnings || warn_unused)
-		&& !(TREE_CODE (TREE_VALUE (list)) == CONVERT_EXPR
-		      && TREE_TYPE (TREE_VALUE (list)) == void_type_node))
-	      warning ("left-hand operand of comma expression has no effect");
-	  }
-	else if (warn_unused)
-	  warn_if_unused_value(e);
+        if (!e->side_effects)
+          {
+            /* The left-hand operand of a comma expression is like an expression
+               statement: with -W or -Wunused, we should warn if it doesn't have
+               any side-effects, unless it was explicitly cast to (void).  */
+            if ((extra_warnings || warn_unused)
+                && !(TREE_CODE (TREE_VALUE (list)) == CONVERT_EXPR
+                      && TREE_TYPE (TREE_VALUE (list)) == void_type_node))
+              warning ("left-hand operand of comma expression has no effect");
+          }
+        else if (warn_unused)
+          warn_if_unused_value(e);
 #endif
       }
     else
       {
-	if (type_array(e->type))
-	  result->type = default_conversion(e);
-	else
-	  result->type = e->type;
+        if (type_array(e->type))
+          result->type = default_conversion(e);
+        else
+          result->type = e->type;
 
-	if (!pedantic)
-	  {
-	    /* (e1, ..., en) is a constant expression if all ei are constant
-	       expressions. Weird? (see cst10.c) */
-	    if (all_cst)
-	      result->cst = e->cst;
-	    result->lvalue = e->lvalue;
-	    result->isregister = e->isregister;
-	    result->bitfield = e->bitfield;
-	  }
+        if (!pedantic)
+          {
+            /* (e1, ..., en) is a constant expression if all ei are constant
+               expressions. Weird? (see cst10.c) */
+            if (all_cst)
+              result->cst = e->cst;
+            result->lvalue = e->lvalue;
+            result->isregister = e->isregister;
+            result->bitfield = e->bitfield;
+          }
       }
 
   return result;
 }
 
 static void check_dereference(expression result, type dereferenced,
-			      const char *errorstring)
+                              const char *errorstring)
 {
   if (type_pointer(dereferenced))
     {
@@ -581,20 +581,20 @@ static void check_dereference(expression result, type dereferenced,
       result->type = t;
 #if 0
       if (TYPE_SIZE (t) == 0 && TREE_CODE (t) != ARRAY_TYPE)
-	{
-	  error ("dereferencing pointer to incomplete type");
-	  return error_mark_node;
-	}
+        {
+          error ("dereferencing pointer to incomplete type");
+          return error_mark_node;
+        }
 #endif
       if (type_void(t) && !unevaluated_expression())
-	warning("dereferencing `void *' pointer");
+        warning("dereferencing `void *' pointer");
       result->side_effects |= type_volatile(t) /*|| flag_volatile*/;
     }
   else
     {
       result->type = error_type;
       if (dereferenced != error_type)
-	error("invalid type argument of `%s'", errorstring);
+        error("invalid type argument of `%s'", errorstring);
     }
   result->lvalue = TRUE;
 }
@@ -638,10 +638,10 @@ expression make_address_of(location loc, expression e)
   else
     {
       if (e->isregister)
-	pedwarn("address of a register variable requested");
+        pedwarn("address of a register variable requested");
 
       if (!(type_function(e->type) || e->lvalue))
-	error("invalid lvalue in unary `&'");
+        error("invalid lvalue in unary `&'");
 
       result->type = make_pointer_type(e->type);
       result->cst = e->static_address;
@@ -661,60 +661,60 @@ expression make_unary(location loc, int unop, expression e)
       return make_predecrement(loc, e);
     default:
       {
-	expression result = CAST(expression, newkind_unary(parse_region, unop, loc, e));
-	type etype = default_conversion(e);
-	const char *errstring = NULL;
+        expression result = CAST(expression, newkind_unary(parse_region, unop, loc, e));
+        type etype = default_conversion(e);
+        const char *errstring = NULL;
 
-	if (etype == error_type)
-	  result->type = error_type;
-	else
-	  {
-	    switch (unop)
-	      {
-	      case kind_unary_plus:
-		if (!type_arithmetic(etype))
-		  errstring = "wrong type argument to unary plus";
-		break;
-	      case kind_unary_minus:
-		if (!type_arithmetic(etype))
-		  errstring = "wrong type argument to unary minus";
-		break;
-	      case kind_bitnot:
-		if (type_complex(etype))
-		  result->kind = kind_conjugate;
-		else if (!type_integer(etype))
-		  errstring = "wrong type argument to bit-complement";
-		break;
-	      case kind_not:
-		if (!type_scalar(etype))
-		  errstring = "wrong type argument to unary exclamation mark";
-		else
-		  etype = int_type;
-		break;
-	      case kind_realpart: case kind_imagpart:
-		if (!type_arithmetic(etype))
-		  if (unop == kind_realpart)
-		    errstring = "wrong type argument to __real__";
-		  else
-		    errstring = "wrong type argument to __imag__";
-		else
-		  etype = type_complex(etype) ? make_base_type(etype) : etype;
-		break;
-	      default:
-		assert(0);
-	      }
-	    if (errstring)
-	      {
-		error(errstring);
-		result->type = error_type;
-	      }
-	    else
-	      {
-		result->type = etype;
-		result->cst = fold_unary(result);
-	      }
-	  }
-	return result;
+        if (etype == error_type)
+          result->type = error_type;
+        else
+          {
+            switch (unop)
+              {
+              case kind_unary_plus:
+                if (!type_arithmetic(etype))
+                  errstring = "wrong type argument to unary plus";
+                break;
+              case kind_unary_minus:
+                if (!type_arithmetic(etype))
+                  errstring = "wrong type argument to unary minus";
+                break;
+              case kind_bitnot:
+                if (type_complex(etype))
+                  result->kind = kind_conjugate;
+                else if (!type_integer(etype))
+                  errstring = "wrong type argument to bit-complement";
+                break;
+              case kind_not:
+                if (!type_scalar(etype))
+                  errstring = "wrong type argument to unary exclamation mark";
+                else
+                  etype = int_type;
+                break;
+              case kind_realpart: case kind_imagpart:
+                if (!type_arithmetic(etype))
+                  if (unop == kind_realpart)
+                    errstring = "wrong type argument to __real__";
+                  else
+                    errstring = "wrong type argument to __imag__";
+                else
+                  etype = type_complex(etype) ? make_base_type(etype) : etype;
+                break;
+              default:
+                assert(0);
+              }
+            if (errstring)
+              {
+                error(errstring);
+                result->type = error_type;
+              }
+            else
+              {
+                result->type = etype;
+                result->cst = fold_unary(result);
+              }
+          }
+        return result;
       }
     }
 }
@@ -748,12 +748,12 @@ void check_sizeof(expression result, type stype)
   if (type_function(stype))
     {
       if (pedantic || warn_pointer_arith)
-	pedwarn("sizeof applied to a function type");
+        pedwarn("sizeof applied to a function type");
     }
   else if (type_void(stype))
     {
       if (pedantic || warn_pointer_arith)
-	pedwarn("sizeof applied to a void type");
+        pedwarn("sizeof applied to a void type");
     }
   else
     check_sizealign("sizeof", stype);
@@ -818,89 +818,89 @@ expression make_cast(location loc, asttype t, expression e)
   else if (type_equal_unqualified(castto, e->type))
     {
       if (pedantic && type_aggregate(castto))
-	pedwarn("ANSI C forbids casting nonscalar to the same type");
+        pedwarn("ANSI C forbids casting nonscalar to the same type");
     }
   else
     {
       type etype = e->type;
 
       /* Convert functions and arrays to pointers,
-	 but don't convert any other types.  */
+         but don't convert any other types.  */
       if (type_function(etype) || type_array(etype))
-	etype = default_conversion(e);
+        etype = default_conversion(e);
 
       if (type_union(castto))
-	{
-	  tag_declaration utag = type_tag(castto);
-	  field_declaration ufield;
+        {
+          tag_declaration utag = type_tag(castto);
+          field_declaration ufield;
 
-	  /* Look for etype as a field of the union */
-	  for (ufield = utag->fieldlist; ufield; ufield = ufield->next)
-	    if (ufield->name && type_equal_unqualified(ufield->type, etype))
-	      {
-		if (pedantic)
-		  pedwarn("ANSI C forbids casts to union type");
-		break;
-	      }
-	  if (!ufield)
-	    error("cast to union type from type not present in union");
-	}
+          /* Look for etype as a field of the union */
+          for (ufield = utag->fieldlist; ufield; ufield = ufield->next)
+            if (ufield->name && type_equal_unqualified(ufield->type, etype))
+              {
+                if (pedantic)
+                  pedwarn("ANSI C forbids casts to union type");
+                break;
+              }
+          if (!ufield)
+            error("cast to union type from type not present in union");
+        }
       else 
-	{
-	  /* Optionally warn about potentially worrisome casts.  */
+        {
+          /* Optionally warn about potentially worrisome casts.  */
 
-	  if (warn_cast_qual && type_pointer(etype) && type_pointer(castto))
-	    {
-	      type ep = type_points_to(etype), cp = type_points_to(castto);
+          if (warn_cast_qual && type_pointer(etype) && type_pointer(castto))
+            {
+              type ep = type_points_to(etype), cp = type_points_to(castto);
 
-	      if (type_volatile(ep) && !type_volatile(cp))
-		pedwarn("cast discards `volatile' from pointer target type");
-	      if (type_const(ep) && !type_const(cp))
-		pedwarn("cast discards `const' from pointer target type");
-	    }
+              if (type_volatile(ep) && !type_volatile(cp))
+                pedwarn("cast discards `volatile' from pointer target type");
+              if (type_const(ep) && !type_const(cp))
+                pedwarn("cast discards `const' from pointer target type");
+            }
 
-	  /* This warning is weird */
-	  if (warn_bad_function_cast && is_function_call(e) &&
-	      !type_equal_unqualified(castto, etype))
-	    warning ("cast does not match function type");
+          /* This warning is weird */
+          if (warn_bad_function_cast && is_function_call(e) &&
+              !type_equal_unqualified(castto, etype))
+            warning ("cast does not match function type");
 
 #if 0
-	  /* Warn about possible alignment problems.  */
-	  if (STRICT_ALIGNMENT && warn_cast_align
-	      && TREE_CODE (type) == POINTER_TYPE
-	      && TREE_CODE (otype) == POINTER_TYPE
-	      && TREE_CODE (TREE_TYPE (otype)) != VOID_TYPE
-	      && TREE_CODE (TREE_TYPE (otype)) != FUNCTION_TYPE
-	      /* Don't warn about opaque types, where the actual alignment
-		 restriction is unknown.  */
-	      && !((TREE_CODE (TREE_TYPE (otype)) == UNION_TYPE
-		    || TREE_CODE (TREE_TYPE (otype)) == RECORD_TYPE)
-		   && TYPE_MODE (TREE_TYPE (otype)) == VOIDmode)
-	      && TYPE_ALIGN (TREE_TYPE (type)) > TYPE_ALIGN (TREE_TYPE (otype)))
-	    warning ("cast increases required alignment of target type");
+          /* Warn about possible alignment problems.  */
+          if (STRICT_ALIGNMENT && warn_cast_align
+              && TREE_CODE (type) == POINTER_TYPE
+              && TREE_CODE (otype) == POINTER_TYPE
+              && TREE_CODE (TREE_TYPE (otype)) != VOID_TYPE
+              && TREE_CODE (TREE_TYPE (otype)) != FUNCTION_TYPE
+              /* Don't warn about opaque types, where the actual alignment
+                 restriction is unknown.  */
+              && !((TREE_CODE (TREE_TYPE (otype)) == UNION_TYPE
+                    || TREE_CODE (TREE_TYPE (otype)) == RECORD_TYPE)
+                   && TYPE_MODE (TREE_TYPE (otype)) == VOIDmode)
+              && TYPE_ALIGN (TREE_TYPE (type)) > TYPE_ALIGN (TREE_TYPE (otype)))
+            warning ("cast increases required alignment of target type");
 
-	  if (TREE_CODE (type) == INTEGER_TYPE
-	      && TREE_CODE (otype) == POINTER_TYPE
-	      && TYPE_PRECISION (type) != TYPE_PRECISION (otype)
-	      && !TREE_CONSTANT (value))
-	    warning ("cast from pointer to integer of different size");
+          if (TREE_CODE (type) == INTEGER_TYPE
+              && TREE_CODE (otype) == POINTER_TYPE
+              && TYPE_PRECISION (type) != TYPE_PRECISION (otype)
+              && !TREE_CONSTANT (value))
+            warning ("cast from pointer to integer of different size");
 
-	  if (TREE_CODE (type) == POINTER_TYPE
-	      && TREE_CODE (otype) == INTEGER_TYPE
-	      && TYPE_PRECISION (type) != TYPE_PRECISION (otype)
+          if (TREE_CODE (type) == POINTER_TYPE
+              && TREE_CODE (otype) == INTEGER_TYPE
+              && TYPE_PRECISION (type) != TYPE_PRECISION (otype)
 #if 0
-	      /* Don't warn about converting 0 to pointer,
-		 provided the 0 was explicit--not cast or made by folding.  */
-	      && !(TREE_CODE (value) == INTEGER_CST && integer_zerop (value))
+              /* Don't warn about converting 0 to pointer,
+                 provided the 0 was explicit--not cast or made by folding.  */
+              && !(TREE_CODE (value) == INTEGER_CST && integer_zerop (value))
 #endif
-	      /* Don't warn about converting any constant.  */
-	      && !TREE_CONSTANT (value))
-	    warning ("cast to pointer from integer of different size");
+              /* Don't warn about converting any constant.  */
+              && !TREE_CONSTANT (value))
+            warning ("cast to pointer from integer of different size");
 #endif
 
-	  if (!check_conversion(castto, etype))
-	    castto = error_type;
-	}
+          if (!check_conversion(castto, etype))
+            castto = error_type;
+        }
     }
 
   result->lvalue = !pedantic && e->lvalue;
@@ -921,12 +921,12 @@ type pointer_int_sum(type ptype, type itype)
   if (type_void(pointed))
     {
       if (pedantic || warn_pointer_arith)
-	pedwarn("pointer of type `void *' used in arithmetic");
+        pedwarn("pointer of type `void *' used in arithmetic");
     }
   else if (type_function(pointed))
     {
       if (pedantic || warn_pointer_arith)
-	pedwarn("pointer to a function used in arithmetic");
+        pedwarn("pointer to a function used in arithmetic");
     }
   else if (type_incomplete(pointed))
     error("arithmetic on pointer to an incomplete type");
@@ -939,7 +939,7 @@ bool valid_compare(type t1, type t2, expression e1)
   if (type_void(type_points_to(t1)))
     {
       if (pedantic && type_function(type_points_to(t2)) && !definite_null(e1))
-	pedwarn("ANSI C forbids comparison of `void *' with function pointer");
+        pedwarn("ANSI C forbids comparison of `void *' with function pointer");
       return TRUE;
     }
   return FALSE;
@@ -958,28 +958,28 @@ type check_binary(int binop, expression e1, expression e2)
     {
     case kind_plus:
       if (type_pointer(t1) && type_integer(t2))
-	rtype = pointer_int_sum(t1, t2);
+        rtype = pointer_int_sum(t1, t2);
       else if (type_pointer(t2) && type_integer(t1))
-	rtype = pointer_int_sum(t2, t1);
+        rtype = pointer_int_sum(t2, t1);
       else
-	common = TRUE;
+        common = TRUE;
       break;
 
     case kind_minus: 
       if (type_pointer(t1) && type_integer(t2))
-	rtype = pointer_int_sum(t1, t2);
+        rtype = pointer_int_sum(t1, t2);
       else if (type_pointer(t1) && type_pointer(t2) &&
-	       compatible_pointer_types(t1, t2))
-	rtype = ptrdiff_t_type;
+               compatible_pointer_types(t1, t2))
+        rtype = ptrdiff_t_type;
       else
-	common = TRUE;
+        common = TRUE;
       break;
 
     case kind_plus_assign: case kind_minus_assign:
       if (type_pointer(t1) && type_integer(t2))
-	rtype = pointer_int_sum(t1, t2);
+        rtype = pointer_int_sum(t1, t2);
       else
-	common = TRUE;
+        common = TRUE;
       break;
 
     case kind_times: case kind_divide:
@@ -992,70 +992,70 @@ type check_binary(int binop, expression e1, expression e2)
     case kind_modulo_assign: case kind_bitand_assign: case kind_bitor_assign:
     case kind_bitxor_assign: case kind_lshift_assign: case kind_rshift_assign:
       if (type_integer(t1) && type_integer(t2))
-	rtype = common_type(t1, t2);
+        rtype = common_type(t1, t2);
       break;
 
     case kind_leq: case kind_geq: case kind_lt: case kind_gt:
       rtype = int_type; /* Default to assuming success */
       if (type_real(t1) && type_real(t2))
-	;
+        ;
       else if (type_pointer(t1) && type_pointer(t2))
-	{
-	  if (compatible_pointer_types(t1, t2))
-	    {
-	      /* XXX: how can this happen ? */
-	      if (type_incomplete(t1) != type_incomplete(t2))
-		pedwarn("comparison of complete and incomplete pointers");
-	      else if (pedantic && type_function(type_points_to(t1)))
-		pedwarn("ANSI C forbids ordered comparisons of pointers to functions");
-	    }
-	  else
-	    pedwarn("comparison of distinct pointer types lacks a cast");
-	}
+        {
+          if (compatible_pointer_types(t1, t2))
+            {
+              /* XXX: how can this happen ? */
+              if (type_incomplete(t1) != type_incomplete(t2))
+                pedwarn("comparison of complete and incomplete pointers");
+              else if (pedantic && type_function(type_points_to(t1)))
+                pedwarn("ANSI C forbids ordered comparisons of pointers to functions");
+            }
+          else
+            pedwarn("comparison of distinct pointer types lacks a cast");
+        }
       /* XXX: Use of definite_zero may lead to extra warnings when !extra_warnings */
       else if ((type_pointer(t1) && definite_zero(e2)) ||
-	       (type_pointer(t2) && definite_zero(e1)))
-	{
-	  if (pedantic || extra_warnings)
-	    pedwarn("ordered comparison of pointer with integer zero");
-	}
+               (type_pointer(t2) && definite_zero(e1)))
+        {
+          if (pedantic || extra_warnings)
+            pedwarn("ordered comparison of pointer with integer zero");
+        }
       else if ((type_pointer(t1) && type_integer(t2)) ||
-	       (type_pointer(t2) && type_integer(t1)))
-	{
-	  if (!flag_traditional)
-	    pedwarn("comparison between pointer and integer");
-	}
+               (type_pointer(t2) && type_integer(t1)))
+        {
+          if (!flag_traditional)
+            pedwarn("comparison between pointer and integer");
+        }
       else
-	rtype = NULL; /* Force error */
+        rtype = NULL; /* Force error */
       break;
 
     case kind_eq: case kind_ne:
       rtype = int_type; /* Default to assuming success */
       if (type_arithmetic(t1) && type_arithmetic(t2))
-	;
+        ;
       else if (type_pointer(t1) && type_pointer(t2))
-	{
-	  if (!compatible_pointer_types(t1, t2) &&
-	      !valid_compare(t1, t2, e1) &&
-	      !valid_compare(t2, t1, e2))
-	    pedwarn("comparison of distinct pointer types lacks a cast");
-	}
+        {
+          if (!compatible_pointer_types(t1, t2) &&
+              !valid_compare(t1, t2, e1) &&
+              !valid_compare(t2, t1, e2))
+            pedwarn("comparison of distinct pointer types lacks a cast");
+        }
       else if ((type_pointer(t1) && definite_null(e2)) ||
-	       (type_pointer(t2) && definite_null(e1)))
-	;
+               (type_pointer(t2) && definite_null(e1)))
+        ;
       else if ((type_pointer(t1) && type_integer(t2)) ||
-	       (type_pointer(t2) && type_integer(t1)))
-	{
-	  if (!flag_traditional)
-	    pedwarn("comparison between pointer and integer");
-	}
+               (type_pointer(t2) && type_integer(t1)))
+        {
+          if (!flag_traditional)
+            pedwarn("comparison between pointer and integer");
+        }
       else
-	rtype = NULL; /* Force error */
+        rtype = NULL; /* Force error */
       break;
 
     case kind_andand: case kind_oror:
       if (type_scalar(t1) && type_scalar(t2))
-	rtype = int_type;
+        rtype = int_type;
       break;
 
     default: assert(0); break;
@@ -1096,57 +1096,57 @@ expression make_binary(location loc, int binop, expression e1, expression e2)
       int code1 = e1->parens ? 0 : e1->kind, code2 = e2->parens ? 0 : e2->kind;
 
       if (binop == kind_lshift || binop == kind_rshift)
-	{
-	  if (code1 == kind_plus || code1 == kind_minus
-	      || code2 == kind_plus || code2 == kind_minus)
-	    warning("suggest parentheses around + or - inside shift");
-	}
+        {
+          if (code1 == kind_plus || code1 == kind_minus
+              || code2 == kind_plus || code2 == kind_minus)
+            warning("suggest parentheses around + or - inside shift");
+        }
 
       if (binop == kind_oror)
-	{
-	  if (code1 == kind_andand || code2 == kind_andand)
-	    warning("suggest parentheses around && within ||");
-	}
+        {
+          if (code1 == kind_andand || code2 == kind_andand)
+            warning("suggest parentheses around && within ||");
+        }
 
       if (binop == kind_bitor)
-	{
-	  if (code1 == kind_bitand || code1 == kind_bitxor
-	      || code1 == kind_plus || code1 == kind_minus
-	      || code2 == kind_bitand || code2 == kind_bitxor
-	      || code2 == kind_plus || code2 == kind_minus)
-	    warning("suggest parentheses around arithmetic in operand of |");
-	  /* Check cases like x|y==z */
-	  if (unsafe_comparison(e1) || unsafe_comparison(e2))
-	    warning("suggest parentheses around comparison in operand of |");
-	}
+        {
+          if (code1 == kind_bitand || code1 == kind_bitxor
+              || code1 == kind_plus || code1 == kind_minus
+              || code2 == kind_bitand || code2 == kind_bitxor
+              || code2 == kind_plus || code2 == kind_minus)
+            warning("suggest parentheses around arithmetic in operand of |");
+          /* Check cases like x|y==z */
+          if (unsafe_comparison(e1) || unsafe_comparison(e2))
+            warning("suggest parentheses around comparison in operand of |");
+        }
 
       if (binop == kind_bitxor)
-	{
-	  if (code1 == kind_bitand
-	      || code1 == kind_plus || code1 == kind_minus
-	      || code2 == kind_bitand
-	      || code2 == kind_plus || code2 == kind_minus)
-	    warning ("suggest parentheses around arithmetic in operand of ^");
-	  /* Check cases like x^y==z */
-	  if (unsafe_comparison(e1) || unsafe_comparison(e2))
-	    warning("suggest parentheses around comparison in operand of ^");
-	}
+        {
+          if (code1 == kind_bitand
+              || code1 == kind_plus || code1 == kind_minus
+              || code2 == kind_bitand
+              || code2 == kind_plus || code2 == kind_minus)
+            warning ("suggest parentheses around arithmetic in operand of ^");
+          /* Check cases like x^y==z */
+          if (unsafe_comparison(e1) || unsafe_comparison(e2))
+            warning("suggest parentheses around comparison in operand of ^");
+        }
 
       if (binop == kind_bitand)
-	{
-	  if (code1 == kind_plus || code1 == kind_minus
-	      || code2 == kind_plus || code2 == kind_minus)
-	    warning ("suggest parentheses around + or - in operand of &");
-	  /* Check cases like x&y==z */
-	  if (unsafe_comparison(e1) || unsafe_comparison(e2))
-	    warning("suggest parentheses around comparison in operand of &");
-	}
+        {
+          if (code1 == kind_plus || code1 == kind_minus
+              || code2 == kind_plus || code2 == kind_minus)
+            warning ("suggest parentheses around + or - in operand of &");
+          /* Check cases like x&y==z */
+          if (unsafe_comparison(e1) || unsafe_comparison(e2))
+            warning("suggest parentheses around comparison in operand of &");
+        }
 
       /* Similarly, check for cases like 1<=i<=10 that are probably errors.  */
       /* This was under extra_warnings in 3.4.x, but under warn_parentheses in 4.? */
       if (unsafe_comparison(result) 
-	  && (unsafe_comparison(e1) || unsafe_comparison(e2)))
-	warning("comparisons like X<=Y<=Z do not have their mathematical meaning");
+          && (unsafe_comparison(e1) || unsafe_comparison(e2)))
+        warning("comparisons like X<=Y<=Z do not have their mathematical meaning");
     }
 
 #if 0
@@ -1163,7 +1163,7 @@ static bool voidstar_conditional(type t1, type t2)
   if (type_void(t1))
     {
       if (pedantic && type_function(t2))
-	pedwarn("ANSI C forbids conditional expr between `void *' and function pointer");
+        pedwarn("ANSI C forbids conditional expr between `void *' and function pointer");
       return TRUE;
     }
   return FALSE;
@@ -1174,14 +1174,14 @@ static bool pointerint_conditional(type t1, type t2, expression e2)
   if (type_pointer(t1) && type_integer(t2))
     {
       if (!definite_zero(e2))
-	pedwarn("pointer/integer type mismatch in conditional expression");
+        pedwarn("pointer/integer type mismatch in conditional expression");
       return TRUE;
     }
   return FALSE;
 }
 
 expression make_conditional(location loc, expression cond,
-			    expression true, expression false)
+                            expression true, expression false)
 {
   expression result =
     CAST(expression, new_conditional(parse_region, loc, cond, true, false));
@@ -1218,7 +1218,7 @@ expression make_conditional(location loc, expression cond,
   else if (type_void(ttype) || type_void(ftype))
     {
       if (pedantic && (!type_void(ttype) || !type_void(ftype)))
-	pedwarn("ANSI C forbids conditional expr with only one void side");
+        pedwarn("ANSI C forbids conditional expr with only one void side");
       rtype = void_type;
     }
   else if (type_pointer(ttype) && type_pointer(ftype))
@@ -1226,22 +1226,22 @@ expression make_conditional(location loc, expression cond,
       type tpointsto = type_points_to(ttype), fpointsto = type_points_to(ftype);
 
       if (compatible_pointer_types(ttype, ftype))
-	rtype = common_type(tpointsto, fpointsto);
+        rtype = common_type(tpointsto, fpointsto);
       else if (definite_null(true) && type_void(tpointsto))
-	rtype = fpointsto;
+        rtype = fpointsto;
       else if (definite_null(false) && type_void(fpointsto))
-	rtype = tpointsto;
+        rtype = tpointsto;
       else if (voidstar_conditional(tpointsto, fpointsto))
-	rtype = tpointsto; /* void * result */
+        rtype = tpointsto; /* void * result */
       else if (voidstar_conditional(fpointsto, tpointsto))
-	rtype = fpointsto; /* void * result */
+        rtype = fpointsto; /* void * result */
       else
-	{
-	  pedwarn("pointer type mismatch in conditional expression");
-	  /* Slight difference from GCC: I qualify the result type with
-	     the appropriate qualifiers */
-	  rtype = void_type;
-	}
+        {
+          pedwarn("pointer type mismatch in conditional expression");
+          /* Slight difference from GCC: I qualify the result type with
+             the appropriate qualifiers */
+          rtype = void_type;
+        }
 
       /* Qualifiers depend on both types */
       rtype = make_pointer_type(qualify_type2(rtype, tpointsto, fpointsto));
@@ -1274,7 +1274,7 @@ expression make_conditional(location loc, expression cond,
 expression make_assign(location loc, int binop, expression e1, expression e2)
 {
   expression result = CAST(expression, newkind_binary(parse_region, binop,
-						      loc, e1, e2));
+                                                      loc, e1, e2));
   type t1 = require_complete_type(e1, e1->type), t2;
 
   result->type = error_type;
@@ -1283,19 +1283,19 @@ expression make_assign(location loc, int binop, expression e1, expression e2)
       expression rhs;
 
       if (binop == kind_assign)
-	{
-	  t2 = default_conversion_for_assignment(e2);
-	  rhs = e2;
-	}
+        {
+          t2 = default_conversion_for_assignment(e2);
+          rhs = e2;
+        }
       else
-	{
-	  t2 = check_binary(binop, e1, e2);
-	  rhs = NULL;
-	}
+        {
+          t2 = check_binary(binop, e1, e2);
+          rhs = NULL;
+        }
 
       if (check_writable_lvalue(e1, "assignment") &&
-	  check_assignment(e1->type, t2, rhs, "assignment", NULL, 0))
-	result->type = make_qualified_type(e1->type, no_qualifiers);
+          check_assignment(e1->type, t2, rhs, "assignment", NULL, 0))
+        result->type = make_qualified_type(e1->type, no_qualifiers);
     }
 
   return result;
@@ -1316,26 +1316,26 @@ expression make_identifier(location loc, cstring id, bool maybe_implicit)
   if (!decl)
     {
       /* Suppress undeclare identifier errors in deputy scopes - they
-	 will be reprocessed later under deputy scoping rules (see
-	 nesc-deputy.c) */
+         will be reprocessed later under deputy scoping rules (see
+         nesc-deputy.c) */
       if (!current.env->deputy_scope)
-	{
-	  if (!current.function_decl)
-	    error("`%s' undeclared here (not in a function)", id.data);
-	  else if (!env_lookup(current.function_decl->undeclared_variables, id.data, FALSE))
-	    {
-	      static bool undeclared_variable_notice;
+        {
+          if (!current.function_decl)
+            error("`%s' undeclared here (not in a function)", id.data);
+          else if (!env_lookup(current.function_decl->undeclared_variables, id.data, FALSE))
+            {
+              static bool undeclared_variable_notice;
 
-	      error("`%s' undeclared (first use in this function)", id.data);
-	      env_add(current.function_decl->undeclared_variables, id.data, (void *)1);
-	      if (!undeclared_variable_notice)
-		{
-		  error("(Each undeclared identifier is reported only once");
-		  error("for each function it appears in.)");
-		  undeclared_variable_notice = TRUE;
-		}
-	    }
-	}
+              error("`%s' undeclared (first use in this function)", id.data);
+              env_add(current.function_decl->undeclared_variables, id.data, (void *)1);
+              if (!undeclared_variable_notice)
+                {
+                  error("(Each undeclared identifier is reported only once");
+                  error("for each function it appears in.)");
+                  undeclared_variable_notice = TRUE;
+                }
+            }
+        }
       decl = bad_decl;
     }
 
@@ -1363,16 +1363,16 @@ expression make_compound_expr(location loc, statement block)
       statement last_stmt = last_statement(bs->stmts);
 
       if (last_stmt && is_expression_stmt(last_stmt))
-	result->type = CAST(expression_stmt, last_stmt)->arg1->type;
+        result->type = CAST(expression_stmt, last_stmt)->arg1->type;
       else
-	result->type = void_type;
+        result->type = void_type;
 
       return result;
     }
 }
 
 bool check_arguments(type fntype, expression arglist,
-		     data_declaration fundecl, bool generic_call)
+                     data_declaration fundecl, bool generic_call)
 {
   typelist_scanner parmtypes;
   int parmstep = generic_call ? -1 : 1, parmnum = parmstep;
@@ -1385,70 +1385,70 @@ bool check_arguments(type fntype, expression arglist,
       typelist_scan(type_function_arguments(fntype), &parmtypes);
 
       while ((parmtype = typelist_next(&parmtypes)) && arglist)
-	{
-	  type argtype = arglist->type;
+        {
+          type argtype = arglist->type;
 
-	  if (type_incomplete(parmtype))
-	    error("type of formal parameter %d is incomplete", parmnum);
-	  else
-	    {
-	      if (warn_conversion)
-		{
-		  if (type_integer(parmtype) && type_floating(argtype))
-		    warn_for_assignment("%s as integer rather than floating due to prototype",
-					NULL, fundecl, parmnum);
-		  else if (type_floating(parmtype) && type_integer(argtype))
-		    warn_for_assignment ("%s as floating rather than integer due to prototype",
-					 NULL, fundecl, parmnum);
-		  else if (type_complex(parmtype) && type_floating(argtype))
-		    warn_for_assignment ("%s as complex rather than floating due to prototype",
-					NULL, fundecl, parmnum);
-		  else if (type_floating(parmtype) && type_complex(argtype))
-		    warn_for_assignment ("%s as floating rather than complex due to prototype",
-					NULL, fundecl, parmnum);
-		  /* Warn if any argument is passed as `float',
-		     since without a prototype it would be `double'.  */
-		  else if (type_float(parmtype) && type_floating(argtype))
-		    warn_for_assignment ("%s as `float' rather than `double' due to prototype",
-					NULL, fundecl, parmnum);
+          if (type_incomplete(parmtype))
+            error("type of formal parameter %d is incomplete", parmnum);
+          else
+            {
+              if (warn_conversion)
+                {
+                  if (type_integer(parmtype) && type_floating(argtype))
+                    warn_for_assignment("%s as integer rather than floating due to prototype",
+                                        NULL, fundecl, parmnum);
+                  else if (type_floating(parmtype) && type_integer(argtype))
+                    warn_for_assignment ("%s as floating rather than integer due to prototype",
+                                         NULL, fundecl, parmnum);
+                  else if (type_complex(parmtype) && type_floating(argtype))
+                    warn_for_assignment ("%s as complex rather than floating due to prototype",
+                                        NULL, fundecl, parmnum);
+                  else if (type_floating(parmtype) && type_complex(argtype))
+                    warn_for_assignment ("%s as floating rather than complex due to prototype",
+                                        NULL, fundecl, parmnum);
+                  /* Warn if any argument is passed as `float',
+                     since without a prototype it would be `double'.  */
+                  else if (type_float(parmtype) && type_floating(argtype))
+                    warn_for_assignment ("%s as `float' rather than `double' due to prototype",
+                                        NULL, fundecl, parmnum);
 #if 0
-		  else
-		    {
-		      /* Type that would have been passed w/o proto */
-		      type type1 = default_conversion(arglist);
+                  else
+                    {
+                      /* Type that would have been passed w/o proto */
+                      type type1 = default_conversion(arglist);
 
-		      /* No warning if function asks for enum
-			 and the actual arg is that enum type.  */
-		      if (type_enum(parmtype) && type_equal_unqualified(parmtype, argtype))
-			;
-		      /* XXX: else messy stuff that cannot easily be done w/o constant
-			 folding and type size info */
-		    }
+                      /* No warning if function asks for enum
+                         and the actual arg is that enum type.  */
+                      if (type_enum(parmtype) && type_equal_unqualified(parmtype, argtype))
+                        ;
+                      /* XXX: else messy stuff that cannot easily be done w/o constant
+                         folding and type size info */
+                    }
 #endif
-		}
-	      check_assignment(parmtype, default_conversion_for_assignment(arglist),
-			       arglist, NULL, fundecl, parmnum);
-	    }
-	  parmnum += parmstep;
-	  arglist = CAST(expression, arglist->next);
-	}
+                }
+              check_assignment(parmtype, default_conversion_for_assignment(arglist),
+                               arglist, NULL, fundecl, parmnum);
+            }
+          parmnum += parmstep;
+          arglist = CAST(expression, arglist->next);
+        }
       argname = argtype(&parmstep);
       if (parmtype)
-	{
-	  if (fundecl)
-	    error("too few %ss to function `%s'", argname, 
-		  decl_printname(fundecl));
-	  else
-	    error("too few %ss to function", argname);
-	}
+        {
+          if (fundecl)
+            error("too few %ss to function `%s'", argname, 
+                  decl_printname(fundecl));
+          else
+            error("too few %ss to function", argname);
+        }
       else if (arglist && !type_function_varargs(fntype))
-	{
-	  if (fundecl)
-	    error("too many %ss to function `%s'", argname,
-		  decl_printname(fundecl));
-	  else
-	    error("too many %ss to function", argname);
-	}
+        {
+          if (fundecl)
+            error("too many %ss to function `%s'", argname,
+                  decl_printname(fundecl));
+          else
+            error("too many %ss to function", argname);
+        }
     }
 
   /* Checks for arguments with no corresponding argument type */
@@ -1476,7 +1476,7 @@ expression make_function_call(location loc, expression fn, expression arglist)
     {
       current.function_decl->ddecl->extra_contexts |= c_call_nonatomic;
       if (current.in_atomic)
-	warning("call to __nesc_enable_interrupt within an atomic statement");
+        warning("call to __nesc_enable_interrupt within an atomic statement");
     }
 
   if (type_pointer(fntype))
@@ -1487,9 +1487,9 @@ expression make_function_call(location loc, expression fn, expression arglist)
   if (!type_functional(fntype))
     {
       if (type_generic(fntype))
-	error("parameters missing in call to parameterised command or event");
+        error("parameters missing in call to parameterised command or event");
       else
-	error("called object is not a function, command, event or task");
+        error("called object is not a function, command, event or task");
       return result;
     }
 
@@ -1520,10 +1520,10 @@ expression make_va_arg(location loc, expression arg, asttype type)
 
       error("char, short and float are automatically promoted when passed through `...'");
       if (!gave_help)
-	{
-	  gave_help = TRUE;
-	  error("(so you should pass `int', `unsigned' or `double' to `va_arg')");
-	}
+        {
+          gave_help = TRUE;
+          error("(so you should pass `int', `unsigned' or `double' to `va_arg')");
+        }
     }
   result->type = type->type;
 
@@ -1553,18 +1553,18 @@ expression make_offsetof(location loc, asttype t, dd_list fields)
 
       /* Build ((size_t)&((t *)0)->fields) */
       ptr_to_t_d = CAST(declarator,
-	new_pointer_declarator(parse_region, loc, t->declarator));
+        new_pointer_declarator(parse_region, loc, t->declarator));
       t = make_type(t->qualifiers, ptr_to_t_d);
       cast = make_cast(loc, t, zero);
       fieldref = make_dereference(loc, cast);
       dd_scan (field, fields)
-	{
-	  cstring f;
+        {
+          cstring f;
 
-	  f.data = DD_GET(char *, field);
-	  f.length = strlen(f.data);
-	  fieldref = make_field_ref(loc, fieldref, f);
-	}
+          f.data = DD_GET(char *, field);
+          f.length = strlen(f.data);
+          fieldref = make_field_ref(loc, fieldref, f);
+        }
       addrof = make_unary(loc, kind_address_of, fieldref);
 
       type2ast(parse_region, loc, size_t_type, NULL, &size_t_d, &size_t_m);
@@ -1593,13 +1593,13 @@ expression make_array_ref(location loc, expression array, expression index)
     {
       /* Some special GCC extensions */
       /* XXX: Ignoring the weird register stuff, going for a simple version
-	 which seems essentially identical for our purposes */
+         which seems essentially identical for our purposes */
       if (pedantic)
-	pedwarn("ANSI C forbids subscripting non-lvalue array");
+        pedwarn("ANSI C forbids subscripting non-lvalue array");
       atype = make_pointer_type(type_array_of(array->type));
 
        /* this should not be possible (non-lvalue arrays come from
-	  array fields of non-lvalue struct expressions) */
+          array fields of non-lvalue struct expressions) */
       assert(!array->static_address);
     }
   else
@@ -1649,26 +1649,26 @@ expression make_field_ref(location loc, expression object, cstring field)
       tag_declaration tag = type_tag(otype);
 
       if (!tag->defined)
-	incomplete_type_error(NULL, otype);
+        incomplete_type_error(NULL, otype);
       else
-	{
-	  field_declaration fdecl = env_lookup(tag->fields, field.data, FALSE);
+        {
+          field_declaration fdecl = env_lookup(tag->fields, field.data, FALSE);
 
-	  if (!fdecl)
-	    error("%s has no member named `%s'", tagkind_name(tag->kind),
-		  field.data);
-	  else
-	    {
-	      result->fdecl = fdecl;
-	      result->type = qualify_type2(fdecl->type, fdecl->type, object->type);
-	      result->bitfield = !cval_istop(fdecl->bitwidth);
-	      result->static_address = foldaddress_field_ref(CAST(expression, result));
-	    }
-	}
+          if (!fdecl)
+            error("%s has no member named `%s'", tagkind_name(tag->kind),
+                  field.data);
+          else
+            {
+              result->fdecl = fdecl;
+              result->type = qualify_type2(fdecl->type, fdecl->type, object->type);
+              result->bitfield = !cval_istop(fdecl->bitwidth);
+              result->static_address = foldaddress_field_ref(CAST(expression, result));
+            }
+        }
     }
   else if (otype != error_type)
     error("request for member `%s' in something not a structure or union",
-	  field.data);
+          field.data);
 
   result->lvalue = object->lvalue;
 
@@ -1687,14 +1687,14 @@ static expression finish_increment(unary result, char *name)
   else 
     {
       if (type_incomplete(etype))
-	error("%s of pointer to unknown structure or union", name);
+        error("%s of pointer to unknown structure or union", name);
       else if (type_pointer(etype) && (pedantic || warn_pointer_arith) &&
-	       (type_void(type_points_to(etype)) ||
-		type_function(type_points_to(etype))))
-	pedwarn("wrong type argument to %s", name);
+               (type_void(type_points_to(etype)) ||
+                type_function(type_points_to(etype))))
+        pedwarn("wrong type argument to %s", name);
 
       if (check_writable_lvalue(e, name))
-	result->type = etype;
+        result->type = etype;
     }
   return CAST(expression, result);
 }
@@ -1702,23 +1702,23 @@ static expression finish_increment(unary result, char *name)
 expression make_postincrement(location loc, expression e)
 {
   return finish_increment(CAST(unary, new_postincrement(parse_region, loc, e)),
-			  "increment");
+                          "increment");
 }
 
 expression make_preincrement(location loc, expression e)
 {
   return finish_increment(CAST(unary, new_preincrement(parse_region, loc, e)),
-			  "increment");
+                          "increment");
 }
 
 expression make_postdecrement(location loc, expression e)
 {
   return finish_increment(CAST(unary, new_postdecrement(parse_region, loc, e)),
-			  "decrement");
+                          "decrement");
 }
 
 expression make_predecrement(location loc, expression e)
 {
   return finish_increment(CAST(unary, new_predecrement(parse_region, loc, e)),
-			  "decrement");
+                          "decrement");
 }

--- a/src/expr.h
+++ b/src/expr.h
@@ -37,7 +37,7 @@ expression make_alignof_type(location loc, asttype t);
 expression make_cast(location loc, asttype t, expression e);
 expression make_binary(location loc, int binop, expression e1, expression e2);
 expression make_conditional(location loc, expression cond,
-			    expression true, expression false);
+                            expression true, expression false);
 expression make_assign(location loc, int assignop, expression left, expression right);
 expression make_identifier(location loc, cstring id, bool maybe_implicit);
 expression make_compound_expr(location loc, statement block);
@@ -47,7 +47,7 @@ expression make_offsetof(location loc, asttype t, dd_list fields);
 expression make_array_ref(location loc, expression array, expression index);
 expression make_field_ref(location loc, expression object, cstring field);
 expression make_field_indirectref(location loc, expression object,
-				  cstring field);
+                                  cstring field);
 expression make_postincrement(location loc, expression e);
 expression make_preincrement(location loc, expression e);
 expression make_postdecrement(location loc, expression e);
@@ -55,12 +55,12 @@ expression make_predecrement(location loc, expression e);
 
 /* Return TRUE if no error and lhstype and rhstype are not error_type */
 bool check_assignment(type lhstype, type rhstype, expression rhs,
-		      const char *context, data_declaration fundecl,
-		      int parmnum);
+                      const char *context, data_declaration fundecl,
+                      int parmnum);
 
 bool check_conversion(type to, type from);
 bool check_arguments(type fntype, expression arglist,
-		     data_declaration fundecl, bool generic_call);
+                     data_declaration fundecl, bool generic_call);
 
 type default_conversion(expression e);
 type default_function_array_conversion(expression e);

--- a/src/graph.c
+++ b/src/graph.c
@@ -48,23 +48,23 @@ struct ggraph
 {
   region sameregion r;
   sd_list sameregion nodes;
-  long mark_count;		/* Value used to mark nodes/edges */
+  long mark_count;                /* Value used to mark nodes/edges */
 };
 
 struct gnode
 {
   struct sd_list_pos node;
   ggraph sameregion graph;
-  gedge sameregion in;		/* Ingoing edges */
-  gedge sameregion out;		/* Outgoing edges */
+  gedge sameregion in;                /* Ingoing edges */
+  gedge sameregion out;                /* Outgoing edges */
   void *data;
-  long mark;			/* Mark count for this node */
+  long mark;                        /* Mark count for this node */
 };
 
 struct gedge
 {
-  gnode sameregion in_node, out_node;	/* Extremities */
-  gedge sameregion next_in, next_out;	/* Edge in in/outgoing lists */
+  gnode sameregion in_node, out_node;        /* Extremities */
+  gedge sameregion next_in, next_out;        /* Edge in in/outgoing lists */
   void *data;
   long mark;
 };
@@ -86,8 +86,8 @@ ggraph new_graph(region r)
 }
 
 void delete_graph(ggraph g,
-		  void (*delete_node)(gnode n),
-		  void (*delete_edge)(gedge e))
+                  void (*delete_node)(gnode n),
+                  void (*delete_edge)(gedge e))
 /* Effects: Deletes graph g. Calls functions delete_node & delete_edge
      on nodes and edges before deleting them. All edges of a node
      are deleted before it is.
@@ -105,10 +105,10 @@ void delete_graph(ggraph g,
       gedge e, next;
       
       for (e = n->in; e; e = next)
-	{
-	  next = e->next_in;
-	  if (delete_edge) delete_edge(e);
-	}
+        {
+          next = e->next_in;
+          if (delete_edge) delete_edge(e);
+        }
     }
   for (node = sd_first(g->nodes); !sd_is_end(node); node = next)
     {
@@ -142,10 +142,10 @@ ggraph copy_graph(region r, ggraph g)
       nnode = onode->data;
 
       graph_scan_in (oedge, onode)
-	{
-	  nedge = graph_add_edge(graph_edge_from(oedge)->data, nnode, oedge->data);
-	  nedge->mark = oedge->mark;
-	}
+        {
+          nedge = graph_add_edge(graph_edge_from(oedge)->data, nnode, oedge->data);
+          nedge->mark = oedge->mark;
+        }
     }
 
   /* Finally restore original graph */
@@ -452,23 +452,23 @@ void dbg_graph(ggraph g, void (*pnode)(gnode g)) deletes
       fprintf(stderr, "%d(0x%p):", i++, node);
 
       graph_scan_out (out, node)
-	{
-	  gnode to = graph_edge_to(out);
-	  int j = 0;
-	  dd_list_pos anode2;
+        {
+          gnode to = graph_edge_to(out);
+          int j = 0;
+          dd_list_pos anode2;
 
-	  dd_scan (anode2, allnodes)
-	    {
-	      if (DD_GET(gnode, anode2) == to)
-		{
-		  fprintf(stderr, " %d", j);
-		  break;
-		}
-	      j++;
-	    }
-	}
+          dd_scan (anode2, allnodes)
+            {
+              if (DD_GET(gnode, anode2) == to)
+                {
+                  fprintf(stderr, " %d", j);
+                  break;
+                }
+              j++;
+            }
+        }
       if (pnode)
-	pnode(node);
+        pnode(node);
       fprintf(stderr, "\n");
     }
   deleteregion(temp);

--- a/src/graph.h
+++ b/src/graph.h
@@ -51,8 +51,8 @@ ggraph new_graph(region r);
 */
 
 void delete_graph(ggraph g,
-		  void (*delete_node)(gnode n),
-		  void (*delete_edge)(gedge e));
+                  void (*delete_node)(gnode n),
+                  void (*delete_edge)(gedge e));
 /* Effects: Deletes graph g. Calls functions delete_node & delete_edge
      on nodes and edges before deleting them. All edges of a node
      are deleted before it is.

--- a/src/init.c
+++ b/src/init.c
@@ -36,8 +36,8 @@ Boston, MA 02111-1307, USA. */
 static type set_array_length(type t, largest_int length)
 {
   return make_array_type(type_array_of(t),
-			 build_uint_constant(parse_region, dummy_location,
-					     size_t_type, length));
+                         build_uint_constant(parse_region, dummy_location,
+                                             size_t_type, length));
 }
 
 static largest_int string_constant_length(expression e)
@@ -89,9 +89,9 @@ struct spelling
 #define SPELLING_MEMBER 2
 #define SPELLING_BOUNDS 3
 
-static struct spelling *spelling;	/* Next stack element (unused).  */
-static struct spelling *spelling_base;	/* Spelling stack base.  */
-static int spelling_size;		/* Size of the spelling stack.  */
+static struct spelling *spelling;        /* Next stack element (unused).  */
+static struct spelling *spelling_base;        /* Spelling stack base.  */
+static int spelling_size;                /* Size of the spelling stack.  */
 
 /* Macros to save and restore the spelling stack around push_... functions.
    Alternative to SAVE_SPELLING_STACK.  */
@@ -101,36 +101,36 @@ static int spelling_size;		/* Size of the spelling stack.  */
 
 /* Save and restore the spelling stack around arbitrary C code.  */
 
-#define SAVE_SPELLING_DEPTH(code)		\
-{						\
-  int __depth = SPELLING_DEPTH ();		\
-  code;						\
-  RESTORE_SPELLING_DEPTH (__depth);		\
+#define SAVE_SPELLING_DEPTH(code)                \
+{                                                \
+  int __depth = SPELLING_DEPTH ();                \
+  code;                                                \
+  RESTORE_SPELLING_DEPTH (__depth);                \
 }
 
 /* Push an element on the spelling stack with type KIND and assign VALUE
    to MEMBER.  */
 
-#define PUSH_SPELLING(KIND, VALUE, MEMBER)				\
-{									\
-  int depth = SPELLING_DEPTH ();					\
-									\
-  if (depth >= spelling_size)						\
-    {									\
-      spelling_size += 10;						\
-      if (spelling_base == 0)						\
-	spelling_base							\
-	  = (struct spelling *) xmalloc (spelling_size * sizeof (struct spelling));	\
-      else								\
-        spelling_base							\
-	  = (struct spelling *) xrealloc (spelling_base,		\
-					  spelling_size * sizeof (struct spelling));	\
-      RESTORE_SPELLING_DEPTH (depth);					\
-    }									\
-									\
-  spelling->kind = (KIND);						\
-  spelling->MEMBER = (VALUE);						\
-  spelling++;								\
+#define PUSH_SPELLING(KIND, VALUE, MEMBER)                                \
+{                                                                        \
+  int depth = SPELLING_DEPTH ();                                        \
+                                                                        \
+  if (depth >= spelling_size)                                                \
+    {                                                                        \
+      spelling_size += 10;                                                \
+      if (spelling_base == 0)                                                \
+        spelling_base                                                        \
+          = (struct spelling *) xmalloc (spelling_size * sizeof (struct spelling));        \
+      else                                                                \
+        spelling_base                                                        \
+          = (struct spelling *) xrealloc (spelling_base,                \
+                                          spelling_size * sizeof (struct spelling));        \
+      RESTORE_SPELLING_DEPTH (depth);                                        \
+    }                                                                        \
+                                                                        \
+  spelling->kind = (KIND);                                                \
+  spelling->MEMBER = (VALUE);                                                \
+  spelling++;                                                                \
 }
 
 /* Push STRING on the stack.  Printed literally.  */
@@ -164,9 +164,9 @@ static int spelling_length(void)
   for (p = spelling_base; p < spelling; p++)
     {
       if (p->kind == SPELLING_BOUNDS)
-	size += 25;
+        size += 25;
       else
-	size += strlen (p->u.s) + 1;
+        size += strlen (p->u.s) + 1;
     }
 
   return size;
@@ -184,16 +184,16 @@ print_spelling (buffer)
   for (p = spelling_base; p < spelling; p++)
     if (p->kind == SPELLING_BOUNDS)
       {
-	sprintf (d, "[%ld]", (long)p->u.i);
-	d += strlen (d);
+        sprintf (d, "[%ld]", (long)p->u.i);
+        d += strlen (d);
       }
     else
       {
-	const char *s;
-	if (p->kind == SPELLING_MEMBER)
-	  *d++ = '.';
-	for (s = p->u.s; (*d = *s++); d++)
-	  ;
+        const char *s;
+        if (p->kind == SPELLING_MEMBER)
+          *d++ = '.';
+        for (s = p->u.s; (*d = *s++); d++)
+          ;
       }
   *d++ = '\0';
   return buffer;
@@ -278,38 +278,38 @@ static bool digest_init(type t, expression init)
       type typ1 = type_array_of(t);
 
       if ((type_char(typ1) || type_equal_unqualified(typ1, wchar_type))
-	  && is_string(init))
-	{
-	  type init_chartype = type_array_of(itype);
-	  cval tcsize;
+          && is_string(init))
+        {
+          type init_chartype = type_array_of(itype);
+          cval tcsize;
 
-	  if (type_compatible_unqualified(t, itype))
-	    return TRUE;
+          if (type_compatible_unqualified(t, itype))
+            return TRUE;
 
-	  if (!type_char(init_chartype) && type_char(typ1))
-	    {
-	      error_init ("char-array initialized from wide string");
-	      return FALSE;
-	    }
-	  if (type_char(init_chartype) && !type_char(typ1))
-	    {
-	      error_init ("int-array initialized from non-wide string");
-	      return FALSE;
-	    }
+          if (!type_char(init_chartype) && type_char(typ1))
+            {
+              error_init ("char-array initialized from wide string");
+              return FALSE;
+            }
+          if (type_char(init_chartype) && !type_char(typ1))
+            {
+              error_init ("int-array initialized from non-wide string");
+              return FALSE;
+            }
 
-	  tcsize = type_array_size_cval(t);
-	  if (!cval_istop(tcsize))
-	    {
-	      largest_uint tsize = cval_uint_value(tcsize);
-	      data_declaration sdecl = CAST(string, init)->ddecl;
+          tcsize = type_array_size_cval(t);
+          if (!cval_istop(tcsize))
+            {
+              largest_uint tsize = cval_uint_value(tcsize);
+              data_declaration sdecl = CAST(string, init)->ddecl;
 
-	      /* Don't count the null char (char x[1] = "a" is ok) */
-	      if (tsize && tsize < sdecl->schars.length / type_size_int(type_array_of(sdecl->type)))
-		pedwarn_init ("initializer-string for array of chars is too long");
-	    }
+              /* Don't count the null char (char x[1] = "a" is ok) */
+              if (tsize && tsize < sdecl->schars.length / type_size_int(type_array_of(sdecl->type)))
+                pedwarn_init ("initializer-string for array of chars is too long");
+            }
 
-	  return TRUE;
-	}
+          return TRUE;
+        }
     }
 
   /* Any type can be initialized
@@ -321,29 +321,29 @@ static bool digest_init(type t, expression init)
       type_compatible(t, type_default_conversion_for_assignment(itype)))
     {
       if (type_pointer(t))
-	itype = default_conversion_for_assignment(init);
+        itype = default_conversion_for_assignment(init);
 
 #if 0
       if (require_constant /*&& !flag_isoc99*/ && is_cast_list(init))
-	{
-	  /* As an extension, allow initializing objects with static storage
-	     duration with compound literals (which are then treated just as
-	     the brace enclosed list they contain).  */
-	  init = CAST(cast_list, init)->init_expr;
-	  itype = init->type;
-	}
+        {
+          /* As an extension, allow initializing objects with static storage
+             duration with compound literals (which are then treated just as
+             the brace enclosed list they contain).  */
+          init = CAST(cast_list, init)->init_expr;
+          itype = init->type;
+        }
 #endif
 
       if (type_array(t) && !(is_string(init) || is_init_list(init)))
-	{
-	  error_init ("array initialized from non-constant array expression");
-	  return FALSE;
-	}
+        {
+          error_init ("array initialized from non-constant array expression");
+          return FALSE;
+        }
 
       /* Note: gcc allows "static int a = (1,2)" if -pedantic is
-	 specified even though it doesn't allow case (1,2) when
-	 -pedantic is specified. For the sake of consistency,
-	 I'm not allowing either when -pedantic is specified. */
+         specified even though it doesn't allow case (1,2) when
+         -pedantic is specified. For the sake of consistency,
+         I'm not allowing either when -pedantic is specified. */
 
       return TRUE;
     }
@@ -362,26 +362,26 @@ static bool digest_init(type t, expression init)
       bool changed = FALSE;
 
       while (type_array(t) || type_aggregate(t))
-	{
-	  changed = TRUE;
-	  if (type_array(t))
-	    t = type_array_of(t);
-	  else
-	    {
-	      tag_declaration tdecl = type_tag(t);
+        {
+          changed = TRUE;
+          if (type_array(t))
+            t = type_array_of(t);
+          else
+            {
+              tag_declaration tdecl = type_tag(t);
 
-	      if (tdecl->fieldlist)
-		t = tdecl->fieldlist->type;
-	      else
-		{
-		  error_init ("invalid initializer");
-		  return FALSE;
-		}
-	    }
-	}
+              if (tdecl->fieldlist)
+                t = tdecl->fieldlist->type;
+              else
+                {
+                  error_init ("invalid initializer");
+                  return FALSE;
+                }
+            }
+        }
 
       if (changed)
-	return digest_init(t, init);
+        return digest_init(t, init);
     }
   error_init("invalid initializer");
   return FALSE;
@@ -528,8 +528,8 @@ static void pop_exhausted_levels(void)
   /* If we've exhausted any levels that didn't have braces,
      pop them now.  */
   while (constructor_stack->implicit &&
-	 ((constructor_kind == c_aggregate && constructor_fields == 0) ||
-	  (constructor_kind == c_array && constructor_max_index < constructor_index)))
+         ((constructor_kind == c_aggregate && constructor_fields == 0) ||
+          (constructor_kind == c_array && constructor_max_index < constructor_index)))
     pop_implicit_level();
 }
 
@@ -742,13 +742,13 @@ void push_init_level(int implicit)
     {
       /* Don't die if there are extra init elts at the end.  */
       if (constructor_fields == 0)
-	constructor_type = 0;
+        constructor_type = 0;
       else
-	{
-	  constructor_type = constructor_fields->type;
-	  push_member_name(constructor_fields);
-	  constructor_depth++;
-	}
+        {
+          constructor_type = constructor_fields->type;
+          push_member_name(constructor_fields);
+          constructor_depth++;
+        }
     }
   else if (constructor_kind == c_array)
     {
@@ -805,9 +805,9 @@ static bool new_constructor_type(void)
 
       constructor_kind = c_array;
       if (cval_istop(max))
-	constructor_max_index = -1;
+        constructor_max_index = -1;
       else
-	constructor_max_index = cval_sint_value(max) - 1;
+        constructor_max_index = cval_sint_value(max) - 1;
       constructor_index = constructor_array_size = 0;
       constructor_value = new_ivalue(parse_region, iv_array, constructor_type);
     }
@@ -843,20 +843,20 @@ static type pop_init_level(void)
       && !type_array_size(constructor_type))
     {
       /* Silently discard empty initializations.  The parser will
-	 already have pedwarned for empty brackets.  */
+         already have pedwarned for empty brackets.  */
       if (constructor_count > 0)
-	{
-	  if (constructor_depth > 2)
-	    error_init("initialization of flexible array member in a nested context");
-	  else if (pedantic)
-	    pedwarn_init("initialization of a flexible array member");
+        {
+          if (constructor_depth > 2)
+            error_init("initialization of flexible array member in a nested context");
+          else if (pedantic)
+            pedwarn_init("initialization of a flexible array member");
 
-	  /* We have already issued an error message for the existence
-	     of a flexible array member not at the end of the structure.
-	     Discard the initializer so that we do not abort later.  */
-	  if (constructor_fields->next)
-	    constructor_type = NULL;
-	}
+          /* We have already issued an error message for the existence
+             of a flexible array member not at the end of the structure.
+             Discard the initializer so that we do not abort later.  */
+          if (constructor_fields->next)
+            constructor_type = NULL;
+        }
     }
 
 #if 0
@@ -866,20 +866,20 @@ static type pop_init_level(void)
       && TREE_CODE (constructor_type) == RECORD_TYPE
       && constructor_unfilled_fields)
     {
-	/* Do not warn for flexible array members or zero-length arrays.  */
-	while (constructor_unfilled_fields
-	       && (! DECL_SIZE (constructor_unfilled_fields)
-		   || integer_zerop (DECL_SIZE (constructor_unfilled_fields))))
-	  constructor_unfilled_fields = TREE_CHAIN (constructor_unfilled_fields);
+        /* Do not warn for flexible array members or zero-length arrays.  */
+        while (constructor_unfilled_fields
+               && (! DECL_SIZE (constructor_unfilled_fields)
+                   || integer_zerop (DECL_SIZE (constructor_unfilled_fields))))
+          constructor_unfilled_fields = TREE_CHAIN (constructor_unfilled_fields);
 
-	/* Do not warn if this level of the initializer uses member
-	   designators; it is likely to be deliberate.  */
-	if (constructor_unfilled_fields && !constructor_designated)
-	  {
-	    push_member_name (constructor_unfilled_fields);
-	    warning_init ("missing initializer");
-	    RESTORE_SPELLING_DEPTH (constructor_depth);
-	  }
+        /* Do not warn if this level of the initializer uses member
+           designators; it is likely to be deliberate.  */
+        if (constructor_unfilled_fields && !constructor_designated)
+          {
+            push_member_name (constructor_unfilled_fields);
+            warning_init ("missing initializer");
+            RESTORE_SPELLING_DEPTH (constructor_depth);
+          }
     }
 #endif
 
@@ -925,10 +925,10 @@ static bool set_designator(bool array)
   if (!designator_depth)
     {
       if (constructor_range_stack)
-	abort ();
+        abort ();
 
       /* Designator list starts at the level of closest explicit
-	 braces.  */
+         braces.  */
       pop_all_implicit_levels();
       constructor_designated = 1;
       return FALSE;
@@ -996,7 +996,7 @@ static void push_range_stack(expression range_end)
 designator set_init_index(location loc, expression first, expression last)
 {
   designator d = CAST(designator,
-		      new_designate_index(parse_region, loc, first, last));
+                      new_designate_index(parse_region, loc, first, last));
 
   if (set_designator(TRUE))
     return d;
@@ -1010,7 +1010,7 @@ designator set_init_index(location loc, expression first, expression last)
   else if (constructor_kind != c_array)
     error_init("array index in non-array initializer");
   else if (constructor_max_index >= 0
-	   && constructor_max_index < constant_sint_value(first->cst))
+           && constructor_max_index < constant_sint_value(first->cst))
     error_init("array index in initializer exceeds array bounds");
   else
     {
@@ -1019,30 +1019,30 @@ designator set_init_index(location loc, expression first, expression last)
       constructor_index = fval;
 
       if (last)
-	{
-	  largest_int lval = constant_sint_value(last->cst);
+        {
+          largest_int lval = constant_sint_value(last->cst);
 
-	  if (fval == lval)
-	    last = 0;
-	  else if (lval < fval)
-	    {
-	      error_init("empty index range in initializer");
-	      last = 0;
-	    }
-	  else
-	    {
-	      if (constructor_max_index >= 0 && constructor_max_index < lval)
-		{
-		  error_init("array index range in initializer exceeds array bounds");
-		  last = 0;
-		}
-	    }
-	}
+          if (fval == lval)
+            last = 0;
+          else if (lval < fval)
+            {
+              error_init("empty index range in initializer");
+              last = 0;
+            }
+          else
+            {
+              if (constructor_max_index >= 0 && constructor_max_index < lval)
+                {
+                  error_init("array index range in initializer exceeds array bounds");
+                  last = 0;
+                }
+            }
+        }
 
       designator_depth++;
       designator_erroneous = 0;
       if (constructor_range_stack || last)
-	push_range_stack(last);
+        push_range_stack(last);
     }
 
   return d;
@@ -1053,7 +1053,7 @@ designator set_init_index(location loc, expression first, expression last)
 designator set_init_label(location loc, cstring fieldname)
 {
   designator d = CAST(designator,
-		      new_designate_field(parse_region, loc, fieldname));
+                      new_designate_field(parse_region, loc, fieldname));
   field_declaration tail;
   tag_declaration tdecl;
 
@@ -1078,7 +1078,7 @@ designator set_init_label(location loc, cstring fieldname)
       designator_depth++;
       designator_erroneous = 0;
       if (constructor_range_stack)
-	push_range_stack(NULL);
+        push_range_stack(NULL);
     }
 
   return d;
@@ -1125,10 +1125,10 @@ void check_init_element(expression init)
     {
       constant_overflow_warning(c);
       if (init->ivalue)
-	{
-	  assert(init->ivalue->kind == iv_base);
-	  init->ivalue->u.base.value = cval_cast(c->cval, init->ivalue->type);
-	}
+        {
+          assert(init->ivalue->kind == iv_base);
+          init->ivalue->u.base.value = cval_cast(c->cval, init->ivalue->type);
+        }
     }
 }
 
@@ -1152,9 +1152,9 @@ static void output_init_element(expression init, type t)
     {
       check_init_element(init);
       /* If we haven't checked it yet then we'll need the spelling later
-	 (see nesc-constants.c) */
+         (see nesc-constants.c) */
       if (!init->cst_checked)
-	save_expression_spelling(init);
+        save_expression_spelling(init);
     }
 }
 
@@ -1188,10 +1188,10 @@ void process_init_element(expression value)
       constructor_kind = c_scalar;
       constructor_index = 0;
       if (!type_array_size(constructor_type))
-	constructor_type = constructor_value->type =
-	  set_string_length(constructor_type, value);
+        constructor_type = constructor_value->type =
+          set_string_length(constructor_type, value);
       /* XXX: maybe this should stay as a iv_array, and the string should
-	 be broken down into characters? */
+         be broken down into characters? */
       constructor_value->kind = iv_base;
       constructor_value->u.base.expr = NULL;
       constructor_value->u.base.value = cval_top;
@@ -1212,92 +1212,92 @@ void process_init_element(expression value)
       type elttype = error_type;
 
       switch (constructor_kind)
-	{
-	case c_aggregate:
-	  if (constructor_fields == 0)
-	    {
-	      pedwarn_init("excess elements in struct or union initializer");
-	      break;
-	    }
-	  elttype = constructor_fields->type;
+        {
+        case c_aggregate:
+          if (constructor_fields == 0)
+            {
+              pedwarn_init("excess elements in struct or union initializer");
+              break;
+            }
+          elttype = constructor_fields->type;
 
-	  /* Error for non-static initialization of a flexible array member.  */
-	  if (type_array(elttype)
-	      && !require_constant_value
-	      && (type_array_size(elttype) && definite_zero(type_array_size(elttype)))
-	      && !constructor_fields->next)
-	    {
-	      error_init("non-static initialization of a flexible array member");
-	      break;
-	    }
-	  push_member_name (constructor_fields);
+          /* Error for non-static initialization of a flexible array member.  */
+          if (type_array(elttype)
+              && !require_constant_value
+              && (type_array_size(elttype) && definite_zero(type_array_size(elttype)))
+              && !constructor_fields->next)
+            {
+              error_init("non-static initialization of a flexible array member");
+              break;
+            }
+          push_member_name (constructor_fields);
 
-	  break;
-	case c_array:
-	  if (constructor_max_index >= 0
-	      && constructor_max_index < constructor_index)
-	    {
-	      pedwarn_init("excess elements in array initializer");
-	      break;
-	    }
+          break;
+        case c_array:
+          if (constructor_max_index >= 0
+              && constructor_max_index < constructor_index)
+            {
+              pedwarn_init("excess elements in array initializer");
+              break;
+            }
 
-	  elttype = type_array_of(constructor_type);
-	  push_array_bounds(constructor_index);
-	  if (type_array(elttype) && !type_array_size(elttype))
-	    {
-	      elttype = error_type;
-	      error_init("array type has incomplete element type");
-	    }
-	  break;
-	case c_scalar:
-	  if (constructor_count == 0)
-	    elttype = constructor_type;
-	  else if (constructor_count == 1) /* Only warn once */
-	    pedwarn_init("excess elements in scalar initializer");
-	  break;
-	default: assert(0); break;
-	}
+          elttype = type_array_of(constructor_type);
+          push_array_bounds(constructor_index);
+          if (type_array(elttype) && !type_array_size(elttype))
+            {
+              elttype = error_type;
+              error_init("array type has incomplete element type");
+            }
+          break;
+        case c_scalar:
+          if (constructor_count == 0)
+            elttype = constructor_type;
+          else if (constructor_count == 1) /* Only warn once */
+            pedwarn_init("excess elements in scalar initializer");
+          break;
+        default: assert(0); break;
+        }
 
       /* Accept a string constant to initialize a subarray.  */
       if (type_array(elttype) && type_integer(type_array_of(elttype))
-	  && string_flag)
-	;
+          && string_flag)
+        ;
       /* Otherwise, if we have come to a subaggregate,
-	 and we don't have an element of its type, push into it.  */
+         and we don't have an element of its type, push into it.  */
       else if ((constructor_kind == c_array || constructor_kind == c_aggregate) &&
-	       value->type != error_type
-	       && !type_equal_unqualified(value->type, elttype)
-	       && (type_aggregate(elttype) || type_array(elttype)))
-	{
-	  push_init_level(1);
-	  goto tryagain;
-	}
+               value->type != error_type
+               && !type_equal_unqualified(value->type, elttype)
+               && (type_aggregate(elttype) || type_array(elttype)))
+        {
+          push_init_level(1);
+          goto tryagain;
+        }
 
       /* This is here rather than in the previous switch because of
-	 the tryagain ("walk-into-array-or-aggregate") case */
+         the tryagain ("walk-into-array-or-aggregate") case */
       if (elttype != error_type)
-	{
-	  ivalue valueholder = NULL;
+        {
+          ivalue valueholder = NULL;
 
-	  switch (constructor_kind)
-	    {
-	    case c_aggregate:
-	      valueholder = new_ivalue(parse_region, iv_base, elttype);
-	      add_ivalue_field(constructor_value, constructor_fields, valueholder);
-	      break;
-	    case c_array:
-	      valueholder = new_ivalue(parse_region, iv_base, elttype);
-	      add_ivalue_array(constructor_value, constructor_index, valueholder);
-	      break;
-	    case c_scalar:
-	      valueholder = constructor_value;
-	      break;
-	    default: assert(0); break;
-	    }
-	  value->ivalue = valueholder;
-	}
+          switch (constructor_kind)
+            {
+            case c_aggregate:
+              valueholder = new_ivalue(parse_region, iv_base, elttype);
+              add_ivalue_field(constructor_value, constructor_fields, valueholder);
+              break;
+            case c_array:
+              valueholder = new_ivalue(parse_region, iv_base, elttype);
+              add_ivalue_array(constructor_value, constructor_index, valueholder);
+              break;
+            case c_scalar:
+              valueholder = constructor_value;
+              break;
+            default: assert(0); break;
+            }
+          value->ivalue = valueholder;
+        }
       else
-	value->ivalue = new_ivalue(parse_region, iv_base, error_type);
+        value->ivalue = new_ivalue(parse_region, iv_base, error_type);
 
       output_init_element (value, elttype);
     }
@@ -1308,39 +1308,39 @@ void process_init_element(expression value)
     {
     case c_aggregate:
       if (value)
-	RESTORE_SPELLING_DEPTH (constructor_depth);
+        RESTORE_SPELLING_DEPTH (constructor_depth);
 
       if (!type_union(constructor_type))
-	{
-	  if (constructor_fields)
-	    constructor_fields = skip_unnamed_bitfields(constructor_fields->next);
-	}
+        {
+          if (constructor_fields)
+            constructor_fields = skip_unnamed_bitfields(constructor_fields->next);
+        }
       else
-	{
-	  /* Warn that traditional C rejects initialization of unions.
-	     We skip the warning if the value is zero.  This is done
-	     under the assumption that the zero initializer in user
-	     code appears conditioned on e.g. __STDC__ to avoid
-	     "missing initializer" warnings and relies on default
-	     initialization to zero in the traditional C case.
-	     We also skip the warning if the initializer is designated,
-	     again on the assumption that this must be conditional on
-	     __STDC__ anyway (and we've already complained about the
-	     member-designator already).  */
-	  if (value && warn_traditional &&
-	      !value->location->in_system_header &&
-	      !constructor_designated && !definite_zero(value))
-	    warning("traditional C rejects initialization of unions");
+        {
+          /* Warn that traditional C rejects initialization of unions.
+             We skip the warning if the value is zero.  This is done
+             under the assumption that the zero initializer in user
+             code appears conditioned on e.g. __STDC__ to avoid
+             "missing initializer" warnings and relies on default
+             initialization to zero in the traditional C case.
+             We also skip the warning if the initializer is designated,
+             again on the assumption that this must be conditional on
+             __STDC__ anyway (and we've already complained about the
+             member-designator already).  */
+          if (value && warn_traditional &&
+              !value->location->in_system_header &&
+              !constructor_designated && !definite_zero(value))
+            warning("traditional C rejects initialization of unions");
 
-	  constructor_fields = 0;
-	}
+          constructor_fields = 0;
+        }
       break;
     case c_array:
       if (value)
-	RESTORE_SPELLING_DEPTH (constructor_depth);
+        RESTORE_SPELLING_DEPTH (constructor_depth);
       constructor_index++;
       if (constructor_index > constructor_array_size)
-	constructor_array_size = constructor_index;
+        constructor_array_size = constructor_index;
       break;
     case c_scalar: /* the weird {"foo"} case above */
       break;
@@ -1357,12 +1357,12 @@ void process_init_element(expression value)
 
       /* First pop back to the level at which the designator ended */
       while (constructor_stack != range_stack->stack)
-	pop_implicit_level();
+        pop_implicit_level();
 
       /* Then pop back up all the designators (note that the topmost one
-	 does not have an implicit level) */
+         does not have an implicit level) */
       for (p = range_stack; p->prev; p = p->prev)
-	pop_implicit_level();
+        pop_implicit_level();
     }
 
   // XXX: mem dealloc for range stack

--- a/src/init.h
+++ b/src/init.h
@@ -34,10 +34,10 @@ struct ivalue {
   ivalue instantiation;
 
   union {
-    struct {			/* for iv_base */
-      expression expr;		/* not an init_list */
+    struct {                        /* for iv_base */
+      expression expr;                /* not an init_list */
       bool require_constant_value;
-      cval value; 		/* value if constant, cval_top otherwise */
+      cval value;                 /* value if constant, cval_top otherwise */
     } base;
     struct ivalue_array *array; /* for iv_array */
     struct ivalue_field *structured; /* for iv_structured */

--- a/src/libcompat/alloc.c
+++ b/src/libcompat/alloc.c
@@ -37,8 +37,8 @@
 
 static
 void alloc_block(region r, struct allocator *a, struct ablock *blk,
-		 void **p1, int s1, int a1, void **p2, int s2, int a2,
-		 size_t blksize, int needsclear)
+                 void **p1, int s1, int a1, void **p2, int s2, int a2,
+                 size_t blksize, int needsclear)
 {
   struct page *newp;
   char *mem1, *mem2;
@@ -51,23 +51,23 @@ void alloc_block(region r, struct allocator *a, struct ablock *blk,
   if (mem2 + s2 >= blk->end)
     {
       if (blksize == RPAGESIZE)
-	{
-	  newp = alloc_single_page(a->pages);
-	  a->pages = newp;
-	  blk->allocfrom = (char *)newp + offsetof(struct page, previous);
-	  set_region(newp, 1, r);
-	}
+        {
+          newp = alloc_single_page(a->pages);
+          a->pages = newp;
+          blk->allocfrom = (char *)newp + offsetof(struct page, previous);
+          set_region(newp, 1, r);
+        }
       else
-	{
-	  newp = alloc_pages(blksize >> RPAGELOG, a->bigpages);
-	  a->bigpages = newp;
-	  blk->allocfrom = (char *)newp + offsetof(struct page, previous);
-	  set_region(newp, blksize >> RPAGELOG, r);
-	}
+        {
+          newp = alloc_pages(blksize >> RPAGELOG, a->bigpages);
+          a->bigpages = newp;
+          blk->allocfrom = (char *)newp + offsetof(struct page, previous);
+          set_region(newp, blksize >> RPAGELOG, r);
+        }
       blk->end = (char *)newp + blksize;
 
       if (needsclear)
-	preclear(blk->allocfrom, blksize - (blk->allocfrom - (char *)newp));
+        preclear(blk->allocfrom, blksize - (blk->allocfrom - (char *)newp));
       mem1 = PALIGN(blk->allocfrom, a1);
       mem2 = PALIGN(mem1 + s1, a2);
     }
@@ -81,7 +81,7 @@ void alloc_block(region r, struct allocator *a, struct ablock *blk,
 
 static inline 
 void qalloc(region r, struct allocator *a, void **p1, int s1, int a1,
-	    void **p2, int s2, int a2, int needsclear)
+            void **p2, int s2, int a2, int needsclear)
 {
   struct page *p;
   char *mem;
@@ -99,26 +99,26 @@ void qalloc(region r, struct allocator *a, void **p1, int s1, int a1,
        valid) */
     if (mem2 + s2 < a->page.end)
       {
-	ASSERT_INUSE(blk->end - blksize, r);
-	a->page.allocfrom = mem2 + s2;
+        ASSERT_INUSE(blk->end - blksize, r);
+        a->page.allocfrom = mem2 + s2;
 
-	*p1 = mem1;
-	*p2 = mem2;
-	return;
+        *p1 = mem1;
+        *p2 = mem2;
+        return;
       }
   }
 
   if (n <= RPAGESIZE / K)
     {
       alloc_block(r, a, &a->page, p1, s1, a1, p2, s2, a2, RPAGESIZE,
-		  needsclear);
+                  needsclear);
       return;
     }
 #if K >= 2
   if (n <= RPAGESIZE)
     {
       alloc_block(r, a, &a->superpage, p1, s1, a1, p2, s2, a2,
-		  K * RPAGESIZE, needsclear);
+                  K * RPAGESIZE, needsclear);
       return;
     }
 #endif
@@ -126,7 +126,7 @@ void qalloc(region r, struct allocator *a, void **p1, int s1, int a1,
   if (n <= RPAGESIZE * K)
     {
       alloc_block(r, a, &a->hyperpage, p1, s1, a1, p2, s2, a2,
-		  K * K * RPAGESIZE, needsclear);
+                  K * K * RPAGESIZE, needsclear);
       return;
     }
 #endif

--- a/src/libcompat/fnmatch.c
+++ b/src/libcompat/fnmatch.c
@@ -22,7 +22,7 @@
 
 /* Enable GNU extensions in fnmatch.h.  */
 #ifndef _GNU_SOURCE
-# define _GNU_SOURCE	1
+# define _GNU_SOURCE        1
 #endif
 
 #include <assert.h>
@@ -120,25 +120,25 @@
 #  endif
 
 #  ifdef _LIBC
-#   define ISWCTYPE(WC, WT)	__iswctype (WC, WT)
+#   define ISWCTYPE(WC, WT)        __iswctype (WC, WT)
 #  else
-#   define ISWCTYPE(WC, WT)	iswctype (WC, WT)
+#   define ISWCTYPE(WC, WT)        iswctype (WC, WT)
 #  endif
 
 #  if (HAVE_MBSTATE_T && HAVE_MBSRTOWCS) || _LIBC
 /* In this case we are implementing the multibyte character handling.  */
-#   define HANDLE_MULTIBYTE	1
+#   define HANDLE_MULTIBYTE        1
 #  endif
 
 # else
 #  define CHAR_CLASS_MAX_LENGTH  6 /* Namely, `xdigit'.  */
 
-#  define IS_CHAR_CLASS(string)						      \
-   (STREQ (string, "alpha") || STREQ (string, "upper")			      \
-    || STREQ (string, "lower") || STREQ (string, "digit")		      \
-    || STREQ (string, "alnum") || STREQ (string, "xdigit")		      \
-    || STREQ (string, "space") || STREQ (string, "print")		      \
-    || STREQ (string, "punct") || STREQ (string, "graph")		      \
+#  define IS_CHAR_CLASS(string)                                                      \
+   (STREQ (string, "alpha") || STREQ (string, "upper")                              \
+    || STREQ (string, "lower") || STREQ (string, "digit")                      \
+    || STREQ (string, "alnum") || STREQ (string, "xdigit")                      \
+    || STREQ (string, "space") || STREQ (string, "print")                      \
+    || STREQ (string, "punct") || STREQ (string, "graph")                      \
     || STREQ (string, "cntrl") || STREQ (string, "blank"))
 # endif
 
@@ -193,16 +193,16 @@ __wcschrnul (s, c)
 # else
 #  define FOLD(c) ((flags & FNM_CASEFOLD) && ISUPPER (c) ? tolower (c) : (c))
 # endif
-# define CHAR	char
-# define UCHAR	unsigned char
-# define FCT	internal_fnmatch
-# define L(CS)	CS
+# define CHAR        char
+# define UCHAR        unsigned char
+# define FCT        internal_fnmatch
+# define L(CS)        CS
 # ifdef _LIBC
-#  define BTOWC(C)	__btowc (C)
+#  define BTOWC(C)        __btowc (C)
 # else
-#  define BTOWC(C)	btowc (C)
+#  define BTOWC(C)        btowc (C)
 # endif
-# define STRCHR(S, C)	strchr (S, C)
+# define STRCHR(S, C)        strchr (S, C)
 # define STRCHRNUL(S, C) __strchrnul (S, C)
 # define STRCOLL(S1, S2) strcoll (S1, S2)
 # include "fnmatch_loop.c"
@@ -215,12 +215,12 @@ __wcschrnul (s, c)
 #  else
 #   define FOLD(c) ((flags & FNM_CASEFOLD) && ISUPPER (c) ? towlower (c) : (c))
 #  endif
-#  define CHAR	wchar_t
-#  define UCHAR	wint_t
-#  define FCT	internal_fnwmatch
-#  define L(CS)	L##CS
-#  define BTOWC(C)	(C)
-#  define STRCHR(S, C)	wcschr (S, C)
+#  define CHAR        wchar_t
+#  define UCHAR        wint_t
+#  define FCT        internal_fnwmatch
+#  define L(CS)        L##CS
+#  define BTOWC(C)        (C)
+#  define STRCHR(S, C)        wcschr (S, C)
 #  define STRCHRNUL(S, C) __wcschrnul (S, C)
 #  define STRCOLL(S1, S2) wcscoll (S1, S2)
 #  define WIDE_CHAR_VERSION 1
@@ -243,40 +243,40 @@ is_char_class (const wchar_t *wcs)
       /* Test for a printable character from the portable character set.  */
 #  ifdef _LIBC
       if (*wcs < 0x20 || *wcs > 0x7e
-	  || *wcs == 0x24 || *wcs == 0x40 || *wcs == 0x60)
-	return (wctype_t) 0;
+          || *wcs == 0x24 || *wcs == 0x40 || *wcs == 0x60)
+        return (wctype_t) 0;
 #  else
       switch (*wcs)
-	{
-	case L' ': case L'!': case L'"': case L'#': case L'%':
-	case L'&': case L'\'': case L'(': case L')': case L'*':
-	case L'+': case L',': case L'-': case L'.': case L'/':
-	case L'0': case L'1': case L'2': case L'3': case L'4':
-	case L'5': case L'6': case L'7': case L'8': case L'9':
-	case L':': case L';': case L'<': case L'=': case L'>':
-	case L'?':
-	case L'A': case L'B': case L'C': case L'D': case L'E':
-	case L'F': case L'G': case L'H': case L'I': case L'J':
-	case L'K': case L'L': case L'M': case L'N': case L'O':
-	case L'P': case L'Q': case L'R': case L'S': case L'T':
-	case L'U': case L'V': case L'W': case L'X': case L'Y':
-	case L'Z':
-	case L'[': case L'\\': case L']': case L'^': case L'_':
-	case L'a': case L'b': case L'c': case L'd': case L'e':
-	case L'f': case L'g': case L'h': case L'i': case L'j':
-	case L'k': case L'l': case L'm': case L'n': case L'o':
-	case L'p': case L'q': case L'r': case L's': case L't':
-	case L'u': case L'v': case L'w': case L'x': case L'y':
-	case L'z': case L'{': case L'|': case L'}': case L'~':
-	  break;
-	default:
-	  return (wctype_t) 0;
-	}
+        {
+        case L' ': case L'!': case L'"': case L'#': case L'%':
+        case L'&': case L'\'': case L'(': case L')': case L'*':
+        case L'+': case L',': case L'-': case L'.': case L'/':
+        case L'0': case L'1': case L'2': case L'3': case L'4':
+        case L'5': case L'6': case L'7': case L'8': case L'9':
+        case L':': case L';': case L'<': case L'=': case L'>':
+        case L'?':
+        case L'A': case L'B': case L'C': case L'D': case L'E':
+        case L'F': case L'G': case L'H': case L'I': case L'J':
+        case L'K': case L'L': case L'M': case L'N': case L'O':
+        case L'P': case L'Q': case L'R': case L'S': case L'T':
+        case L'U': case L'V': case L'W': case L'X': case L'Y':
+        case L'Z':
+        case L'[': case L'\\': case L']': case L'^': case L'_':
+        case L'a': case L'b': case L'c': case L'd': case L'e':
+        case L'f': case L'g': case L'h': case L'i': case L'j':
+        case L'k': case L'l': case L'm': case L'n': case L'o':
+        case L'p': case L'q': case L'r': case L's': case L't':
+        case L'u': case L'v': case L'w': case L'x': case L'y':
+        case L'z': case L'{': case L'|': case L'}': case L'~':
+          break;
+        default:
+          return (wctype_t) 0;
+        }
 #  endif
 
       /* Avoid overrunning the buffer.  */
       if (cp == s + CHAR_CLASS_MAX_LENGTH)
-	return (wctype_t) 0;
+        return (wctype_t) 0;
 
       *cp++ = (char) *wcs++;
     }
@@ -341,4 +341,4 @@ fnmatch (pattern, string, flags)
 # endif  /* mbstate_t and mbsrtowcs or _LIBC.  */
 }
 
-#endif	/* _LIBC or not __GNU_LIBRARY__.  */
+#endif        /* _LIBC or not __GNU_LIBRARY__.  */

--- a/src/libcompat/fnmatch/fnmatch.h
+++ b/src/libcompat/fnmatch/fnmatch.h
@@ -16,21 +16,21 @@
    write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
    Boston, MA 02111-1307, USA.  */
 
-#ifndef	_FNMATCH_H
-#define	_FNMATCH_H	1
+#ifndef        _FNMATCH_H
+#define        _FNMATCH_H        1
 
-#ifdef	__cplusplus
+#ifdef        __cplusplus
 extern "C" {
 #endif
 
 #if defined __cplusplus || (defined __STDC__ && __STDC__) || defined WINDOWS32
 # if !defined __GLIBC__ || !defined __P
-#  undef	__P
-#  define __P(protos)	protos
+#  undef        __P
+#  define __P(protos)        protos
 # endif
 #else /* Not C++ or ANSI C.  */
-# undef	__P
-# define __P(protos)	()
+# undef        __P
+# define __P(protos)        ()
 /* We can get away without defining `const' here only because in this file
    it is used only inside the prototype for `fnmatch', which is elided in
    non-ANSI C where `const' is problematical.  */
@@ -38,7 +38,7 @@ extern "C" {
 
 #ifndef const
 # if (defined __STDC__ && __STDC__) || defined __cplusplus
-#  define __const	const
+#  define __const        const
 # else
 #  define __const
 # endif
@@ -46,38 +46,38 @@ extern "C" {
 
 /* We #undef these before defining them because some losing systems
    (HP-UX A.08.07 for example) define these in <unistd.h>.  */
-#undef	FNM_PATHNAME
-#undef	FNM_NOESCAPE
-#undef	FNM_PERIOD
+#undef        FNM_PATHNAME
+#undef        FNM_NOESCAPE
+#undef        FNM_PERIOD
 
 /* Bits set in the FLAGS argument to `fnmatch'.  */
-#define	FNM_PATHNAME	(1 << 0) /* No wildcard can ever match `/'.  */
-#define	FNM_NOESCAPE	(1 << 1) /* Backslashes don't quote special chars.  */
-#define	FNM_PERIOD	(1 << 2) /* Leading `.' is matched only explicitly.  */
+#define        FNM_PATHNAME        (1 << 0) /* No wildcard can ever match `/'.  */
+#define        FNM_NOESCAPE        (1 << 1) /* Backslashes don't quote special chars.  */
+#define        FNM_PERIOD        (1 << 2) /* Leading `.' is matched only explicitly.  */
 
 #if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 2 || defined _GNU_SOURCE
-# define FNM_FILE_NAME	 FNM_PATHNAME	/* Preferred GNU name.  */
-# define FNM_LEADING_DIR (1 << 3)	/* Ignore `/...' after a match.  */
-# define FNM_CASEFOLD	 (1 << 4)	/* Compare without regard to case.  */
+# define FNM_FILE_NAME         FNM_PATHNAME        /* Preferred GNU name.  */
+# define FNM_LEADING_DIR (1 << 3)        /* Ignore `/...' after a match.  */
+# define FNM_CASEFOLD         (1 << 4)        /* Compare without regard to case.  */
 #endif
 
 /* Value returned by `fnmatch' if STRING does not match PATTERN.  */
-#define	FNM_NOMATCH	1
+#define        FNM_NOMATCH        1
 
 /* This value is returned if the implementation does not support
    `fnmatch'.  Since this is not the case here it will never be
    returned but the conformance test suites still require the symbol
    to be defined.  */
 #ifdef _XOPEN_SOURCE
-# define FNM_NOSYS	(-1)
+# define FNM_NOSYS        (-1)
 #endif
 
 /* Match NAME against the filename pattern PATTERN,
    returning zero if it matches, FNM_NOMATCH if not.  */
 extern int fnmatch __P ((__const char *__pattern, __const char *__name,
-			 int __flags));
+                         int __flags));
 
-#ifdef	__cplusplus
+#ifdef        __cplusplus
 }
 #endif
 

--- a/src/libcompat/fnmatch_loop.c
+++ b/src/libcompat/fnmatch_loop.c
@@ -19,7 +19,7 @@
 /* Match STRING against the filename pattern PATTERN, returning zero if
    it matches, nonzero if not.  */
 static int FCT (const CHAR *pattern, const CHAR *string,
-		int no_leading_period, int flags) internal_function;
+                int no_leading_period, int flags) internal_function;
 
 static int
 internal_function
@@ -46,281 +46,281 @@ FCT (pattern, string, no_leading_period, flags)
       c = FOLD (c);
 
       switch (c)
-	{
-	case L('?'):
-	  if (*n == L('\0'))
-	    return FNM_NOMATCH;
-	  else if (*n == L('/') && (flags & FNM_FILE_NAME))
-	    return FNM_NOMATCH;
-	  else if (*n == L('.') && no_leading_period
-		   && (n == string
-		       || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
-	    return FNM_NOMATCH;
-	  break;
+        {
+        case L('?'):
+          if (*n == L('\0'))
+            return FNM_NOMATCH;
+          else if (*n == L('/') && (flags & FNM_FILE_NAME))
+            return FNM_NOMATCH;
+          else if (*n == L('.') && no_leading_period
+                   && (n == string
+                       || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
+            return FNM_NOMATCH;
+          break;
 
-	case L('\\'):
-	  if (!(flags & FNM_NOESCAPE))
-	    {
-	      c = *p++;
-	      if (c == L('\0'))
-		/* Trailing \ loses.  */
-		return FNM_NOMATCH;
-	      c = FOLD (c);
-	    }
-	  if (FOLD ((UCHAR) *n) != c)
-	    return FNM_NOMATCH;
-	  break;
+        case L('\\'):
+          if (!(flags & FNM_NOESCAPE))
+            {
+              c = *p++;
+              if (c == L('\0'))
+                /* Trailing \ loses.  */
+                return FNM_NOMATCH;
+              c = FOLD (c);
+            }
+          if (FOLD ((UCHAR) *n) != c)
+            return FNM_NOMATCH;
+          break;
 
-	case L('*'):
-	  if (*n == L('.') && no_leading_period
-	      && (n == string
-		  || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
-	    return FNM_NOMATCH;
+        case L('*'):
+          if (*n == L('.') && no_leading_period
+              && (n == string
+                  || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
+            return FNM_NOMATCH;
 
-	  for (c = *p++; c == L('?') || c == L('*'); c = *p++)
-	    {
-	      if (*n == L('/') && (flags & FNM_FILE_NAME))
-		/* A slash does not match a wildcard under FNM_FILE_NAME.  */
-		return FNM_NOMATCH;
-	      else if (c == L('?'))
-		{
-		  /* A ? needs to match one character.  */
-		  if (*n == L('\0'))
-		    /* There isn't another character; no match.  */
-		    return FNM_NOMATCH;
-		  else
-		    /* One character of the string is consumed in matching
-		       this ? wildcard, so *??? won't match if there are
-		       less than three characters.  */
-		    ++n;
-		}
-	    }
+          for (c = *p++; c == L('?') || c == L('*'); c = *p++)
+            {
+              if (*n == L('/') && (flags & FNM_FILE_NAME))
+                /* A slash does not match a wildcard under FNM_FILE_NAME.  */
+                return FNM_NOMATCH;
+              else if (c == L('?'))
+                {
+                  /* A ? needs to match one character.  */
+                  if (*n == L('\0'))
+                    /* There isn't another character; no match.  */
+                    return FNM_NOMATCH;
+                  else
+                    /* One character of the string is consumed in matching
+                       this ? wildcard, so *??? won't match if there are
+                       less than three characters.  */
+                    ++n;
+                }
+            }
 
-	  if (c == L('\0'))
-	    /* The wildcard(s) is/are the last element of the pattern.
-	       If the name is a file name and contains another slash
-	       this means it cannot match, unless the FNM_LEADING_DIR
-	       flag is set.  */
-	    {
-	      int result = (flags & FNM_FILE_NAME) == 0 ? 0 : FNM_NOMATCH;
+          if (c == L('\0'))
+            /* The wildcard(s) is/are the last element of the pattern.
+               If the name is a file name and contains another slash
+               this means it cannot match, unless the FNM_LEADING_DIR
+               flag is set.  */
+            {
+              int result = (flags & FNM_FILE_NAME) == 0 ? 0 : FNM_NOMATCH;
 
-	      if (flags & FNM_FILE_NAME)
-		{
-		  if (flags & FNM_LEADING_DIR)
-		    result = 0;
-		  else
-		    {
-		      if (STRCHR (n, L('/')) == NULL)
-			result = 0;
-		    }
-		}
+              if (flags & FNM_FILE_NAME)
+                {
+                  if (flags & FNM_LEADING_DIR)
+                    result = 0;
+                  else
+                    {
+                      if (STRCHR (n, L('/')) == NULL)
+                        result = 0;
+                    }
+                }
 
-	      return result;
-	    }
-	  else
-	    {
-	      const CHAR *endp;
+              return result;
+            }
+          else
+            {
+              const CHAR *endp;
 
-	      endp = STRCHRNUL (n, (flags & FNM_FILE_NAME) ? L('/') : L('\0'));
+              endp = STRCHRNUL (n, (flags & FNM_FILE_NAME) ? L('/') : L('\0'));
 
-	      if (c == L('['))
-		{
-		  int flags2 = ((flags & FNM_FILE_NAME)
-				? flags : (flags & ~FNM_PERIOD));
+              if (c == L('['))
+                {
+                  int flags2 = ((flags & FNM_FILE_NAME)
+                                ? flags : (flags & ~FNM_PERIOD));
 
-		  for (--p; n < endp; ++n)
-		    if (FCT (p, n, (no_leading_period
-				    && (n == string
-					|| (n[-1] == L('/')
-					    && (flags & FNM_FILE_NAME)))),
-			     flags2) == 0)
-		      return 0;
-		}
-	      else if (c == L('/') && (flags & FNM_FILE_NAME))
-		{
-		  while (*n != L('\0') && *n != L('/'))
-		    ++n;
-		  if (*n == L('/')
-		      && (FCT (p, n + 1, flags & FNM_PERIOD, flags) == 0))
-		    return 0;
-		}
-	      else
-		{
-		  int flags2 = ((flags & FNM_FILE_NAME)
-				? flags : (flags & ~FNM_PERIOD));
+                  for (--p; n < endp; ++n)
+                    if (FCT (p, n, (no_leading_period
+                                    && (n == string
+                                        || (n[-1] == L('/')
+                                            && (flags & FNM_FILE_NAME)))),
+                             flags2) == 0)
+                      return 0;
+                }
+              else if (c == L('/') && (flags & FNM_FILE_NAME))
+                {
+                  while (*n != L('\0') && *n != L('/'))
+                    ++n;
+                  if (*n == L('/')
+                      && (FCT (p, n + 1, flags & FNM_PERIOD, flags) == 0))
+                    return 0;
+                }
+              else
+                {
+                  int flags2 = ((flags & FNM_FILE_NAME)
+                                ? flags : (flags & ~FNM_PERIOD));
 
-		  if (c == L('\\') && !(flags & FNM_NOESCAPE))
-		    c = *p;
-		  c = FOLD (c);
-		  for (--p; n < endp; ++n)
-		    if (FOLD ((UCHAR) *n) == c
-			&& (FCT (p, n, (no_leading_period
-					&& (n == string
-					    || (n[-1] == L('/')
-						&& (flags & FNM_FILE_NAME)))),
-				 flags2) == 0))
-		      return 0;
-		}
-	    }
+                  if (c == L('\\') && !(flags & FNM_NOESCAPE))
+                    c = *p;
+                  c = FOLD (c);
+                  for (--p; n < endp; ++n)
+                    if (FOLD ((UCHAR) *n) == c
+                        && (FCT (p, n, (no_leading_period
+                                        && (n == string
+                                            || (n[-1] == L('/')
+                                                && (flags & FNM_FILE_NAME)))),
+                                 flags2) == 0))
+                      return 0;
+                }
+            }
 
-	  /* If we come here no match is possible with the wildcard.  */
-	  return FNM_NOMATCH;
+          /* If we come here no match is possible with the wildcard.  */
+          return FNM_NOMATCH;
 
-	case L('['):
-	  {
-	    static int posixly_correct;
-	    /* Nonzero if the sense of the character class is inverted.  */
-	    register int not;
-	    CHAR cold;
+        case L('['):
+          {
+            static int posixly_correct;
+            /* Nonzero if the sense of the character class is inverted.  */
+            register int not;
+            CHAR cold;
 
-	    if (posixly_correct == 0)
-	      posixly_correct = getenv ("POSIXLY_CORRECT") != NULL ? 1 : -1;
+            if (posixly_correct == 0)
+              posixly_correct = getenv ("POSIXLY_CORRECT") != NULL ? 1 : -1;
 
-	    if (*n == L('\0'))
-	      return FNM_NOMATCH;
+            if (*n == L('\0'))
+              return FNM_NOMATCH;
 
-	    if (*n == L('.') && no_leading_period
-		&& (n == string
-		    || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
-	      return FNM_NOMATCH;
+            if (*n == L('.') && no_leading_period
+                && (n == string
+                    || (n[-1] == L('/') && (flags & FNM_FILE_NAME))))
+              return FNM_NOMATCH;
 
-	    if (*n == L('/') && (flags & FNM_FILE_NAME))
-	      /* `/' cannot be matched.  */
-	      return FNM_NOMATCH;
+            if (*n == L('/') && (flags & FNM_FILE_NAME))
+              /* `/' cannot be matched.  */
+              return FNM_NOMATCH;
 
-	    not = (*p == L('!') || (posixly_correct < 0 && *p == L('^')));
-	    if (not)
-	      ++p;
+            not = (*p == L('!') || (posixly_correct < 0 && *p == L('^')));
+            if (not)
+              ++p;
 
-	    c = *p++;
-	    for (;;)
-	      {
-		UCHAR fn = FOLD ((UCHAR) *n);
+            c = *p++;
+            for (;;)
+              {
+                UCHAR fn = FOLD ((UCHAR) *n);
 
-		if (!(flags & FNM_NOESCAPE) && c == L('\\'))
-		  {
-		    if (*p == L('\0'))
-		      return FNM_NOMATCH;
-		    c = FOLD ((UCHAR) *p);
-		    ++p;
+                if (!(flags & FNM_NOESCAPE) && c == L('\\'))
+                  {
+                    if (*p == L('\0'))
+                      return FNM_NOMATCH;
+                    c = FOLD ((UCHAR) *p);
+                    ++p;
 
-		    if (c == fn)
-		      goto matched;
-		  }
-		else if (c == L('[') && *p == L(':'))
-		  {
-		    /* Leave room for the null.  */
-		    CHAR str[CHAR_CLASS_MAX_LENGTH + 1];
-		    size_t c1 = 0;
+                    if (c == fn)
+                      goto matched;
+                  }
+                else if (c == L('[') && *p == L(':'))
+                  {
+                    /* Leave room for the null.  */
+                    CHAR str[CHAR_CLASS_MAX_LENGTH + 1];
+                    size_t c1 = 0;
 #if defined _LIBC || (defined HAVE_WCTYPE_H && defined HAVE_WCHAR_H)
-		    wctype_t wt;
+                    wctype_t wt;
 #endif
-		    const CHAR *startp = p;
+                    const CHAR *startp = p;
 
-		    for (;;)
-		      {
-			if (c1 == CHAR_CLASS_MAX_LENGTH)
-			  /* The name is too long and therefore the pattern
-			     is ill-formed.  */
-			  return FNM_NOMATCH;
+                    for (;;)
+                      {
+                        if (c1 == CHAR_CLASS_MAX_LENGTH)
+                          /* The name is too long and therefore the pattern
+                             is ill-formed.  */
+                          return FNM_NOMATCH;
 
-			c = *++p;
-			if (c == L(':') && p[1] == L(']'))
-			  {
-			    p += 2;
-			    break;
-			  }
-			if (c < L('a') || c >= L('z'))
-			  {
-			    /* This cannot possibly be a character class name.
-			       Match it as a normal range.  */
-			    p = startp;
-			    c = L('[');
-			    goto normal_bracket;
-			  }
-			str[c1++] = c;
-		      }
-		    str[c1] = L('\0');
+                        c = *++p;
+                        if (c == L(':') && p[1] == L(']'))
+                          {
+                            p += 2;
+                            break;
+                          }
+                        if (c < L('a') || c >= L('z'))
+                          {
+                            /* This cannot possibly be a character class name.
+                               Match it as a normal range.  */
+                            p = startp;
+                            c = L('[');
+                            goto normal_bracket;
+                          }
+                        str[c1++] = c;
+                      }
+                    str[c1] = L('\0');
 
 #if defined _LIBC || (defined HAVE_WCTYPE_H && defined HAVE_WCHAR_H)
-		    wt = IS_CHAR_CLASS (str);
-		    if (wt == 0)
-		      /* Invalid character class name.  */
-		      return FNM_NOMATCH;
+                    wt = IS_CHAR_CLASS (str);
+                    if (wt == 0)
+                      /* Invalid character class name.  */
+                      return FNM_NOMATCH;
 
 # if defined _LIBC && ! WIDE_CHAR_VERSION
-		    /* The following code is glibc specific but does
-		       there a good job in speeding up the code since
-		       we can avoid the btowc() call.  */
-		    if (_ISCTYPE ((UCHAR) *n, wt))
-		      goto matched;
+                    /* The following code is glibc specific but does
+                       there a good job in speeding up the code since
+                       we can avoid the btowc() call.  */
+                    if (_ISCTYPE ((UCHAR) *n, wt))
+                      goto matched;
 # else
-		    if (ISWCTYPE (BTOWC ((UCHAR) *n), wt))
-		      goto matched;
+                    if (ISWCTYPE (BTOWC ((UCHAR) *n), wt))
+                      goto matched;
 # endif
 #else
-		    if ((STREQ (str, L("alnum")) && ISALNUM ((UCHAR) *n))
-			|| (STREQ (str, L("alpha")) && ISALPHA ((UCHAR) *n))
-			|| (STREQ (str, L("blank")) && ISBLANK ((UCHAR) *n))
-			|| (STREQ (str, L("cntrl")) && ISCNTRL ((UCHAR) *n))
-			|| (STREQ (str, L("digit")) && ISDIGIT ((UCHAR) *n))
-			|| (STREQ (str, L("graph")) && ISGRAPH ((UCHAR) *n))
-			|| (STREQ (str, L("lower")) && ISLOWER ((UCHAR) *n))
-			|| (STREQ (str, L("print")) && ISPRINT ((UCHAR) *n))
-			|| (STREQ (str, L("punct")) && ISPUNCT ((UCHAR) *n))
-			|| (STREQ (str, L("space")) && ISSPACE ((UCHAR) *n))
-			|| (STREQ (str, L("upper")) && ISUPPER ((UCHAR) *n))
-			|| (STREQ (str, L("xdigit")) && ISXDIGIT ((UCHAR) *n)))
-		      goto matched;
+                    if ((STREQ (str, L("alnum")) && ISALNUM ((UCHAR) *n))
+                        || (STREQ (str, L("alpha")) && ISALPHA ((UCHAR) *n))
+                        || (STREQ (str, L("blank")) && ISBLANK ((UCHAR) *n))
+                        || (STREQ (str, L("cntrl")) && ISCNTRL ((UCHAR) *n))
+                        || (STREQ (str, L("digit")) && ISDIGIT ((UCHAR) *n))
+                        || (STREQ (str, L("graph")) && ISGRAPH ((UCHAR) *n))
+                        || (STREQ (str, L("lower")) && ISLOWER ((UCHAR) *n))
+                        || (STREQ (str, L("print")) && ISPRINT ((UCHAR) *n))
+                        || (STREQ (str, L("punct")) && ISPUNCT ((UCHAR) *n))
+                        || (STREQ (str, L("space")) && ISSPACE ((UCHAR) *n))
+                        || (STREQ (str, L("upper")) && ISUPPER ((UCHAR) *n))
+                        || (STREQ (str, L("xdigit")) && ISXDIGIT ((UCHAR) *n)))
+                      goto matched;
 #endif
-		    c = *p++;
-		  }
+                    c = *p++;
+                  }
 #ifdef _LIBC
-		else if (c == L('[') && *p == L('='))
-		  {
-		    UCHAR str[1];
-		    uint32_t nrules =
-		      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
-		    const CHAR *startp = p;
+                else if (c == L('[') && *p == L('='))
+                  {
+                    UCHAR str[1];
+                    uint32_t nrules =
+                      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
+                    const CHAR *startp = p;
 
-		    c = *++p;
-		    if (c == L('\0'))
-		      {
-			p = startp;
-			c = L('[');
-			goto normal_bracket;
-		      }
-		    str[0] = c;
+                    c = *++p;
+                    if (c == L('\0'))
+                      {
+                        p = startp;
+                        c = L('[');
+                        goto normal_bracket;
+                      }
+                    str[0] = c;
 
-		    c = *++p;
-		    if (c != L('=') || p[1] != L(']'))
-		      {
-			p = startp;
-			c = L('[');
-			goto normal_bracket;
-		      }
-		    p += 2;
+                    c = *++p;
+                    if (c != L('=') || p[1] != L(']'))
+                      {
+                        p = startp;
+                        c = L('[');
+                        goto normal_bracket;
+                      }
+                    p += 2;
 
-		    if (nrules == 0)
-		      {
-			if ((UCHAR) *n == str[0])
-			  goto matched;
-		      }
-		    else
-		      {
-			const int32_t *table;
+                    if (nrules == 0)
+                      {
+                        if ((UCHAR) *n == str[0])
+                          goto matched;
+                      }
+                    else
+                      {
+                        const int32_t *table;
 # if WIDE_CHAR_VERSION
-			const int32_t *weights;
-			const int32_t *extra;
+                        const int32_t *weights;
+                        const int32_t *extra;
 # else
-			const unsigned char *weights;
-			const unsigned char *extra;
+                        const unsigned char *weights;
+                        const unsigned char *extra;
 # endif
-			const int32_t *indirect;
-			int32_t idx;
-			const UCHAR *cp = (const UCHAR *) str;
+                        const int32_t *indirect;
+                        int32_t idx;
+                        const UCHAR *cp = (const UCHAR *) str;
 
-			/* This #include defines a local function!  */
+                        /* This #include defines a local function!  */
 # if WIDE_CHAR_VERSION
 #  include <locale/weightwc.h>
 # else
@@ -328,567 +328,567 @@ FCT (pattern, string, no_leading_period, flags)
 # endif
 
 # if WIDE_CHAR_VERSION
-			table = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEWC);
-			weights = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTWC);
-			extra = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAWC);
-			indirect = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTWC);
+                        table = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEWC);
+                        weights = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTWC);
+                        extra = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAWC);
+                        indirect = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTWC);
 # else
-			table = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEMB);
-			weights = (const unsigned char *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTMB);
-			extra = (const unsigned char *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAMB);
-			indirect = (const int32_t *)
-			  _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTMB);
+                        table = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEMB);
+                        weights = (const unsigned char *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTMB);
+                        extra = (const unsigned char *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAMB);
+                        indirect = (const int32_t *)
+                          _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTMB);
 # endif
 
-			idx = findidx (&cp);
-			if (idx != 0)
-			  {
-			    /* We found a table entry.  Now see whether the
-			       character we are currently at has the same
-			       equivalance class value.  */
+                        idx = findidx (&cp);
+                        if (idx != 0)
+                          {
+                            /* We found a table entry.  Now see whether the
+                               character we are currently at has the same
+                               equivalance class value.  */
 # if !WIDE_CHAR_VERSION
-			    int len = weights[idx];
+                            int len = weights[idx];
 # endif
-			    int32_t idx2;
-			    const UCHAR *np = (const UCHAR *) n;
+                            int32_t idx2;
+                            const UCHAR *np = (const UCHAR *) n;
 
-			    idx2 = findidx (&np);
+                            idx2 = findidx (&np);
 # if WIDE_CHAR_VERSION
-			    if (idx2 != 0 && weights[idx] == weights[idx2])
-			      goto matched;
+                            if (idx2 != 0 && weights[idx] == weights[idx2])
+                              goto matched;
 # else
-			    if (idx2 != 0 && len == weights[idx2])
-			      {
-				int cnt = 0;
+                            if (idx2 != 0 && len == weights[idx2])
+                              {
+                                int cnt = 0;
 
-				while (cnt < len
-				       && (weights[idx + 1 + cnt]
-					   == weights[idx2 + 1 + cnt]))
-				  ++cnt;
+                                while (cnt < len
+                                       && (weights[idx + 1 + cnt]
+                                           == weights[idx2 + 1 + cnt]))
+                                  ++cnt;
 
-				if (cnt == len)
-				  goto matched;
-			      }
+                                if (cnt == len)
+                                  goto matched;
+                              }
 # endif
-			  }
-		      }
+                          }
+                      }
 
-		    c = *p++;
-		  }
+                    c = *p++;
+                  }
 #endif
-		else if (c == L('\0'))
-		  /* [ (unterminated) loses.  */
-		  return FNM_NOMATCH;
-		else
-		  {
-		    int is_range = 0;
+                else if (c == L('\0'))
+                  /* [ (unterminated) loses.  */
+                  return FNM_NOMATCH;
+                else
+                  {
+                    int is_range = 0;
 
 #ifdef _LIBC
-		    int is_seqval = 0;
+                    int is_seqval = 0;
 
-		    if (c == L('[') && *p == L('.'))
-		      {
-			uint32_t nrules =
-			  _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
-			const CHAR *startp = p;
-			size_t c1 = 0;
+                    if (c == L('[') && *p == L('.'))
+                      {
+                        uint32_t nrules =
+                          _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
+                        const CHAR *startp = p;
+                        size_t c1 = 0;
 
-			while (1)
-			  {
-			    c = *++p;
-			    if (c == L('.') && p[1] == L(']'))
-			      {
-				p += 2;
-				break;
-			      }
-			    if (c == '\0')
-			      return FNM_NOMATCH;
-			    ++c1;
-			  }
+                        while (1)
+                          {
+                            c = *++p;
+                            if (c == L('.') && p[1] == L(']'))
+                              {
+                                p += 2;
+                                break;
+                              }
+                            if (c == '\0')
+                              return FNM_NOMATCH;
+                            ++c1;
+                          }
 
-			/* We have to handling the symbols differently in
-			   ranges since then the collation sequence is
-			   important.  */
-			is_range = *p == L('-') && p[1] != L('\0');
+                        /* We have to handling the symbols differently in
+                           ranges since then the collation sequence is
+                           important.  */
+                        is_range = *p == L('-') && p[1] != L('\0');
 
-			if (nrules == 0)
-			  {
-			    /* There are no names defined in the collation
-			       data.  Therefore we only accept the trivial
-			       names consisting of the character itself.  */
-			    if (c1 != 1)
-			      return FNM_NOMATCH;
+                        if (nrules == 0)
+                          {
+                            /* There are no names defined in the collation
+                               data.  Therefore we only accept the trivial
+                               names consisting of the character itself.  */
+                            if (c1 != 1)
+                              return FNM_NOMATCH;
 
-			    if (!is_range && *n == startp[1])
-			      goto matched;
+                            if (!is_range && *n == startp[1])
+                              goto matched;
 
-			    cold = startp[1];
-			    c = *p++;
-			  }
-			else
-			  {
-			    int32_t table_size;
-			    const int32_t *symb_table;
+                            cold = startp[1];
+                            c = *p++;
+                          }
+                        else
+                          {
+                            int32_t table_size;
+                            const int32_t *symb_table;
 # ifdef WIDE_CHAR_VERSION
-			    char str[c1];
-			    int strcnt;
+                            char str[c1];
+                            int strcnt;
 # else
 #  define str (startp + 1)
 # endif
-			    const unsigned char *extra;
-			    int32_t idx;
-			    int32_t elem;
-			    int32_t second;
-			    int32_t hash;
+                            const unsigned char *extra;
+                            int32_t idx;
+                            int32_t elem;
+                            int32_t second;
+                            int32_t hash;
 
 # ifdef WIDE_CHAR_VERSION
-			    /* We have to convert the name to a single-byte
-			       string.  This is possible since the names
-			       consist of ASCII characters and the internal
-			       representation is UCS4.  */
-			    for (strcnt = 0; strcnt < c1; ++strcnt)
-			      str[strcnt] = startp[1 + strcnt];
+                            /* We have to convert the name to a single-byte
+                               string.  This is possible since the names
+                               consist of ASCII characters and the internal
+                               representation is UCS4.  */
+                            for (strcnt = 0; strcnt < c1; ++strcnt)
+                              str[strcnt] = startp[1 + strcnt];
 #endif
 
-			    table_size =
-			      _NL_CURRENT_WORD (LC_COLLATE,
-						_NL_COLLATE_SYMB_HASH_SIZEMB);
-			    symb_table = (const int32_t *)
-			      _NL_CURRENT (LC_COLLATE,
-					   _NL_COLLATE_SYMB_TABLEMB);
-			    extra = (const unsigned char *)
-			      _NL_CURRENT (LC_COLLATE,
-					   _NL_COLLATE_SYMB_EXTRAMB);
+                            table_size =
+                              _NL_CURRENT_WORD (LC_COLLATE,
+                                                _NL_COLLATE_SYMB_HASH_SIZEMB);
+                            symb_table = (const int32_t *)
+                              _NL_CURRENT (LC_COLLATE,
+                                           _NL_COLLATE_SYMB_TABLEMB);
+                            extra = (const unsigned char *)
+                              _NL_CURRENT (LC_COLLATE,
+                                           _NL_COLLATE_SYMB_EXTRAMB);
 
-			    /* Locate the character in the hashing table.  */
-			    hash = elem_hash (str, c1);
+                            /* Locate the character in the hashing table.  */
+                            hash = elem_hash (str, c1);
 
-			    idx = 0;
-			    elem = hash % table_size;
-			    second = hash % (table_size - 2);
-			    while (symb_table[2 * elem] != 0)
-			      {
-				/* First compare the hashing value.  */
-				if (symb_table[2 * elem] == hash
-				    && c1 == extra[symb_table[2 * elem + 1]]
-				    && memcmp (str,
-					       &extra[symb_table[2 * elem + 1]
-						     + 1], c1) == 0)
-				  {
-				    /* Yep, this is the entry.  */
-				    idx = symb_table[2 * elem + 1];
-				    idx += 1 + extra[idx];
-				    break;
-				  }
+                            idx = 0;
+                            elem = hash % table_size;
+                            second = hash % (table_size - 2);
+                            while (symb_table[2 * elem] != 0)
+                              {
+                                /* First compare the hashing value.  */
+                                if (symb_table[2 * elem] == hash
+                                    && c1 == extra[symb_table[2 * elem + 1]]
+                                    && memcmp (str,
+                                               &extra[symb_table[2 * elem + 1]
+                                                     + 1], c1) == 0)
+                                  {
+                                    /* Yep, this is the entry.  */
+                                    idx = symb_table[2 * elem + 1];
+                                    idx += 1 + extra[idx];
+                                    break;
+                                  }
 
-				/* Next entry.  */
-				elem += second;
-			      }
+                                /* Next entry.  */
+                                elem += second;
+                              }
 
-			    if (symb_table[2 * elem] != 0)
-			      {
-				/* Compare the byte sequence but only if
-				   this is not part of a range.  */
+                            if (symb_table[2 * elem] != 0)
+                              {
+                                /* Compare the byte sequence but only if
+                                   this is not part of a range.  */
 # ifdef WIDE_CHAR_VERSION
-				int32_t *wextra;
+                                int32_t *wextra;
 
-				idx += 1 + extra[idx];
-				/* Adjust for the alignment.  */
-				idx = (idx + 3) & ~4;
+                                idx += 1 + extra[idx];
+                                /* Adjust for the alignment.  */
+                                idx = (idx + 3) & ~4;
 
-				wextra = (int32_t *) &extra[idx + 4];
+                                wextra = (int32_t *) &extra[idx + 4];
 # endif
 
-				if (! is_range)
-				  {
+                                if (! is_range)
+                                  {
 # ifdef WIDE_CHAR_VERSION
-				    for (c1 = 0; c1 < wextra[idx]; ++c1)
-				      if (n[c1] != wextra[1 + c1])
-					break;
+                                    for (c1 = 0; c1 < wextra[idx]; ++c1)
+                                      if (n[c1] != wextra[1 + c1])
+                                        break;
 
-				    if (c1 == wextra[idx])
-				      goto matched;
+                                    if (c1 == wextra[idx])
+                                      goto matched;
 # else
-				    for (c1 = 0; c1 < extra[idx]; ++c1)
-				      if (n[c1] != extra[1 + c1])
-					break;
+                                    for (c1 = 0; c1 < extra[idx]; ++c1)
+                                      if (n[c1] != extra[1 + c1])
+                                        break;
 
-				    if (c1 == extra[idx])
-				      goto matched;
+                                    if (c1 == extra[idx])
+                                      goto matched;
 # endif
-				  }
+                                  }
 
-				/* Get the collation sequence value.  */
-				is_seqval = 1;
+                                /* Get the collation sequence value.  */
+                                is_seqval = 1;
 # ifdef WIDE_CHAR_VERSION
-				cold = wextra[1 + wextra[idx]];
+                                cold = wextra[1 + wextra[idx]];
 # else
-				/* Adjust for the alignment.  */
-				idx += 1 + extra[idx];
-				idx = (idx + 3) & ~4;
-				cold = *((int32_t *) &extra[idx]);
+                                /* Adjust for the alignment.  */
+                                idx += 1 + extra[idx];
+                                idx = (idx + 3) & ~4;
+                                cold = *((int32_t *) &extra[idx]);
 # endif
 
-				c = *p++;
-			      }
-			    else if (symb_table[2 * elem] != 0 && c1 == 1)
-			      {
-				/* No valid character.  Match it as a
-				   single byte.  */
-				if (!is_range && *n == str[0])
-				  goto matched;
+                                c = *p++;
+                              }
+                            else if (symb_table[2 * elem] != 0 && c1 == 1)
+                              {
+                                /* No valid character.  Match it as a
+                                   single byte.  */
+                                if (!is_range && *n == str[0])
+                                  goto matched;
 
-				cold = str[0];
-				c = *p++;
-			      }
-			    else
-			      return FNM_NOMATCH;
-			  }
-		      }
-		    else
+                                cold = str[0];
+                                c = *p++;
+                              }
+                            else
+                              return FNM_NOMATCH;
+                          }
+                      }
+                    else
 # undef str
 #endif
-		      {
-			c = FOLD (c);
-		      normal_bracket:
+                      {
+                        c = FOLD (c);
+                      normal_bracket:
 
-			/* We have to handling the symbols differently in
-			   ranges since then the collation sequence is
-			   important.  */
-			is_range = *p == L('-') && p[1] != L('\0');
+                        /* We have to handling the symbols differently in
+                           ranges since then the collation sequence is
+                           important.  */
+                        is_range = *p == L('-') && p[1] != L('\0');
 
-			if (!is_range && c == fn)
-			  goto matched;
+                        if (!is_range && c == fn)
+                          goto matched;
 
-			cold = c;
-			c = *p++;
-		      }
+                        cold = c;
+                        c = *p++;
+                      }
 
-		    if (c == L('-') && *p != L(']'))
-		      {
+                    if (c == L('-') && *p != L(']'))
+                      {
 #if _LIBC
-			/* We have to find the collation sequence
-			   value for C.  Collation sequence is nothing
-			   we can regularly access.  The sequence
-			   value is defined by the order in which the
-			   definitions of the collation values for the
-			   various characters appear in the source
-			   file.  A strange concept, nowhere
-			   documented.  */
-			uint32_t fcollseq;
-			uint32_t lcollseq;
-			UCHAR cend = *p++;
+                        /* We have to find the collation sequence
+                           value for C.  Collation sequence is nothing
+                           we can regularly access.  The sequence
+                           value is defined by the order in which the
+                           definitions of the collation values for the
+                           various characters appear in the source
+                           file.  A strange concept, nowhere
+                           documented.  */
+                        uint32_t fcollseq;
+                        uint32_t lcollseq;
+                        UCHAR cend = *p++;
 
 # ifdef WIDE_CHAR_VERSION
-			/* Search in the `names' array for the characters.  */
-			fcollseq = collseq_table_lookup (collseq, fn);
-			if (fcollseq == ~((uint32_t) 0))
-			  /* XXX We don't know anything about the character
-			     we are supposed to match.  This means we are
-			     failing.  */
-			  goto range_not_matched;
+                        /* Search in the `names' array for the characters.  */
+                        fcollseq = collseq_table_lookup (collseq, fn);
+                        if (fcollseq == ~((uint32_t) 0))
+                          /* XXX We don't know anything about the character
+                             we are supposed to match.  This means we are
+                             failing.  */
+                          goto range_not_matched;
 
-			if (is_seqval)
-			  lcollseq = cold;
-			else
-			  lcollseq = collseq_table_lookup (collseq, cold);
+                        if (is_seqval)
+                          lcollseq = cold;
+                        else
+                          lcollseq = collseq_table_lookup (collseq, cold);
 # else
-			fcollseq = collseq[fn];
-			lcollseq = is_seqval ? cold : collseq[(UCHAR) cold];
+                        fcollseq = collseq[fn];
+                        lcollseq = is_seqval ? cold : collseq[(UCHAR) cold];
 # endif
 
-			is_seqval = 0;
-			if (cend == L('[') && *p == L('.'))
-			  {
-			    uint32_t nrules =
-			      _NL_CURRENT_WORD (LC_COLLATE,
-						_NL_COLLATE_NRULES);
-			    const CHAR *startp = p;
-			    size_t c1 = 0;
+                        is_seqval = 0;
+                        if (cend == L('[') && *p == L('.'))
+                          {
+                            uint32_t nrules =
+                              _NL_CURRENT_WORD (LC_COLLATE,
+                                                _NL_COLLATE_NRULES);
+                            const CHAR *startp = p;
+                            size_t c1 = 0;
 
-			    while (1)
-			      {
-				c = *++p;
-				if (c == L('.') && p[1] == L(']'))
-				  {
-				    p += 2;
-				    break;
-				  }
-				if (c == '\0')
-				  return FNM_NOMATCH;
-				++c1;
-			      }
+                            while (1)
+                              {
+                                c = *++p;
+                                if (c == L('.') && p[1] == L(']'))
+                                  {
+                                    p += 2;
+                                    break;
+                                  }
+                                if (c == '\0')
+                                  return FNM_NOMATCH;
+                                ++c1;
+                              }
 
-			    if (nrules == 0)
-			      {
-				/* There are no names defined in the
-				   collation data.  Therefore we only
-				   accept the trivial names consisting
-				   of the character itself.  */
-				if (c1 != 1)
-				  return FNM_NOMATCH;
+                            if (nrules == 0)
+                              {
+                                /* There are no names defined in the
+                                   collation data.  Therefore we only
+                                   accept the trivial names consisting
+                                   of the character itself.  */
+                                if (c1 != 1)
+                                  return FNM_NOMATCH;
 
-				cend = startp[1];
-			      }
-			    else
-			      {
-				int32_t table_size;
-				const int32_t *symb_table;
+                                cend = startp[1];
+                              }
+                            else
+                              {
+                                int32_t table_size;
+                                const int32_t *symb_table;
 # ifdef WIDE_CHAR_VERSION
-				char str[c1];
-				int strcnt;
+                                char str[c1];
+                                int strcnt;
 # else
 #  define str (startp + 1)
 # endif
-				const unsigned char *extra;
-				int32_t idx;
-				int32_t elem;
-				int32_t second;
-				int32_t hash;
+                                const unsigned char *extra;
+                                int32_t idx;
+                                int32_t elem;
+                                int32_t second;
+                                int32_t hash;
 
 # ifdef WIDE_CHAR_VERSION
-				/* We have to convert the name to a single-byte
-				   string.  This is possible since the names
-				   consist of ASCII characters and the internal
-				   representation is UCS4.  */
-				for (strcnt = 0; strcnt < c1; ++strcnt)
-				  str[strcnt] = startp[1 + strcnt];
+                                /* We have to convert the name to a single-byte
+                                   string.  This is possible since the names
+                                   consist of ASCII characters and the internal
+                                   representation is UCS4.  */
+                                for (strcnt = 0; strcnt < c1; ++strcnt)
+                                  str[strcnt] = startp[1 + strcnt];
 #endif
 
-				table_size =
-				  _NL_CURRENT_WORD (LC_COLLATE,
-						    _NL_COLLATE_SYMB_HASH_SIZEMB);
-				symb_table = (const int32_t *)
-				  _NL_CURRENT (LC_COLLATE,
-					       _NL_COLLATE_SYMB_TABLEMB);
-				extra = (const unsigned char *)
-				  _NL_CURRENT (LC_COLLATE,
-					       _NL_COLLATE_SYMB_EXTRAMB);
+                                table_size =
+                                  _NL_CURRENT_WORD (LC_COLLATE,
+                                                    _NL_COLLATE_SYMB_HASH_SIZEMB);
+                                symb_table = (const int32_t *)
+                                  _NL_CURRENT (LC_COLLATE,
+                                               _NL_COLLATE_SYMB_TABLEMB);
+                                extra = (const unsigned char *)
+                                  _NL_CURRENT (LC_COLLATE,
+                                               _NL_COLLATE_SYMB_EXTRAMB);
 
-				/* Locate the character in the hashing
+                                /* Locate the character in the hashing
                                    table.  */
-				hash = elem_hash (str, c1);
+                                hash = elem_hash (str, c1);
 
-				idx = 0;
-				elem = hash % table_size;
-				second = hash % (table_size - 2);
-				while (symb_table[2 * elem] != 0)
-				  {
-				/* First compare the hashing value.  */
-				    if (symb_table[2 * elem] == hash
-					&& (c1
-					    == extra[symb_table[2 * elem + 1]])
-					&& memcmp (str,
-						   &extra[symb_table[2 * elem + 1]
-							 + 1], c1) == 0)
-				      {
-					/* Yep, this is the entry.  */
-					idx = symb_table[2 * elem + 1];
-					idx += 1 + extra[idx];
-					break;
-				      }
+                                idx = 0;
+                                elem = hash % table_size;
+                                second = hash % (table_size - 2);
+                                while (symb_table[2 * elem] != 0)
+                                  {
+                                /* First compare the hashing value.  */
+                                    if (symb_table[2 * elem] == hash
+                                        && (c1
+                                            == extra[symb_table[2 * elem + 1]])
+                                        && memcmp (str,
+                                                   &extra[symb_table[2 * elem + 1]
+                                                         + 1], c1) == 0)
+                                      {
+                                        /* Yep, this is the entry.  */
+                                        idx = symb_table[2 * elem + 1];
+                                        idx += 1 + extra[idx];
+                                        break;
+                                      }
 
-				    /* Next entry.  */
-				    elem += second;
-				  }
+                                    /* Next entry.  */
+                                    elem += second;
+                                  }
 
-				if (symb_table[2 * elem] != 0)
-				  {
-				    /* Compare the byte sequence but only if
-				       this is not part of a range.  */
+                                if (symb_table[2 * elem] != 0)
+                                  {
+                                    /* Compare the byte sequence but only if
+                                       this is not part of a range.  */
 # ifdef WIDE_CHAR_VERSION
-				    int32_t *wextra;
+                                    int32_t *wextra;
 
-				    idx += 1 + extra[idx];
-				    /* Adjust for the alignment.  */
-				    idx = (idx + 3) & ~4;
+                                    idx += 1 + extra[idx];
+                                    /* Adjust for the alignment.  */
+                                    idx = (idx + 3) & ~4;
 
-				    wextra = (int32_t *) &extra[idx + 4];
+                                    wextra = (int32_t *) &extra[idx + 4];
 # endif
-				    /* Get the collation sequence value.  */
-				    is_seqval = 1;
+                                    /* Get the collation sequence value.  */
+                                    is_seqval = 1;
 # ifdef WIDE_CHAR_VERSION
-				    cend = wextra[1 + wextra[idx]];
+                                    cend = wextra[1 + wextra[idx]];
 # else
-				    /* Adjust for the alignment.  */
-				    idx += 1 + extra[idx];
-				    idx = (idx + 3) & ~4;
-				    cend = *((int32_t *) &extra[idx]);
+                                    /* Adjust for the alignment.  */
+                                    idx += 1 + extra[idx];
+                                    idx = (idx + 3) & ~4;
+                                    cend = *((int32_t *) &extra[idx]);
 # endif
-				  }
-				else if (symb_table[2 * elem] != 0 && c1 == 1)
-				  {
-				    cend = str[0];
-				    c = *p++;
-				  }
-				else
-				  return FNM_NOMATCH;
-			      }
+                                  }
+                                else if (symb_table[2 * elem] != 0 && c1 == 1)
+                                  {
+                                    cend = str[0];
+                                    c = *p++;
+                                  }
+                                else
+                                  return FNM_NOMATCH;
+                              }
 # undef str
-			  }
-			else
-			  {
-			    if (!(flags & FNM_NOESCAPE) && cend == L('\\'))
-			      cend = *p++;
-			    if (cend == L('\0'))
-			      return FNM_NOMATCH;
-			    cend = FOLD (cend);
-			  }
+                          }
+                        else
+                          {
+                            if (!(flags & FNM_NOESCAPE) && cend == L('\\'))
+                              cend = *p++;
+                            if (cend == L('\0'))
+                              return FNM_NOMATCH;
+                            cend = FOLD (cend);
+                          }
 
-			/* XXX It is not entirely clear to me how to handle
-			   characters which are not mentioned in the
-			   collation specification.  */
-			if (
+                        /* XXX It is not entirely clear to me how to handle
+                           characters which are not mentioned in the
+                           collation specification.  */
+                        if (
 # ifdef WIDE_CHAR_VERSION
-			    lcollseq == 0xffffffff ||
+                            lcollseq == 0xffffffff ||
 # endif
-			    lcollseq <= fcollseq)
-			  {
-			    /* We have to look at the upper bound.  */
-			    uint32_t hcollseq;
+                            lcollseq <= fcollseq)
+                          {
+                            /* We have to look at the upper bound.  */
+                            uint32_t hcollseq;
 
-			    if (is_seqval)
-			      hcollseq = cend;
-			    else
-			      {
+                            if (is_seqval)
+                              hcollseq = cend;
+                            else
+                              {
 # ifdef WIDE_CHAR_VERSION
-				hcollseq =
-				  collseq_table_lookup (collseq, cend);
-				if (hcollseq == ~((uint32_t) 0))
-				  {
-				    /* Hum, no information about the upper
-				       bound.  The matching succeeds if the
-				       lower bound is matched exactly.  */
-				    if (lcollseq != fcollseq)
-				      goto range_not_matched;
+                                hcollseq =
+                                  collseq_table_lookup (collseq, cend);
+                                if (hcollseq == ~((uint32_t) 0))
+                                  {
+                                    /* Hum, no information about the upper
+                                       bound.  The matching succeeds if the
+                                       lower bound is matched exactly.  */
+                                    if (lcollseq != fcollseq)
+                                      goto range_not_matched;
 
-				    goto matched;
-				  }
+                                    goto matched;
+                                  }
 # else
-				hcollseq = collseq[cend];
+                                hcollseq = collseq[cend];
 # endif
-			      }
+                              }
 
-			    if (lcollseq <= hcollseq && fcollseq <= hcollseq)
-			      goto matched;
-			  }
+                            if (lcollseq <= hcollseq && fcollseq <= hcollseq)
+                              goto matched;
+                          }
 # ifdef WIDE_CHAR_VERSION
-		      range_not_matched:
+                      range_not_matched:
 # endif
 #else
-			/* We use a boring value comparison of the character
-			   values.  This is better than comparing using
-			   `strcoll' since the latter would have surprising
-			   and sometimes fatal consequences.  */
-			UCHAR cend = *p++;
+                        /* We use a boring value comparison of the character
+                           values.  This is better than comparing using
+                           `strcoll' since the latter would have surprising
+                           and sometimes fatal consequences.  */
+                        UCHAR cend = *p++;
 
-			if (!(flags & FNM_NOESCAPE) && cend == L('\\'))
-			  cend = *p++;
-			if (cend == L('\0'))
-			  return FNM_NOMATCH;
+                        if (!(flags & FNM_NOESCAPE) && cend == L('\\'))
+                          cend = *p++;
+                        if (cend == L('\0'))
+                          return FNM_NOMATCH;
 
-			/* It is a range.  */
-			if (cold <= fn && fn <= c)
-			  goto matched;
+                        /* It is a range.  */
+                        if (cold <= fn && fn <= c)
+                          goto matched;
 #endif
 
-			c = *p++;
-		      }
-		  }
+                        c = *p++;
+                      }
+                  }
 
-		if (c == L(']'))
-		  break;
-	      }
+                if (c == L(']'))
+                  break;
+              }
 
-	    if (!not)
-	      return FNM_NOMATCH;
-	    break;
+            if (!not)
+              return FNM_NOMATCH;
+            break;
 
-	  matched:
-	    /* Skip the rest of the [...] that already matched.  */
-	    do
-	      {
-	      ignore_next:
-		c = *p++;
+          matched:
+            /* Skip the rest of the [...] that already matched.  */
+            do
+              {
+              ignore_next:
+                c = *p++;
 
-		if (c == L('\0'))
-		  /* [... (unterminated) loses.  */
-		  return FNM_NOMATCH;
+                if (c == L('\0'))
+                  /* [... (unterminated) loses.  */
+                  return FNM_NOMATCH;
 
-		if (!(flags & FNM_NOESCAPE) && c == L('\\'))
-		  {
-		    if (*p == L('\0'))
-		      return FNM_NOMATCH;
-		    /* XXX 1003.2d11 is unclear if this is right.  */
-		    ++p;
-		  }
-		else if (c == L('[') && *p == L(':'))
-		  {
-		    int c1 = 0;
-		    const CHAR *startp = p;
+                if (!(flags & FNM_NOESCAPE) && c == L('\\'))
+                  {
+                    if (*p == L('\0'))
+                      return FNM_NOMATCH;
+                    /* XXX 1003.2d11 is unclear if this is right.  */
+                    ++p;
+                  }
+                else if (c == L('[') && *p == L(':'))
+                  {
+                    int c1 = 0;
+                    const CHAR *startp = p;
 
-		    while (1)
-		      {
-			c = *++p;
-			if (++c1 == CHAR_CLASS_MAX_LENGTH)
-			  return FNM_NOMATCH;
+                    while (1)
+                      {
+                        c = *++p;
+                        if (++c1 == CHAR_CLASS_MAX_LENGTH)
+                          return FNM_NOMATCH;
 
-			if (*p == L(':') && p[1] == L(']'))
-			  break;
+                        if (*p == L(':') && p[1] == L(']'))
+                          break;
 
-			if (c < L('a') || c >= L('z'))
-			  {
-			    p = startp;
-			    goto ignore_next;
-			  }
-		      }
-		    p += 2;
-		    c = *p++;
-		  }
-		else if (c == L('[') && *p == L('='))
-		  {
-		    c = *++p;
-		    if (c == L('\0'))
-		      return FNM_NOMATCH;
-		    c = *++p;
-		    if (c != L('=') || p[1] != L(']'))
-		      return FNM_NOMATCH;
-		    p += 2;
-		    c = *p++;
-		  }
-		else if (c == L('[') && *p == L('.'))
-		  {
-		    ++p;
-		    while (1)
-		      {
-			c = *++p;
-			if (c == '\0')
-			  return FNM_NOMATCH;
+                        if (c < L('a') || c >= L('z'))
+                          {
+                            p = startp;
+                            goto ignore_next;
+                          }
+                      }
+                    p += 2;
+                    c = *p++;
+                  }
+                else if (c == L('[') && *p == L('='))
+                  {
+                    c = *++p;
+                    if (c == L('\0'))
+                      return FNM_NOMATCH;
+                    c = *++p;
+                    if (c != L('=') || p[1] != L(']'))
+                      return FNM_NOMATCH;
+                    p += 2;
+                    c = *p++;
+                  }
+                else if (c == L('[') && *p == L('.'))
+                  {
+                    ++p;
+                    while (1)
+                      {
+                        c = *++p;
+                        if (c == '\0')
+                          return FNM_NOMATCH;
 
-			if (*p == L('.') && p[1] == L(']'))
-			  break;
-		      }
-		    p += 2;
-		    c = *p++;
-		  }
-	      }
-	    while (c != L(']'));
-	    if (not)
-	      return FNM_NOMATCH;
-	  }
-	  break;
+                        if (*p == L('.') && p[1] == L(']'))
+                          break;
+                      }
+                    p += 2;
+                    c = *p++;
+                  }
+              }
+            while (c != L(']'));
+            if (not)
+              return FNM_NOMATCH;
+          }
+          break;
 
-	default:
-	  if (c != FOLD ((UCHAR) *n))
-	    return FNM_NOMATCH;
-	}
+        default:
+          if (c != FOLD ((UCHAR) *n))
+            return FNM_NOMATCH;
+        }
 
       ++n;
     }

--- a/src/libcompat/naive.c
+++ b/src/libcompat/naive.c
@@ -15,8 +15,8 @@
 
 #define ALIGN(x, n) (((x) + ((n) - 1)) & ~((n) - 1))
 
-#define BLOCK_SIZE 8172		/* Should probably be chosen w/ respect to
-				   malloc implementation */
+#define BLOCK_SIZE 8172                /* Should probably be chosen w/ respect to
+                                   malloc implementation */
 #define BIG_SIZE 16364
 
 typedef double max_aligned_type;
@@ -29,8 +29,8 @@ struct region_
 struct block
 {
 #ifndef USEMALLOC
-  char *pos;			/* Where next to allocate from */
-  char *end;			/* End of block */
+  char *pos;                        /* Where next to allocate from */
+  char *end;                        /* End of block */
 #endif
   struct block *previous;
   max_aligned_type data[1];
@@ -166,19 +166,19 @@ static void *allocate(region b, unsigned long size)
       struct block *newp;
 
       if (size < BLOCK_SIZE / 4)
-	bsize = BLOCK_SIZE;
+        bsize = BLOCK_SIZE;
       else if (size >= BIG_SIZE)
-	bsize = size;
+        bsize = size;
       else
-	bsize = size * 4;
+        bsize = size * 4;
       newp = make_block(bsize);
 
       if (!newp)
-	{
-	  nomem_h();
-	  abort();
-	  return NULL;
-	}
+        {
+          nomem_h();
+          abort();
+          return NULL;
+        }
 
       newp->previous = blk;
       b->current = newp;
@@ -232,7 +232,7 @@ char *rstrdup(region r, const char *s)
 }
 
 static char *internal_rstrextend(region r, const char *old, size_t newsize,
-				 int needsclear)
+                                 int needsclear)
 {
   abort();
 }

--- a/src/libcompat/pages.c
+++ b/src/libcompat/pages.c
@@ -138,24 +138,24 @@ static void addbyaddress(struct page *p)
   if (p > last_add)
     {
       for (address_scan = pages_byaddress.prev_address; ;
-	   address_scan = address_scan->prev_address)
-	if (p > address_scan || address_scan == &pages_byaddress)
-	  {
-	    last_add = p;
-	    insertafter_address(p, address_scan);
-	    return;
-	  }
+           address_scan = address_scan->prev_address)
+        if (p > address_scan || address_scan == &pages_byaddress)
+          {
+            last_add = p;
+            insertafter_address(p, address_scan);
+            return;
+          }
     }
   else
     {
       for (address_scan = pages_byaddress.next_address; ;
-	   address_scan = address_scan->next_address)
-	if (p < address_scan || address_scan == &pages_byaddress)
-	  {
-	    last_add = p;
-	    insertbefore_address(p, address_scan);
-	    return;
-	  }
+           address_scan = address_scan->next_address)
+        if (p < address_scan || address_scan == &pages_byaddress)
+          {
+            last_add = p;
+            insertbefore_address(p, address_scan);
+            return;
+          }
     }
 }
 
@@ -314,14 +314,14 @@ void set_page_region(pageid pagenb, region r)
 
       rmap = (region *)malloc(sizeof(region) * (1 << MEMSLICE3));
       if (!rmap)
-	{
-	  if (nomem_h)
-	    nomem_h();
-	  abort();
-	}
+        {
+          if (nomem_h)
+            nomem_h();
+          abort();
+        }
       __regiontable[offset2] = rmap;
       for (i = 0; i < (1 << MEMSLICE3); i++) {
-	rmap[i] = NULL;
+        rmap[i] = NULL;
       }
     }
   rmap[offset3] = r;
@@ -407,7 +407,7 @@ struct page *alloc_new(int n, struct page *next)
   if (!newp)
     {
       if (nomem_h)
-	nomem_h();
+        nomem_h();
       abort();
     }
   assert(!((long)newp & (RPAGESIZE - 1)));
@@ -429,7 +429,7 @@ struct page *alloc_pages(int n, struct page *next)
   for (;;)
     {
       if (!scan)
-	return alloc_new(n, next);
+        return alloc_new(n, next);
 
       if (scan->pagecount >= n) break;
       scan = scan->next;
@@ -442,13 +442,13 @@ struct page *alloc_pages(int n, struct page *next)
     {
       scan = scan->next;
       if (!scan)
-	return alloc_split(best, n, next);
+        return alloc_split(best, n, next);
 
       if (scan->pagecount >=n && scan->pagecount < bestn)
-	{
-	  best = scan;
-	  bestn = scan->pagecount;
-	}
+        {
+          best = scan;
+          bestn = scan->pagecount;
+        }
     }
 }
 
@@ -518,7 +518,7 @@ static void add_single_pages(struct page *base)
       base->next = single_pages;
       single_pages = base;
       if (--n == 0)
-	break;
+        break;
       next = (struct page *)((char *)base + RPAGESIZE);
       base->next_address = next;
       base = next;
@@ -542,26 +542,26 @@ void scavenge_single_pages(int n)
   while (scan)
     {
       /* The pages < K can't be used for anything but single pages so we
-	 might as well grab them even if they are a little too big */
+         might as well grab them even if they are a little too big */
       if (scan->pagecount <= n || scan->pagecount < K)
-	{
-	  struct page *adding = scan;
+        {
+          struct page *adding = scan;
 
-	  scan = scan->next;
-	  n -= adding->pagecount;
-	  unlink_page(&unused_pages, adding);
-	  add_single_pages(adding);
-	  if (n <= 0) return;
-	}
+          scan = scan->next;
+          n -= adding->pagecount;
+          unlink_page(&unused_pages, adding);
+          add_single_pages(adding);
+          if (n <= 0) return;
+        }
       else
-	{
-	  if (scan->pagecount < bestn)
-	    {
-	      bestn = scan->pagecount;
-	      best = scan;
-	    }
-	  scan = scan->next;
-	}
+        {
+          if (scan->pagecount < bestn)
+            {
+              bestn = scan->pagecount;
+              best = scan;
+            }
+          scan = scan->next;
+        }
     }
   /* Still not enough. Split the best block if there is one, allocate
      new pages otherwise */

--- a/src/libcompat/regex.c
+++ b/src/libcompat/regex.c
@@ -24,7 +24,7 @@
   #pragma alloca
 #endif
 
-#undef	_GNU_SOURCE
+#undef        _GNU_SOURCE
 #define _GNU_SOURCE
 
 #ifdef HAVE_CONFIG_H
@@ -62,20 +62,20 @@
 # define regexec(pr, st, nm, pm, ef) __regexec (pr, st, nm, pm, ef)
 # define regcomp(preg, pattern, cflags) __regcomp (preg, pattern, cflags)
 # define regerror(errcode, preg, errbuf, errbuf_size) \
-	__regerror(errcode, preg, errbuf, errbuf_size)
+        __regerror(errcode, preg, errbuf, errbuf_size)
 # define re_set_registers(bu, re, nu, st, en) \
-	__re_set_registers (bu, re, nu, st, en)
+        __re_set_registers (bu, re, nu, st, en)
 # define re_match_2(bufp, string1, size1, string2, size2, pos, regs, stop) \
-	__re_match_2 (bufp, string1, size1, string2, size2, pos, regs, stop)
+        __re_match_2 (bufp, string1, size1, string2, size2, pos, regs, stop)
 # define re_match(bufp, string, size, pos, regs) \
-	__re_match (bufp, string, size, pos, regs)
+        __re_match (bufp, string, size, pos, regs)
 # define re_search(bufp, string, size, startpos, range, regs) \
-	__re_search (bufp, string, size, startpos, range, regs)
+        __re_search (bufp, string, size, startpos, range, regs)
 # define re_compile_pattern(pattern, length, bufp) \
-	__re_compile_pattern (pattern, length, bufp)
+        __re_compile_pattern (pattern, length, bufp)
 # define re_set_syntax(syntax) __re_set_syntax (syntax)
 # define re_search_2(bufp, st1, s1, st2, s2, startpos, range, regs, stop) \
-	__re_search_2 (bufp, st1, s1, st2, s2, startpos, range, regs, stop)
+        __re_search_2 (bufp, st1, s1, st2, s2, startpos, range, regs, stop)
 # define re_compile_fastmap(bufp) __re_compile_fastmap (bufp)
 
 # define btowc __btowc
@@ -143,18 +143,18 @@ char *realloc ();
 #   include <string.h>
 #   ifndef bzero
 #    ifndef _LIBC
-#     define bzero(s, n)	(memset (s, '\0', n), (s))
+#     define bzero(s, n)        (memset (s, '\0', n), (s))
 #    else
-#     define bzero(s, n)	__bzero (s, n)
+#     define bzero(s, n)        __bzero (s, n)
 #    endif
 #   endif
 #  else
 #   include <strings.h>
 #   ifndef memcmp
-#    define memcmp(s1, s2, n)	bcmp (s1, s2, n)
+#    define memcmp(s1, s2, n)        bcmp (s1, s2, n)
 #   endif
 #   ifndef memcpy
-#    define memcpy(d, s, n)	(bcopy (s, d, n), (d))
+#    define memcpy(d, s, n)        (bcopy (s, d, n), (d))
 #   endif
 #  endif
 # endif
@@ -277,7 +277,7 @@ init_syntax_once ()
 
    for (c = 0; c < CHAR_SET_SIZE; ++c)
      if (ISALNUM (c))
-	re_syntax_table[c] = Sword;
+        re_syntax_table[c] = Sword;
 
    re_syntax_table['_'] = Sword;
 
@@ -325,8 +325,8 @@ init_syntax_once ()
 # define REGEX_ALLOCATE alloca
 
 /* Assumes a `char *destination' variable.  */
-# define REGEX_REALLOCATE(source, osize, nsize)				\
-  (destination = (char *) alloca (nsize),				\
+# define REGEX_REALLOCATE(source, osize, nsize)                                \
+  (destination = (char *) alloca (nsize),                                \
    memcpy (destination, source, osize))
 
 /* No need to do anything to free, after alloca.  */
@@ -338,11 +338,11 @@ init_syntax_once ()
 
 #if defined REL_ALLOC && defined REGEX_MALLOC
 
-# define REGEX_ALLOCATE_STACK(size)				\
+# define REGEX_ALLOCATE_STACK(size)                                \
   r_alloc (&failure_stack_ptr, (size))
-# define REGEX_REALLOCATE_STACK(source, osize, nsize)		\
+# define REGEX_REALLOCATE_STACK(source, osize, nsize)                \
   r_re_alloc (&failure_stack_ptr, (nsize))
-# define REGEX_FREE_STACK(ptr)					\
+# define REGEX_FREE_STACK(ptr)                                        \
   r_alloc_free (&failure_stack_ptr)
 
 #else /* not using relocating allocator */
@@ -357,7 +357,7 @@ init_syntax_once ()
 
 #  define REGEX_ALLOCATE_STACK alloca
 
-#  define REGEX_REALLOCATE_STACK(source, osize, nsize)			\
+#  define REGEX_REALLOCATE_STACK(source, osize, nsize)                        \
    REGEX_REALLOCATE (source, osize, nsize)
 /* No need to explicitly free anything.  */
 #  define REGEX_FREE_STACK(arg)
@@ -369,7 +369,7 @@ init_syntax_once ()
 /* True if `size1' is non-NULL and PTR is pointing anywhere inside
    `string1' or just past its end.  This works if PTR is NULL, which is
    a good thing.  */
-#define FIRST_STRING_P(ptr) 					\
+#define FIRST_STRING_P(ptr)                                         \
   (size1 && string1 <= (ptr) && (ptr) <= string1 + size1)
 
 /* (Re)Allocate N items of type T using malloc, or fail.  */
@@ -393,11 +393,11 @@ typedef char boolean;
 #define true 1
 
 static int re_match_2_internal PARAMS ((struct re_pattern_buffer *bufp,
-					const char *string1, int size1,
-					const char *string2, int size2,
-					int pos,
-					struct re_registers *regs,
-					int stop));
+                                        const char *string1, int size1,
+                                        const char *string2, int size2,
+                                        int pos,
+                                        struct re_registers *regs,
+                                        int stop));
 
 /* These are the command codes that appear in compiled regular
    expressions.  Some opcodes are followed by argument bytes.  A
@@ -467,7 +467,7 @@ typedef enum
         /* Followed by two byte relative address to which to jump.  */
   jump,
 
-	/* Same as jump, but marks the end of an alternative.  */
+        /* Same as jump, but marks the end of an alternative.  */
   jump_past_alt,
 
         /* Followed by two-byte relative address of place to resume at
@@ -498,8 +498,8 @@ typedef enum
            of jump when compiling an alternative.  */
   dummy_failure_jump,
 
-	/* Push a dummy failure point and continue.  Used at the end of
-	   alternatives.  */
+        /* Push a dummy failure point and continue.  Used at the end of
+           alternatives.  */
   push_dummy_failure,
 
         /* Followed by two-byte relative address and two-byte number n.
@@ -515,25 +515,25 @@ typedef enum
            bytes of number.  */
   set_number_at,
 
-  wordchar,	/* Matches any word-constituent character.  */
-  notwordchar,	/* Matches any char that is not a word-constituent.  */
+  wordchar,        /* Matches any word-constituent character.  */
+  notwordchar,        /* Matches any char that is not a word-constituent.  */
 
-  wordbeg,	/* Succeeds if at word beginning.  */
-  wordend,	/* Succeeds if at word end.  */
+  wordbeg,        /* Succeeds if at word beginning.  */
+  wordend,        /* Succeeds if at word end.  */
 
-  wordbound,	/* Succeeds if at a word boundary.  */
-  notwordbound	/* Succeeds if not at a word boundary.  */
+  wordbound,        /* Succeeds if at a word boundary.  */
+  notwordbound        /* Succeeds if not at a word boundary.  */
 
 #ifdef emacs
-  ,before_dot,	/* Succeeds if before point.  */
-  at_dot,	/* Succeeds if at point.  */
-  after_dot,	/* Succeeds if after point.  */
+  ,before_dot,        /* Succeeds if before point.  */
+  at_dot,        /* Succeeds if at point.  */
+  after_dot,        /* Succeeds if after point.  */
 
-	/* Matches any character whose syntax is specified.  Followed by
+        /* Matches any character whose syntax is specified.  Followed by
            a byte which contains a syntax code, e.g., Sword.  */
   syntaxspec,
 
-	/* Matches any character whose syntax is not that specified.  */
+        /* Matches any character whose syntax is not that specified.  */
   notsyntaxspec
 #endif /* emacs */
 } re_opcode_t;
@@ -542,29 +542,29 @@ typedef enum
 
 /* Store NUMBER in two contiguous bytes starting at DESTINATION.  */
 
-#define STORE_NUMBER(destination, number)				\
-  do {									\
-    (destination)[0] = (number) & 0377;					\
-    (destination)[1] = (number) >> 8;					\
+#define STORE_NUMBER(destination, number)                                \
+  do {                                                                        \
+    (destination)[0] = (number) & 0377;                                        \
+    (destination)[1] = (number) >> 8;                                        \
   } while (0)
 
 /* Same as STORE_NUMBER, except increment DESTINATION to
    the byte after where the number is stored.  Therefore, DESTINATION
    must be an lvalue.  */
 
-#define STORE_NUMBER_AND_INCR(destination, number)			\
-  do {									\
-    STORE_NUMBER (destination, number);					\
-    (destination) += 2;							\
+#define STORE_NUMBER_AND_INCR(destination, number)                        \
+  do {                                                                        \
+    STORE_NUMBER (destination, number);                                        \
+    (destination) += 2;                                                        \
   } while (0)
 
 /* Put into DESTINATION a number stored in two contiguous bytes starting
    at SOURCE.  */
 
-#define EXTRACT_NUMBER(destination, source)				\
-  do {									\
-    (destination) = *(source) & 0377;					\
-    (destination) += SIGN_EXTEND_CHAR (*((source) + 1)) << 8;		\
+#define EXTRACT_NUMBER(destination, source)                                \
+  do {                                                                        \
+    (destination) = *(source) & 0377;                                        \
+    (destination) += SIGN_EXTEND_CHAR (*((source) + 1)) << 8;                \
   } while (0)
 
 #ifdef DEBUG
@@ -589,15 +589,15 @@ extract_number (dest, source)
 /* Same as EXTRACT_NUMBER, except increment SOURCE to after the number.
    SOURCE must be an lvalue.  */
 
-#define EXTRACT_NUMBER_AND_INCR(destination, source)			\
-  do {									\
-    EXTRACT_NUMBER (destination, source);				\
-    (source) += 2; 							\
+#define EXTRACT_NUMBER_AND_INCR(destination, source)                        \
+  do {                                                                        \
+    EXTRACT_NUMBER (destination, source);                                \
+    (source) += 2;                                                         \
   } while (0)
 
 #ifdef DEBUG
 static void extract_number_and_incr _RE_ARGS ((int *destination,
-					       unsigned char **source));
+                                               unsigned char **source));
 static void
 extract_number_and_incr (destination, source)
     int *destination;
@@ -636,9 +636,9 @@ static int debug;
 # define DEBUG_PRINT2(x1, x2) if (debug) printf (x1, x2)
 # define DEBUG_PRINT3(x1, x2, x3) if (debug) printf (x1, x2, x3)
 # define DEBUG_PRINT4(x1, x2, x3, x4) if (debug) printf (x1, x2, x3, x4)
-# define DEBUG_PRINT_COMPILED_PATTERN(p, s, e) 				\
+# define DEBUG_PRINT_COMPILED_PATTERN(p, s, e)                                 \
   if (debug) print_partial_compiled_pattern (s, e)
-# define DEBUG_PRINT_DOUBLE_STRING(w, s1, sz1, s2, sz2)			\
+# define DEBUG_PRINT_DOUBLE_STRING(w, s1, sz1, s2, sz2)                        \
   if (debug) print_double_string (w, s1, sz1, s2, sz2)
 
 
@@ -654,15 +654,15 @@ print_fastmap (fastmap)
   while (i < (1 << BYTEWIDTH))
     {
       if (fastmap[i++])
-	{
-	  was_a_range = 0;
+        {
+          was_a_range = 0;
           putchar (i - 1);
           while (i < (1 << BYTEWIDTH)  &&  fastmap[i])
             {
               was_a_range = 1;
               i++;
             }
-	  if (was_a_range)
+          if (was_a_range)
             {
               printf ("-");
               putchar (i - 1);
@@ -702,250 +702,250 @@ print_partial_compiled_pattern (start, end)
 #endif
 
       switch ((re_opcode_t) *p++)
-	{
+        {
         case no_op:
           printf ("/no_op");
           break;
 
-	case exactn:
-	  mcnt = *p++;
+        case exactn:
+          mcnt = *p++;
           printf ("/exactn/%d", mcnt);
           do
-	    {
+            {
               putchar ('/');
-	      putchar (*p++);
+              putchar (*p++);
             }
           while (--mcnt);
           break;
 
-	case start_memory:
+        case start_memory:
           mcnt = *p++;
           printf ("/start_memory/%d/%d", mcnt, *p++);
           break;
 
-	case stop_memory:
+        case stop_memory:
           mcnt = *p++;
-	  printf ("/stop_memory/%d/%d", mcnt, *p++);
+          printf ("/stop_memory/%d/%d", mcnt, *p++);
           break;
 
-	case duplicate:
-	  printf ("/duplicate/%d", *p++);
-	  break;
+        case duplicate:
+          printf ("/duplicate/%d", *p++);
+          break;
 
-	case anychar:
-	  printf ("/anychar");
-	  break;
+        case anychar:
+          printf ("/anychar");
+          break;
 
-	case charset:
+        case charset:
         case charset_not:
           {
             register int c, last = -100;
-	    register int in_range = 0;
+            register int in_range = 0;
 
-	    printf ("/charset [%s",
-	            (re_opcode_t) *(p - 1) == charset_not ? "^" : "");
+            printf ("/charset [%s",
+                    (re_opcode_t) *(p - 1) == charset_not ? "^" : "");
 
             assert (p + *p < pend);
 
             for (c = 0; c < 256; c++)
-	      if (c / 8 < *p
-		  && (p[1 + (c/8)] & (1 << (c % 8))))
-		{
-		  /* Are we starting a range?  */
-		  if (last + 1 == c && ! in_range)
-		    {
-		      putchar ('-');
-		      in_range = 1;
-		    }
-		  /* Have we broken a range?  */
-		  else if (last + 1 != c && in_range)
+              if (c / 8 < *p
+                  && (p[1 + (c/8)] & (1 << (c % 8))))
+                {
+                  /* Are we starting a range?  */
+                  if (last + 1 == c && ! in_range)
+                    {
+                      putchar ('-');
+                      in_range = 1;
+                    }
+                  /* Have we broken a range?  */
+                  else if (last + 1 != c && in_range)
               {
-		      putchar (last);
-		      in_range = 0;
-		    }
+                      putchar (last);
+                      in_range = 0;
+                    }
 
-		  if (! in_range)
-		    putchar (c);
+                  if (! in_range)
+                    putchar (c);
 
-		  last = c;
+                  last = c;
               }
 
-	    if (in_range)
-	      putchar (last);
+            if (in_range)
+              putchar (last);
 
-	    putchar (']');
+            putchar (']');
 
-	    p += 1 + *p;
-	  }
-	  break;
-
-	case begline:
-	  printf ("/begline");
+            p += 1 + *p;
+          }
           break;
 
-	case endline:
+        case begline:
+          printf ("/begline");
+          break;
+
+        case endline:
           printf ("/endline");
           break;
 
-	case on_failure_jump:
+        case on_failure_jump:
           extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/on_failure_jump to %t", p + mcnt - start);
+            printf ("/on_failure_jump to %t", p + mcnt - start);
 #else
-  	  printf ("/on_failure_jump to %ld", (long int) (p + mcnt - start));
+            printf ("/on_failure_jump to %ld", (long int) (p + mcnt - start));
 #endif
           break;
 
-	case on_failure_keep_string_jump:
+        case on_failure_keep_string_jump:
           extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/on_failure_keep_string_jump to %t", p + mcnt - start);
+            printf ("/on_failure_keep_string_jump to %t", p + mcnt - start);
 #else
-  	  printf ("/on_failure_keep_string_jump to %ld",
-		  (long int) (p + mcnt - start));
+            printf ("/on_failure_keep_string_jump to %ld",
+                  (long int) (p + mcnt - start));
 #endif
           break;
 
-	case dummy_failure_jump:
+        case dummy_failure_jump:
           extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/dummy_failure_jump to %t", p + mcnt - start);
+            printf ("/dummy_failure_jump to %t", p + mcnt - start);
 #else
-  	  printf ("/dummy_failure_jump to %ld", (long int) (p + mcnt - start));
+            printf ("/dummy_failure_jump to %ld", (long int) (p + mcnt - start));
 #endif
           break;
 
-	case push_dummy_failure:
+        case push_dummy_failure:
           printf ("/push_dummy_failure");
           break;
 
         case maybe_pop_jump:
           extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/maybe_pop_jump to %t", p + mcnt - start);
+            printf ("/maybe_pop_jump to %t", p + mcnt - start);
 #else
-  	  printf ("/maybe_pop_jump to %ld", (long int) (p + mcnt - start));
+            printf ("/maybe_pop_jump to %ld", (long int) (p + mcnt - start));
 #endif
-	  break;
+          break;
 
         case pop_failure_jump:
-	  extract_number_and_incr (&mcnt, &p);
+          extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/pop_failure_jump to %t", p + mcnt - start);
+            printf ("/pop_failure_jump to %t", p + mcnt - start);
 #else
-  	  printf ("/pop_failure_jump to %ld", (long int) (p + mcnt - start));
+            printf ("/pop_failure_jump to %ld", (long int) (p + mcnt - start));
 #endif
-	  break;
+          break;
 
         case jump_past_alt:
-	  extract_number_and_incr (&mcnt, &p);
+          extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/jump_past_alt to %t", p + mcnt - start);
+            printf ("/jump_past_alt to %t", p + mcnt - start);
 #else
-  	  printf ("/jump_past_alt to %ld", (long int) (p + mcnt - start));
+            printf ("/jump_past_alt to %ld", (long int) (p + mcnt - start));
 #endif
-	  break;
+          break;
 
         case jump:
-	  extract_number_and_incr (&mcnt, &p);
+          extract_number_and_incr (&mcnt, &p);
 #ifdef _LIBC
-  	  printf ("/jump to %t", p + mcnt - start);
+            printf ("/jump to %t", p + mcnt - start);
 #else
-  	  printf ("/jump to %ld", (long int) (p + mcnt - start));
+            printf ("/jump to %ld", (long int) (p + mcnt - start));
 #endif
-	  break;
+          break;
 
         case succeed_n:
           extract_number_and_incr (&mcnt, &p);
-	  p1 = p + mcnt;
+          p1 = p + mcnt;
           extract_number_and_incr (&mcnt2, &p);
 #ifdef _LIBC
-	  printf ("/succeed_n to %t, %d times", p1 - start, mcnt2);
+          printf ("/succeed_n to %t, %d times", p1 - start, mcnt2);
 #else
-	  printf ("/succeed_n to %ld, %d times",
-		  (long int) (p1 - start), mcnt2);
+          printf ("/succeed_n to %ld, %d times",
+                  (long int) (p1 - start), mcnt2);
 #endif
           break;
 
         case jump_n:
           extract_number_and_incr (&mcnt, &p);
-	  p1 = p + mcnt;
+          p1 = p + mcnt;
           extract_number_and_incr (&mcnt2, &p);
-	  printf ("/jump_n to %d, %d times", p1 - start, mcnt2);
+          printf ("/jump_n to %d, %d times", p1 - start, mcnt2);
           break;
 
         case set_number_at:
           extract_number_and_incr (&mcnt, &p);
-	  p1 = p + mcnt;
+          p1 = p + mcnt;
           extract_number_and_incr (&mcnt2, &p);
 #ifdef _LIBC
-	  printf ("/set_number_at location %t to %d", p1 - start, mcnt2);
+          printf ("/set_number_at location %t to %d", p1 - start, mcnt2);
 #else
-	  printf ("/set_number_at location %ld to %d",
-		  (long int) (p1 - start), mcnt2);
+          printf ("/set_number_at location %ld to %d",
+                  (long int) (p1 - start), mcnt2);
 #endif
           break;
 
         case wordbound:
-	  printf ("/wordbound");
-	  break;
-
-	case notwordbound:
-	  printf ("/notwordbound");
+          printf ("/wordbound");
           break;
 
-	case wordbeg:
-	  printf ("/wordbeg");
-	  break;
+        case notwordbound:
+          printf ("/notwordbound");
+          break;
 
-	case wordend:
-	  printf ("/wordend");
+        case wordbeg:
+          printf ("/wordbeg");
+          break;
+
+        case wordend:
+          printf ("/wordend");
 
 # ifdef emacs
-	case before_dot:
-	  printf ("/before_dot");
+        case before_dot:
+          printf ("/before_dot");
           break;
 
-	case at_dot:
-	  printf ("/at_dot");
+        case at_dot:
+          printf ("/at_dot");
           break;
 
-	case after_dot:
-	  printf ("/after_dot");
+        case after_dot:
+          printf ("/after_dot");
           break;
 
-	case syntaxspec:
+        case syntaxspec:
           printf ("/syntaxspec");
-	  mcnt = *p++;
-	  printf ("/%d", mcnt);
+          mcnt = *p++;
+          printf ("/%d", mcnt);
           break;
 
-	case notsyntaxspec:
+        case notsyntaxspec:
           printf ("/notsyntaxspec");
-	  mcnt = *p++;
-	  printf ("/%d", mcnt);
-	  break;
+          mcnt = *p++;
+          printf ("/%d", mcnt);
+          break;
 # endif /* emacs */
 
-	case wordchar:
-	  printf ("/wordchar");
+        case wordchar:
+          printf ("/wordchar");
           break;
 
-	case notwordchar:
-	  printf ("/notwordchar");
+        case notwordchar:
+          printf ("/notwordchar");
           break;
 
-	case begbuf:
-	  printf ("/begbuf");
+        case begbuf:
+          printf ("/begbuf");
           break;
 
-	case endbuf:
-	  printf ("/endbuf");
+        case endbuf:
+          printf ("/endbuf");
           break;
 
         default:
           printf ("?%d", *(p-1));
-	}
+        }
 
       putchar ('\n');
     }
@@ -966,7 +966,7 @@ print_compiled_pattern (bufp)
 
   print_partial_compiled_pattern (buffer, buffer + bufp->used);
   printf ("%ld bytes used/%ld bytes allocated.\n",
-	  bufp->used, bufp->allocated);
+          bufp->used, bufp->allocated);
 
   if (bufp->fastmap_accurate && bufp->fastmap)
     {
@@ -1080,55 +1080,55 @@ weak_alias (__re_set_syntax, re_set_syntax)
 
 static const char re_error_msgid[] =
   {
-#define REG_NOERROR_IDX	0
-    gettext_noop ("Success")	/* REG_NOERROR */
+#define REG_NOERROR_IDX        0
+    gettext_noop ("Success")        /* REG_NOERROR */
     "\0"
 #define REG_NOMATCH_IDX (REG_NOERROR_IDX + sizeof "Success")
-    gettext_noop ("No match")	/* REG_NOMATCH */
+    gettext_noop ("No match")        /* REG_NOMATCH */
     "\0"
-#define REG_BADPAT_IDX	(REG_NOMATCH_IDX + sizeof "No match")
+#define REG_BADPAT_IDX        (REG_NOMATCH_IDX + sizeof "No match")
     gettext_noop ("Invalid regular expression") /* REG_BADPAT */
     "\0"
 #define REG_ECOLLATE_IDX (REG_BADPAT_IDX + sizeof "Invalid regular expression")
     gettext_noop ("Invalid collation character") /* REG_ECOLLATE */
     "\0"
-#define REG_ECTYPE_IDX	(REG_ECOLLATE_IDX + sizeof "Invalid collation character")
+#define REG_ECTYPE_IDX        (REG_ECOLLATE_IDX + sizeof "Invalid collation character")
     gettext_noop ("Invalid character class name") /* REG_ECTYPE */
     "\0"
-#define REG_EESCAPE_IDX	(REG_ECTYPE_IDX + sizeof "Invalid character class name")
+#define REG_EESCAPE_IDX        (REG_ECTYPE_IDX + sizeof "Invalid character class name")
     gettext_noop ("Trailing backslash") /* REG_EESCAPE */
     "\0"
-#define REG_ESUBREG_IDX	(REG_EESCAPE_IDX + sizeof "Trailing backslash")
+#define REG_ESUBREG_IDX        (REG_EESCAPE_IDX + sizeof "Trailing backslash")
     gettext_noop ("Invalid back reference") /* REG_ESUBREG */
     "\0"
-#define REG_EBRACK_IDX	(REG_ESUBREG_IDX + sizeof "Invalid back reference")
-    gettext_noop ("Unmatched [ or [^")	/* REG_EBRACK */
+#define REG_EBRACK_IDX        (REG_ESUBREG_IDX + sizeof "Invalid back reference")
+    gettext_noop ("Unmatched [ or [^")        /* REG_EBRACK */
     "\0"
-#define REG_EPAREN_IDX	(REG_EBRACK_IDX + sizeof "Unmatched [ or [^")
+#define REG_EPAREN_IDX        (REG_EBRACK_IDX + sizeof "Unmatched [ or [^")
     gettext_noop ("Unmatched ( or \\(") /* REG_EPAREN */
     "\0"
-#define REG_EBRACE_IDX	(REG_EPAREN_IDX + sizeof "Unmatched ( or \\(")
+#define REG_EBRACE_IDX        (REG_EPAREN_IDX + sizeof "Unmatched ( or \\(")
     gettext_noop ("Unmatched \\{") /* REG_EBRACE */
     "\0"
-#define REG_BADBR_IDX	(REG_EBRACE_IDX + sizeof "Unmatched \\{")
+#define REG_BADBR_IDX        (REG_EBRACE_IDX + sizeof "Unmatched \\{")
     gettext_noop ("Invalid content of \\{\\}") /* REG_BADBR */
     "\0"
-#define REG_ERANGE_IDX	(REG_BADBR_IDX + sizeof "Invalid content of \\{\\}")
-    gettext_noop ("Invalid range end")	/* REG_ERANGE */
+#define REG_ERANGE_IDX        (REG_BADBR_IDX + sizeof "Invalid content of \\{\\}")
+    gettext_noop ("Invalid range end")        /* REG_ERANGE */
     "\0"
-#define REG_ESPACE_IDX	(REG_ERANGE_IDX + sizeof "Invalid range end")
+#define REG_ESPACE_IDX        (REG_ERANGE_IDX + sizeof "Invalid range end")
     gettext_noop ("Memory exhausted") /* REG_ESPACE */
     "\0"
-#define REG_BADRPT_IDX	(REG_ESPACE_IDX + sizeof "Memory exhausted")
+#define REG_BADRPT_IDX        (REG_ESPACE_IDX + sizeof "Memory exhausted")
     gettext_noop ("Invalid preceding regular expression") /* REG_BADRPT */
     "\0"
-#define REG_EEND_IDX	(REG_BADRPT_IDX + sizeof "Invalid preceding regular expression")
+#define REG_EEND_IDX        (REG_BADRPT_IDX + sizeof "Invalid preceding regular expression")
     gettext_noop ("Premature end of regular expression") /* REG_EEND */
     "\0"
-#define REG_ESIZE_IDX	(REG_EEND_IDX + sizeof "Premature end of regular expression")
+#define REG_ESIZE_IDX        (REG_EEND_IDX + sizeof "Premature end of regular expression")
     gettext_noop ("Regular expression too big") /* REG_ESIZE */
     "\0"
-#define REG_ERPAREN_IDX	(REG_ESIZE_IDX + sizeof "Regular expression too big")
+#define REG_ERPAREN_IDX        (REG_ESIZE_IDX + sizeof "Regular expression too big")
     gettext_noop ("Unmatched ) or \\)") /* REG_ERPAREN */
   };
 
@@ -1230,7 +1230,7 @@ typedef struct
 {
   fail_stack_elt_t *stack;
   unsigned long int size;
-  unsigned long int avail;		/* Offset of next open position.  */
+  unsigned long int avail;                /* Offset of next open position.  */
 } fail_stack_type;
 
 #else /* not INT_IS_16BIT */
@@ -1255,7 +1255,7 @@ typedef struct
 {
   fail_stack_elt_t *stack;
   unsigned size;
-  unsigned avail;			/* Offset of next open position.  */
+  unsigned avail;                        /* Offset of next open position.  */
 } fail_stack_type;
 
 #endif /* INT_IS_16BIT */
@@ -1269,23 +1269,23 @@ typedef struct
    Do `return -2' if the alloc fails.  */
 
 #ifdef MATCH_MAY_ALLOCATE
-# define INIT_FAIL_STACK()						\
-  do {									\
-    fail_stack.stack = (fail_stack_elt_t *)				\
+# define INIT_FAIL_STACK()                                                \
+  do {                                                                        \
+    fail_stack.stack = (fail_stack_elt_t *)                                \
       REGEX_ALLOCATE_STACK (INIT_FAILURE_ALLOC * sizeof (fail_stack_elt_t)); \
-									\
-    if (fail_stack.stack == NULL)					\
-      return -2;							\
-									\
-    fail_stack.size = INIT_FAILURE_ALLOC;				\
-    fail_stack.avail = 0;						\
+                                                                        \
+    if (fail_stack.stack == NULL)                                        \
+      return -2;                                                        \
+                                                                        \
+    fail_stack.size = INIT_FAILURE_ALLOC;                                \
+    fail_stack.avail = 0;                                                \
   } while (0)
 
 # define RESET_FAIL_STACK()  REGEX_FREE_STACK (fail_stack.stack)
 #else
-# define INIT_FAIL_STACK()						\
-  do {									\
-    fail_stack.avail = 0;						\
+# define INIT_FAIL_STACK()                                                \
+  do {                                                                        \
+    fail_stack.avail = 0;                                                \
   } while (0)
 
 # define RESET_FAIL_STACK()
@@ -1299,46 +1299,46 @@ typedef struct
 
    REGEX_REALLOCATE_STACK requires `destination' be declared.   */
 
-#define DOUBLE_FAIL_STACK(fail_stack)					\
-  ((fail_stack).size > (unsigned) (re_max_failures * MAX_FAILURE_ITEMS)	\
-   ? 0									\
-   : ((fail_stack).stack = (fail_stack_elt_t *)				\
-        REGEX_REALLOCATE_STACK ((fail_stack).stack, 			\
-          (fail_stack).size * sizeof (fail_stack_elt_t),		\
-          ((fail_stack).size << 1) * sizeof (fail_stack_elt_t)),	\
-									\
-      (fail_stack).stack == NULL					\
-      ? 0								\
-      : ((fail_stack).size <<= 1, 					\
+#define DOUBLE_FAIL_STACK(fail_stack)                                        \
+  ((fail_stack).size > (unsigned) (re_max_failures * MAX_FAILURE_ITEMS)        \
+   ? 0                                                                        \
+   : ((fail_stack).stack = (fail_stack_elt_t *)                                \
+        REGEX_REALLOCATE_STACK ((fail_stack).stack,                         \
+          (fail_stack).size * sizeof (fail_stack_elt_t),                \
+          ((fail_stack).size << 1) * sizeof (fail_stack_elt_t)),        \
+                                                                        \
+      (fail_stack).stack == NULL                                        \
+      ? 0                                                                \
+      : ((fail_stack).size <<= 1,                                         \
          1)))
 
 
 /* Push pointer POINTER on FAIL_STACK.
    Return 1 if was able to do so and 0 if ran out of memory allocating
    space to do so.  */
-#define PUSH_PATTERN_OP(POINTER, FAIL_STACK)				\
-  ((FAIL_STACK_FULL ()							\
-    && !DOUBLE_FAIL_STACK (FAIL_STACK))					\
-   ? 0									\
-   : ((FAIL_STACK).stack[(FAIL_STACK).avail++].pointer = POINTER,	\
+#define PUSH_PATTERN_OP(POINTER, FAIL_STACK)                                \
+  ((FAIL_STACK_FULL ()                                                        \
+    && !DOUBLE_FAIL_STACK (FAIL_STACK))                                        \
+   ? 0                                                                        \
+   : ((FAIL_STACK).stack[(FAIL_STACK).avail++].pointer = POINTER,        \
       1))
 
 /* Push a pointer value onto the failure stack.
    Assumes the variable `fail_stack'.  Probably should only
    be called from within `PUSH_FAILURE_POINT'.  */
-#define PUSH_FAILURE_POINTER(item)					\
+#define PUSH_FAILURE_POINTER(item)                                        \
   fail_stack.stack[fail_stack.avail++].pointer = (unsigned char *) (item)
 
 /* This pushes an integer-valued item onto the failure stack.
    Assumes the variable `fail_stack'.  Probably should only
    be called from within `PUSH_FAILURE_POINT'.  */
-#define PUSH_FAILURE_INT(item)					\
+#define PUSH_FAILURE_INT(item)                                        \
   fail_stack.stack[fail_stack.avail++].integer = (item)
 
 /* Push a fail_stack_elt_t value onto the failure stack.
    Assumes the variable `fail_stack'.  Probably should only
    be called from within `PUSH_FAILURE_POINT'.  */
-#define PUSH_FAILURE_ELT(item)					\
+#define PUSH_FAILURE_ELT(item)                                        \
   fail_stack.stack[fail_stack.avail++] =  (item)
 
 /* These three POP... operations complement the three PUSH... operations.
@@ -1366,83 +1366,83 @@ typedef struct
 
    Does `return FAILURE_CODE' if runs out of memory.  */
 
-#define PUSH_FAILURE_POINT(pattern_place, string_place, failure_code)	\
-  do {									\
-    char *destination;							\
-    /* Must be int, so when we don't save any registers, the arithmetic	\
-       of 0 + -1 isn't done as unsigned.  */				\
-    /* Can't be int, since there is not a shred of a guarantee that int	\
-       is wide enough to hold a value of something to which pointer can	\
-       be assigned */							\
-    active_reg_t this_reg;						\
-    									\
-    DEBUG_STATEMENT (failure_id++);					\
-    DEBUG_STATEMENT (nfailure_points_pushed++);				\
-    DEBUG_PRINT2 ("\nPUSH_FAILURE_POINT #%u:\n", failure_id);		\
+#define PUSH_FAILURE_POINT(pattern_place, string_place, failure_code)        \
+  do {                                                                        \
+    char *destination;                                                        \
+    /* Must be int, so when we don't save any registers, the arithmetic        \
+       of 0 + -1 isn't done as unsigned.  */                                \
+    /* Can't be int, since there is not a shred of a guarantee that int        \
+       is wide enough to hold a value of something to which pointer can        \
+       be assigned */                                                        \
+    active_reg_t this_reg;                                                \
+                                                                            \
+    DEBUG_STATEMENT (failure_id++);                                        \
+    DEBUG_STATEMENT (nfailure_points_pushed++);                                \
+    DEBUG_PRINT2 ("\nPUSH_FAILURE_POINT #%u:\n", failure_id);                \
     DEBUG_PRINT2 ("  Before push, next avail: %d\n", (fail_stack).avail);\
     DEBUG_PRINT2 ("                     size: %d\n", (fail_stack).size);\
-									\
-    DEBUG_PRINT2 ("  slots needed: %ld\n", NUM_FAILURE_ITEMS);		\
-    DEBUG_PRINT2 ("     available: %d\n", REMAINING_AVAIL_SLOTS);	\
-									\
-    /* Ensure we have enough space allocated for what we will push.  */	\
-    while (REMAINING_AVAIL_SLOTS < NUM_FAILURE_ITEMS)			\
-      {									\
-        if (!DOUBLE_FAIL_STACK (fail_stack))				\
-          return failure_code;						\
-									\
-        DEBUG_PRINT2 ("\n  Doubled stack; size now: %d\n",		\
-		       (fail_stack).size);				\
+                                                                        \
+    DEBUG_PRINT2 ("  slots needed: %ld\n", NUM_FAILURE_ITEMS);                \
+    DEBUG_PRINT2 ("     available: %d\n", REMAINING_AVAIL_SLOTS);        \
+                                                                        \
+    /* Ensure we have enough space allocated for what we will push.  */        \
+    while (REMAINING_AVAIL_SLOTS < NUM_FAILURE_ITEMS)                        \
+      {                                                                        \
+        if (!DOUBLE_FAIL_STACK (fail_stack))                                \
+          return failure_code;                                                \
+                                                                        \
+        DEBUG_PRINT2 ("\n  Doubled stack; size now: %d\n",                \
+                       (fail_stack).size);                                \
         DEBUG_PRINT2 ("  slots available: %d\n", REMAINING_AVAIL_SLOTS);\
-      }									\
-									\
-    /* Push the info, starting with the registers.  */			\
-    DEBUG_PRINT1 ("\n");						\
-									\
-    if (1)								\
+      }                                                                        \
+                                                                        \
+    /* Push the info, starting with the registers.  */                        \
+    DEBUG_PRINT1 ("\n");                                                \
+                                                                        \
+    if (1)                                                                \
       for (this_reg = lowest_active_reg; this_reg <= highest_active_reg; \
-	   this_reg++)							\
-	{								\
-	  DEBUG_PRINT2 ("  Pushing reg: %lu\n", this_reg);		\
-	  DEBUG_STATEMENT (num_regs_pushed++);				\
-									\
-	  DEBUG_PRINT2 ("    start: %p\n", regstart[this_reg]);		\
-	  PUSH_FAILURE_POINTER (regstart[this_reg]);			\
-									\
-	  DEBUG_PRINT2 ("    end: %p\n", regend[this_reg]);		\
-	  PUSH_FAILURE_POINTER (regend[this_reg]);			\
-									\
-	  DEBUG_PRINT2 ("    info: %p\n      ",				\
-			reg_info[this_reg].word.pointer);		\
-	  DEBUG_PRINT2 (" match_null=%d",				\
-			REG_MATCH_NULL_STRING_P (reg_info[this_reg]));	\
-	  DEBUG_PRINT2 (" active=%d", IS_ACTIVE (reg_info[this_reg]));	\
-	  DEBUG_PRINT2 (" matched_something=%d",			\
-			MATCHED_SOMETHING (reg_info[this_reg]));	\
-	  DEBUG_PRINT2 (" ever_matched=%d",				\
-			EVER_MATCHED_SOMETHING (reg_info[this_reg]));	\
-	  DEBUG_PRINT1 ("\n");						\
-	  PUSH_FAILURE_ELT (reg_info[this_reg].word);			\
-	}								\
-									\
+           this_reg++)                                                        \
+        {                                                                \
+          DEBUG_PRINT2 ("  Pushing reg: %lu\n", this_reg);                \
+          DEBUG_STATEMENT (num_regs_pushed++);                                \
+                                                                        \
+          DEBUG_PRINT2 ("    start: %p\n", regstart[this_reg]);                \
+          PUSH_FAILURE_POINTER (regstart[this_reg]);                        \
+                                                                        \
+          DEBUG_PRINT2 ("    end: %p\n", regend[this_reg]);                \
+          PUSH_FAILURE_POINTER (regend[this_reg]);                        \
+                                                                        \
+          DEBUG_PRINT2 ("    info: %p\n      ",                                \
+                        reg_info[this_reg].word.pointer);                \
+          DEBUG_PRINT2 (" match_null=%d",                                \
+                        REG_MATCH_NULL_STRING_P (reg_info[this_reg]));        \
+          DEBUG_PRINT2 (" active=%d", IS_ACTIVE (reg_info[this_reg]));        \
+          DEBUG_PRINT2 (" matched_something=%d",                        \
+                        MATCHED_SOMETHING (reg_info[this_reg]));        \
+          DEBUG_PRINT2 (" ever_matched=%d",                                \
+                        EVER_MATCHED_SOMETHING (reg_info[this_reg]));        \
+          DEBUG_PRINT1 ("\n");                                                \
+          PUSH_FAILURE_ELT (reg_info[this_reg].word);                        \
+        }                                                                \
+                                                                        \
     DEBUG_PRINT2 ("  Pushing  low active reg: %ld\n", lowest_active_reg);\
-    PUSH_FAILURE_INT (lowest_active_reg);				\
-									\
+    PUSH_FAILURE_INT (lowest_active_reg);                                \
+                                                                        \
     DEBUG_PRINT2 ("  Pushing high active reg: %ld\n", highest_active_reg);\
-    PUSH_FAILURE_INT (highest_active_reg);				\
-									\
-    DEBUG_PRINT2 ("  Pushing pattern %p:\n", pattern_place);		\
-    DEBUG_PRINT_COMPILED_PATTERN (bufp, pattern_place, pend);		\
-    PUSH_FAILURE_POINTER (pattern_place);				\
-									\
-    DEBUG_PRINT2 ("  Pushing string %p: `", string_place);		\
+    PUSH_FAILURE_INT (highest_active_reg);                                \
+                                                                        \
+    DEBUG_PRINT2 ("  Pushing pattern %p:\n", pattern_place);                \
+    DEBUG_PRINT_COMPILED_PATTERN (bufp, pattern_place, pend);                \
+    PUSH_FAILURE_POINTER (pattern_place);                                \
+                                                                        \
+    DEBUG_PRINT2 ("  Pushing string %p: `", string_place);                \
     DEBUG_PRINT_DOUBLE_STRING (string_place, string1, size1, string2,   \
-				 size2);				\
-    DEBUG_PRINT1 ("'\n");						\
-    PUSH_FAILURE_POINTER (string_place);				\
-									\
-    DEBUG_PRINT2 ("  Pushing failure id: %u\n", failure_id);		\
-    DEBUG_PUSH (failure_id);						\
+                                 size2);                                \
+    DEBUG_PRINT1 ("'\n");                                                \
+    PUSH_FAILURE_POINTER (string_place);                                \
+                                                                        \
+    DEBUG_PRINT2 ("  Pushing failure id: %u\n", failure_id);                \
+    DEBUG_PUSH (failure_id);                                                \
   } while (0)
 
 /* This is the number of items that are pushed and popped on the stack
@@ -1463,10 +1463,10 @@ typedef struct
 #define MAX_FAILURE_ITEMS (5 * NUM_REG_ITEMS + NUM_NONREG_ITEMS)
 
 /* We actually push this many items.  */
-#define NUM_FAILURE_ITEMS				\
-  (((0							\
-     ? 0 : highest_active_reg - lowest_active_reg + 1)	\
-    * NUM_REG_ITEMS)					\
+#define NUM_FAILURE_ITEMS                                \
+  (((0                                                        \
+     ? 0 : highest_active_reg - lowest_active_reg + 1)        \
+    * NUM_REG_ITEMS)                                        \
    + NUM_NONREG_ITEMS)
 
 /* How many items can still be added to the stack without overflowing it.  */
@@ -1486,73 +1486,73 @@ typedef struct
    `pend', `string1', `size1', `string2', and `size2'.  */
 
 #define POP_FAILURE_POINT(str, pat, low_reg, high_reg, regstart, regend, reg_info)\
-{									\
-  DEBUG_STATEMENT (unsigned failure_id;)				\
-  active_reg_t this_reg;						\
-  const unsigned char *string_temp;					\
-									\
-  assert (!FAIL_STACK_EMPTY ());					\
-									\
-  /* Remove failure points and point to how many regs pushed.  */	\
-  DEBUG_PRINT1 ("POP_FAILURE_POINT:\n");				\
-  DEBUG_PRINT2 ("  Before pop, next avail: %d\n", fail_stack.avail);	\
-  DEBUG_PRINT2 ("                    size: %d\n", fail_stack.size);	\
-									\
-  assert (fail_stack.avail >= NUM_NONREG_ITEMS);			\
-									\
-  DEBUG_POP (&failure_id);						\
-  DEBUG_PRINT2 ("  Popping failure id: %u\n", failure_id);		\
-									\
-  /* If the saved string location is NULL, it came from an		\
-     on_failure_keep_string_jump opcode, and we want to throw away the	\
-     saved NULL, thus retaining our current position in the string.  */	\
-  string_temp = POP_FAILURE_POINTER ();					\
-  if (string_temp != NULL)						\
-    str = (const char *) string_temp;					\
-									\
-  DEBUG_PRINT2 ("  Popping string %p: `", str);				\
-  DEBUG_PRINT_DOUBLE_STRING (str, string1, size1, string2, size2);	\
-  DEBUG_PRINT1 ("'\n");							\
-									\
-  pat = (unsigned char *) POP_FAILURE_POINTER ();			\
-  DEBUG_PRINT2 ("  Popping pattern %p:\n", pat);			\
-  DEBUG_PRINT_COMPILED_PATTERN (bufp, pat, pend);			\
-									\
-  /* Restore register info.  */						\
-  high_reg = (active_reg_t) POP_FAILURE_INT ();				\
-  DEBUG_PRINT2 ("  Popping high active reg: %ld\n", high_reg);		\
-									\
-  low_reg = (active_reg_t) POP_FAILURE_INT ();				\
-  DEBUG_PRINT2 ("  Popping  low active reg: %ld\n", low_reg);		\
-									\
-  if (1)								\
-    for (this_reg = high_reg; this_reg >= low_reg; this_reg--)		\
-      {									\
-	DEBUG_PRINT2 ("    Popping reg: %ld\n", this_reg);		\
-									\
-	reg_info[this_reg].word = POP_FAILURE_ELT ();			\
-	DEBUG_PRINT2 ("      info: %p\n",				\
-		      reg_info[this_reg].word.pointer);			\
-									\
-	regend[this_reg] = (const char *) POP_FAILURE_POINTER ();	\
-	DEBUG_PRINT2 ("      end: %p\n", regend[this_reg]);		\
-									\
-	regstart[this_reg] = (const char *) POP_FAILURE_POINTER ();	\
-	DEBUG_PRINT2 ("      start: %p\n", regstart[this_reg]);		\
-      }									\
-  else									\
-    {									\
+{                                                                        \
+  DEBUG_STATEMENT (unsigned failure_id;)                                \
+  active_reg_t this_reg;                                                \
+  const unsigned char *string_temp;                                        \
+                                                                        \
+  assert (!FAIL_STACK_EMPTY ());                                        \
+                                                                        \
+  /* Remove failure points and point to how many regs pushed.  */        \
+  DEBUG_PRINT1 ("POP_FAILURE_POINT:\n");                                \
+  DEBUG_PRINT2 ("  Before pop, next avail: %d\n", fail_stack.avail);        \
+  DEBUG_PRINT2 ("                    size: %d\n", fail_stack.size);        \
+                                                                        \
+  assert (fail_stack.avail >= NUM_NONREG_ITEMS);                        \
+                                                                        \
+  DEBUG_POP (&failure_id);                                                \
+  DEBUG_PRINT2 ("  Popping failure id: %u\n", failure_id);                \
+                                                                        \
+  /* If the saved string location is NULL, it came from an                \
+     on_failure_keep_string_jump opcode, and we want to throw away the        \
+     saved NULL, thus retaining our current position in the string.  */        \
+  string_temp = POP_FAILURE_POINTER ();                                        \
+  if (string_temp != NULL)                                                \
+    str = (const char *) string_temp;                                        \
+                                                                        \
+  DEBUG_PRINT2 ("  Popping string %p: `", str);                                \
+  DEBUG_PRINT_DOUBLE_STRING (str, string1, size1, string2, size2);        \
+  DEBUG_PRINT1 ("'\n");                                                        \
+                                                                        \
+  pat = (unsigned char *) POP_FAILURE_POINTER ();                        \
+  DEBUG_PRINT2 ("  Popping pattern %p:\n", pat);                        \
+  DEBUG_PRINT_COMPILED_PATTERN (bufp, pat, pend);                        \
+                                                                        \
+  /* Restore register info.  */                                                \
+  high_reg = (active_reg_t) POP_FAILURE_INT ();                                \
+  DEBUG_PRINT2 ("  Popping high active reg: %ld\n", high_reg);                \
+                                                                        \
+  low_reg = (active_reg_t) POP_FAILURE_INT ();                                \
+  DEBUG_PRINT2 ("  Popping  low active reg: %ld\n", low_reg);                \
+                                                                        \
+  if (1)                                                                \
+    for (this_reg = high_reg; this_reg >= low_reg; this_reg--)                \
+      {                                                                        \
+        DEBUG_PRINT2 ("    Popping reg: %ld\n", this_reg);                \
+                                                                        \
+        reg_info[this_reg].word = POP_FAILURE_ELT ();                        \
+        DEBUG_PRINT2 ("      info: %p\n",                                \
+                      reg_info[this_reg].word.pointer);                        \
+                                                                        \
+        regend[this_reg] = (const char *) POP_FAILURE_POINTER ();        \
+        DEBUG_PRINT2 ("      end: %p\n", regend[this_reg]);                \
+                                                                        \
+        regstart[this_reg] = (const char *) POP_FAILURE_POINTER ();        \
+        DEBUG_PRINT2 ("      start: %p\n", regstart[this_reg]);                \
+      }                                                                        \
+  else                                                                        \
+    {                                                                        \
       for (this_reg = highest_active_reg; this_reg > high_reg; this_reg--) \
-	{								\
-	  reg_info[this_reg].word.integer = 0;				\
-	  regend[this_reg] = 0;						\
-	  regstart[this_reg] = 0;					\
-	}								\
-      highest_active_reg = high_reg;					\
-    }									\
-									\
-  set_regs_matched_done = 0;						\
-  DEBUG_STATEMENT (nfailure_points_popped++);				\
+        {                                                                \
+          reg_info[this_reg].word.integer = 0;                                \
+          regend[this_reg] = 0;                                                \
+          regstart[this_reg] = 0;                                        \
+        }                                                                \
+      highest_active_reg = high_reg;                                        \
+    }                                                                        \
+                                                                        \
+  set_regs_matched_done = 0;                                                \
+  DEBUG_STATEMENT (nfailure_points_popped++);                                \
 } /* POP_FAILURE_POINT */
 
 
@@ -1595,21 +1595,21 @@ typedef union
 /* Call this when have matched a real character; it sets `matched' flags
    for the subexpressions which we are currently inside.  Also records
    that those subexprs have matched.  */
-#define SET_REGS_MATCHED()						\
-  do									\
-    {									\
-      if (!set_regs_matched_done)					\
-	{								\
-	  active_reg_t r;						\
-	  set_regs_matched_done = 1;					\
-	  for (r = lowest_active_reg; r <= highest_active_reg; r++)	\
-	    {								\
-	      MATCHED_SOMETHING (reg_info[r])				\
-		= EVER_MATCHED_SOMETHING (reg_info[r])			\
-		= 1;							\
-	    }								\
-	}								\
-    }									\
+#define SET_REGS_MATCHED()                                                \
+  do                                                                        \
+    {                                                                        \
+      if (!set_regs_matched_done)                                        \
+        {                                                                \
+          active_reg_t r;                                                \
+          set_regs_matched_done = 1;                                        \
+          for (r = lowest_active_reg; r <= highest_active_reg; r++)        \
+            {                                                                \
+              MATCHED_SOMETHING (reg_info[r])                                \
+                = EVER_MATCHED_SOMETHING (reg_info[r])                        \
+                = 1;                                                        \
+            }                                                                \
+        }                                                                \
+    }                                                                        \
   while (0)
 
 /* Registers are set to a sentinel when they haven't yet matched.  */
@@ -1620,43 +1620,43 @@ static char reg_unset_dummy;
 /* Subroutine declarations and macros for regex_compile.  */
 
 static reg_errcode_t regex_compile _RE_ARGS ((const char *pattern, size_t size,
-					      reg_syntax_t syntax,
-					      struct re_pattern_buffer *bufp));
+                                              reg_syntax_t syntax,
+                                              struct re_pattern_buffer *bufp));
 static void store_op1 _RE_ARGS ((re_opcode_t op, unsigned char *loc, int arg));
 static void store_op2 _RE_ARGS ((re_opcode_t op, unsigned char *loc,
-				 int arg1, int arg2));
+                                 int arg1, int arg2));
 static void insert_op1 _RE_ARGS ((re_opcode_t op, unsigned char *loc,
-				  int arg, unsigned char *end));
+                                  int arg, unsigned char *end));
 static void insert_op2 _RE_ARGS ((re_opcode_t op, unsigned char *loc,
-				  int arg1, int arg2, unsigned char *end));
+                                  int arg1, int arg2, unsigned char *end));
 static boolean at_begline_loc_p _RE_ARGS ((const char *pattern, const char *p,
-					   reg_syntax_t syntax));
+                                           reg_syntax_t syntax));
 static boolean at_endline_loc_p _RE_ARGS ((const char *p, const char *pend,
-					   reg_syntax_t syntax));
+                                           reg_syntax_t syntax));
 static reg_errcode_t compile_range _RE_ARGS ((unsigned int range_start,
-					      const char **p_ptr,
-					      const char *pend,
-					      char *translate,
-					      reg_syntax_t syntax,
-					      unsigned char *b));
+                                              const char **p_ptr,
+                                              const char *pend,
+                                              char *translate,
+                                              reg_syntax_t syntax,
+                                              unsigned char *b));
 
 /* Fetch the next character in the uncompiled pattern---translating it
    if necessary.  Also cast from a signed character in the constant
    string passed to us by the user to an unsigned char that we can use
    as an array index (in, e.g., `translate').  */
 #ifndef PATFETCH
-# define PATFETCH(c)							\
-  do {if (p == pend) return REG_EEND;					\
-    c = (unsigned char) *p++;						\
-    if (translate) c = (unsigned char) translate[c];			\
+# define PATFETCH(c)                                                        \
+  do {if (p == pend) return REG_EEND;                                        \
+    c = (unsigned char) *p++;                                                \
+    if (translate) c = (unsigned char) translate[c];                        \
   } while (0)
 #endif
 
 /* Fetch the next character in the uncompiled pattern, with no
    translation.  */
-#define PATFETCH_RAW(c)							\
-  do {if (p == pend) return REG_EEND;					\
-    c = (unsigned char) *p++; 						\
+#define PATFETCH_RAW(c)                                                        \
+  do {if (p == pend) return REG_EEND;                                        \
+    c = (unsigned char) *p++;                                                 \
   } while (0)
 
 /* Go backwards one character in the pattern.  */
@@ -1679,34 +1679,34 @@ static reg_errcode_t compile_range _RE_ARGS ((unsigned int range_start,
 #define INIT_BUF_SIZE  32
 
 /* Make sure we have at least N more bytes of space in buffer.  */
-#define GET_BUFFER_SPACE(n)						\
-    while ((unsigned long) (b - bufp->buffer + (n)) > bufp->allocated)	\
+#define GET_BUFFER_SPACE(n)                                                \
+    while ((unsigned long) (b - bufp->buffer + (n)) > bufp->allocated)        \
       EXTEND_BUFFER ()
 
 /* Make sure we have one more byte of buffer space and then add C to it.  */
-#define BUF_PUSH(c)							\
-  do {									\
-    GET_BUFFER_SPACE (1);						\
-    *b++ = (unsigned char) (c);						\
+#define BUF_PUSH(c)                                                        \
+  do {                                                                        \
+    GET_BUFFER_SPACE (1);                                                \
+    *b++ = (unsigned char) (c);                                                \
   } while (0)
 
 
 /* Ensure we have two more bytes of buffer space and then append C1 and C2.  */
-#define BUF_PUSH_2(c1, c2)						\
-  do {									\
-    GET_BUFFER_SPACE (2);						\
-    *b++ = (unsigned char) (c1);					\
-    *b++ = (unsigned char) (c2);					\
+#define BUF_PUSH_2(c1, c2)                                                \
+  do {                                                                        \
+    GET_BUFFER_SPACE (2);                                                \
+    *b++ = (unsigned char) (c1);                                        \
+    *b++ = (unsigned char) (c2);                                        \
   } while (0)
 
 
 /* As with BUF_PUSH_2, except for three bytes.  */
-#define BUF_PUSH_3(c1, c2, c3)						\
-  do {									\
-    GET_BUFFER_SPACE (3);						\
-    *b++ = (unsigned char) (c1);					\
-    *b++ = (unsigned char) (c2);					\
-    *b++ = (unsigned char) (c3);					\
+#define BUF_PUSH_3(c1, c2, c3)                                                \
+  do {                                                                        \
+    GET_BUFFER_SPACE (3);                                                \
+    *b++ = (unsigned char) (c1);                                        \
+    *b++ = (unsigned char) (c2);                                        \
+    *b++ = (unsigned char) (c3);                                        \
   } while (0)
 
 
@@ -1755,47 +1755,47 @@ static reg_errcode_t compile_range _RE_ARGS ((unsigned int range_start,
 # define SET_HIGH_BOUND(P) (__ptrhigh (P) = __ptrlow (P) + bufp->allocated)
 # define MOVE_BUFFER_POINTER(P) \
   (__ptrlow (P) += incr, SET_HIGH_BOUND (P), __ptrvalue (P) += incr)
-# define ELSE_EXTEND_BUFFER_HIGH_BOUND		\
-  else						\
-    {						\
-      SET_HIGH_BOUND (b);			\
-      SET_HIGH_BOUND (begalt);			\
-      if (fixup_alt_jump)			\
-	SET_HIGH_BOUND (fixup_alt_jump);	\
-      if (laststart)				\
-	SET_HIGH_BOUND (laststart);		\
-      if (pending_exact)			\
-	SET_HIGH_BOUND (pending_exact);		\
+# define ELSE_EXTEND_BUFFER_HIGH_BOUND                \
+  else                                                \
+    {                                                \
+      SET_HIGH_BOUND (b);                        \
+      SET_HIGH_BOUND (begalt);                        \
+      if (fixup_alt_jump)                        \
+        SET_HIGH_BOUND (fixup_alt_jump);        \
+      if (laststart)                                \
+        SET_HIGH_BOUND (laststart);                \
+      if (pending_exact)                        \
+        SET_HIGH_BOUND (pending_exact);                \
     }
 #else
 # define MOVE_BUFFER_POINTER(P) (P) += incr
 # define ELSE_EXTEND_BUFFER_HIGH_BOUND
 #endif
-#define EXTEND_BUFFER()							\
-  do {									\
-    unsigned char *old_buffer = bufp->buffer;				\
-    if (bufp->allocated == MAX_BUF_SIZE)				\
-      return REG_ESIZE;							\
-    bufp->allocated <<= 1;						\
-    if (bufp->allocated > MAX_BUF_SIZE)					\
-      bufp->allocated = MAX_BUF_SIZE;					\
+#define EXTEND_BUFFER()                                                        \
+  do {                                                                        \
+    unsigned char *old_buffer = bufp->buffer;                                \
+    if (bufp->allocated == MAX_BUF_SIZE)                                \
+      return REG_ESIZE;                                                        \
+    bufp->allocated <<= 1;                                                \
+    if (bufp->allocated > MAX_BUF_SIZE)                                        \
+      bufp->allocated = MAX_BUF_SIZE;                                        \
     bufp->buffer = (unsigned char *) REALLOC (bufp->buffer, bufp->allocated);\
-    if (bufp->buffer == NULL)						\
-      return REG_ESPACE;						\
-    /* If the buffer moved, move all the pointers into it.  */		\
-    if (old_buffer != bufp->buffer)					\
-      {									\
-	int incr = bufp->buffer - old_buffer;				\
-	MOVE_BUFFER_POINTER (b);					\
-	MOVE_BUFFER_POINTER (begalt);					\
-	if (fixup_alt_jump)						\
-	  MOVE_BUFFER_POINTER (fixup_alt_jump);				\
-	if (laststart)							\
-	  MOVE_BUFFER_POINTER (laststart);				\
-	if (pending_exact)						\
-	  MOVE_BUFFER_POINTER (pending_exact);				\
-      }									\
-    ELSE_EXTEND_BUFFER_HIGH_BOUND					\
+    if (bufp->buffer == NULL)                                                \
+      return REG_ESPACE;                                                \
+    /* If the buffer moved, move all the pointers into it.  */                \
+    if (old_buffer != bufp->buffer)                                        \
+      {                                                                        \
+        int incr = bufp->buffer - old_buffer;                                \
+        MOVE_BUFFER_POINTER (b);                                        \
+        MOVE_BUFFER_POINTER (begalt);                                        \
+        if (fixup_alt_jump)                                                \
+          MOVE_BUFFER_POINTER (fixup_alt_jump);                                \
+        if (laststart)                                                        \
+          MOVE_BUFFER_POINTER (laststart);                                \
+        if (pending_exact)                                                \
+          MOVE_BUFFER_POINTER (pending_exact);                                \
+      }                                                                        \
+    ELSE_EXTEND_BUFFER_HIGH_BOUND                                        \
   } while (0)
 
 
@@ -1830,7 +1830,7 @@ typedef struct
 {
   compile_stack_elt_t *stack;
   unsigned size;
-  unsigned avail;			/* Offset of next open position.  */
+  unsigned avail;                        /* Offset of next open position.  */
 } compile_stack_type;
 
 
@@ -1850,20 +1850,20 @@ typedef struct
 
 
 /* Get the next unsigned number in the uncompiled pattern.  */
-#define GET_UNSIGNED_NUMBER(num) 					\
-  { if (p != pend)							\
-     {									\
-       PATFETCH (c); 							\
-       while ('0' <= c && c <= '9')					\
-         { 								\
-           if (num < 0)							\
-              num = 0;							\
-           num = num * 10 + c - '0'; 					\
-           if (p == pend) 						\
-              break; 							\
-           PATFETCH (c);						\
-         } 								\
-       } 								\
+#define GET_UNSIGNED_NUMBER(num)                                         \
+  { if (p != pend)                                                        \
+     {                                                                        \
+       PATFETCH (c);                                                         \
+       while ('0' <= c && c <= '9')                                        \
+         {                                                                 \
+           if (num < 0)                                                        \
+              num = 0;                                                        \
+           num = num * 10 + c - '0';                                         \
+           if (p == pend)                                                 \
+              break;                                                         \
+           PATFETCH (c);                                                \
+         }                                                                 \
+       }                                                                 \
     }
 
 #if defined _LIBC || WIDE_CHAR_SUPPORT
@@ -1885,12 +1885,12 @@ typedef struct
 #else
 # define CHAR_CLASS_MAX_LENGTH  6 /* Namely, `xdigit'.  */
 
-# define IS_CHAR_CLASS(string)						\
-   (STREQ (string, "alpha") || STREQ (string, "upper")			\
-    || STREQ (string, "lower") || STREQ (string, "digit")		\
-    || STREQ (string, "alnum") || STREQ (string, "xdigit")		\
-    || STREQ (string, "space") || STREQ (string, "print")		\
-    || STREQ (string, "punct") || STREQ (string, "graph")		\
+# define IS_CHAR_CLASS(string)                                                \
+   (STREQ (string, "alpha") || STREQ (string, "upper")                        \
+    || STREQ (string, "lower") || STREQ (string, "digit")                \
+    || STREQ (string, "alnum") || STREQ (string, "xdigit")                \
+    || STREQ (string, "space") || STREQ (string, "print")                \
+    || STREQ (string, "punct") || STREQ (string, "graph")                \
     || STREQ (string, "cntrl") || STREQ (string, "blank"))
 #endif
 
@@ -1926,14 +1926,14 @@ regex_grow_registers (num_regs)
 {
   if (num_regs > regs_allocated_size)
     {
-      RETALLOC_IF (regstart,	 num_regs, const char *);
-      RETALLOC_IF (regend,	 num_regs, const char *);
+      RETALLOC_IF (regstart,         num_regs, const char *);
+      RETALLOC_IF (regend,         num_regs, const char *);
       RETALLOC_IF (old_regstart, num_regs, const char *);
-      RETALLOC_IF (old_regend,	 num_regs, const char *);
+      RETALLOC_IF (old_regend,         num_regs, const char *);
       RETALLOC_IF (best_regstart, num_regs, const char *);
-      RETALLOC_IF (best_regend,	 num_regs, const char *);
-      RETALLOC_IF (reg_info,	 num_regs, register_info_type);
-      RETALLOC_IF (reg_dummy,	 num_regs, const char *);
+      RETALLOC_IF (best_regend,         num_regs, const char *);
+      RETALLOC_IF (reg_info,         num_regs, register_info_type);
+      RETALLOC_IF (reg_dummy,         num_regs, const char *);
       RETALLOC_IF (reg_info_dummy, num_regs, register_info_type);
 
       regs_allocated_size = num_regs;
@@ -1943,8 +1943,8 @@ regex_grow_registers (num_regs)
 #endif /* not MATCH_MAY_ALLOCATE */
 
 static boolean group_in_compile_stack _RE_ARGS ((compile_stack_type
-						 compile_stack,
-						 regnum_t regnum));
+                                                 compile_stack,
+                                                 regnum_t regnum));
 
 /* `regex_compile' compiles PATTERN (of length SIZE) according to SYNTAX.
    Returns one of error codes defined in `regex.h', or zero for success.
@@ -1965,7 +1965,7 @@ static boolean group_in_compile_stack _RE_ARGS ((compile_stack_type
    examined nor set.  */
 
 /* Return, freeing storage we allocated.  */
-#define FREE_STACK_RETURN(value)		\
+#define FREE_STACK_RETURN(value)                \
   return (free (compile_stack.stack), value)
 
 static reg_errcode_t
@@ -2065,7 +2065,7 @@ regex_compile (pattern, size, syntax, bufp)
   if (bufp->allocated == 0)
     {
       if (bufp->buffer)
-	{ /* If zero allocated, but buffer is non-null, try to realloc
+        { /* If zero allocated, but buffer is non-null, try to realloc
              enough space.  This loses if buffer's address is bogus, but
              that is the user's responsibility.  */
           RETALLOC (bufp->buffer, INIT_BUF_SIZE, unsigned char);
@@ -2118,7 +2118,7 @@ regex_compile (pattern, size, syntax, bufp)
            break;
 
 
-	case '+':
+        case '+':
         case '?':
           if ((syntax & RE_BK_PLUS_QM)
               || (syntax & RE_LIMITED_OPS))
@@ -2212,7 +2212,7 @@ regex_compile (pattern, size, syntax, bufp)
                    the `*'.  Do we have to do something analogous here
                    for null bytes, because of RE_DOT_NOT_NULL?  */
                 if (TRANSLATE (*(p - 2)) == TRANSLATE ('.')
-		    && zero_times_ok
+                    && zero_times_ok
                     && p < pend && TRANSLATE (*p) == TRANSLATE ('\n')
                     && !(syntax & RE_DOT_NEWLINE))
                   { /* We have .*\n.  */
@@ -2248,10 +2248,10 @@ regex_compile (pattern, size, syntax, bufp)
                 b += 3;
               }
             }
-	  break;
+          break;
 
 
-	case '.':
+        case '.':
           laststart = b;
           BUF_PUSH (anychar);
           break;
@@ -2260,13 +2260,13 @@ regex_compile (pattern, size, syntax, bufp)
         case '[':
           {
             boolean had_char_class = false;
-	    unsigned int range_start = 0xffffffff;
+            unsigned int range_start = 0xffffffff;
 
             if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
 
             /* Ensure that we have enough space to push a charset: the
                opcode, the length count, and the bitset; 34 bytes in all.  */
-	    GET_BUFFER_SPACE (34);
+            GET_BUFFER_SPACE (34);
 
             laststart = b;
 
@@ -2304,7 +2304,7 @@ regex_compile (pattern, size, syntax, bufp)
 
                     PATFETCH (c1);
                     SET_LIST_BIT (c1);
-		    range_start = c1;
+                    range_start = c1;
                     continue;
                   }
 
@@ -2330,21 +2330,21 @@ regex_compile (pattern, size, syntax, bufp)
                   {
                     reg_errcode_t ret
                       = compile_range (range_start, &p, pend, translate,
-				       syntax, b);
+                                       syntax, b);
                     if (ret != REG_NOERROR) FREE_STACK_RETURN (ret);
-		    range_start = 0xffffffff;
+                    range_start = 0xffffffff;
                   }
 
                 else if (p[0] == '-' && p[1] != ']')
                   { /* This handles ranges made up of characters only.  */
                     reg_errcode_t ret;
 
-		    /* Move past the `-'.  */
+                    /* Move past the `-'.  */
                     PATFETCH (c1);
 
                     ret = compile_range (c, &p, pend, translate, syntax, b);
                     if (ret != REG_NOERROR) FREE_STACK_RETURN (ret);
-		    range_start = 0xffffffff;
+                    range_start = 0xffffffff;
                   }
 
                 /* See if we're at the beginning of a possible character
@@ -2365,11 +2365,11 @@ regex_compile (pattern, size, syntax, bufp)
                         PATFETCH (c);
                         if ((c == ':' && *p == ']') || p == pend)
                           break;
-			if (c1 < CHAR_CLASS_MAX_LENGTH)
-			  str[c1++] = c;
-			else
-			  /* This is in any case an invalid class name.  */
-			  str[0] = '\0';
+                        if (c1 < CHAR_CLASS_MAX_LENGTH)
+                          str[c1++] = c;
+                        else
+                          /* This is in any case an invalid class name.  */
+                          str[0] = '\0';
                       }
                     str[c1] = '\0';
 
@@ -2381,12 +2381,12 @@ regex_compile (pattern, size, syntax, bufp)
 #if defined _LIBC || WIDE_CHAR_SUPPORT
                         boolean is_lower = STREQ (str, "lower");
                         boolean is_upper = STREQ (str, "upper");
-			wctype_t wt;
+                        wctype_t wt;
                         int ch;
 
-			wt = IS_CHAR_CLASS (str);
-			if (wt == 0)
-			  FREE_STACK_RETURN (REG_ECTYPE);
+                        wt = IS_CHAR_CLASS (str);
+                        if (wt == 0)
+                          FREE_STACK_RETURN (REG_ECTYPE);
 
                         /* Throw away the ] at the end of the character
                            class.  */
@@ -2395,19 +2395,19 @@ regex_compile (pattern, size, syntax, bufp)
                         if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
 
                         for (ch = 0; ch < 1 << BYTEWIDTH; ++ch)
-			  {
+                          {
 # ifdef _LIBC
-			    if (__iswctype (__btowc (ch), wt))
-			      SET_LIST_BIT (ch);
+                            if (__iswctype (__btowc (ch), wt))
+                              SET_LIST_BIT (ch);
 # else
-			    if (iswctype (btowc (ch), wt))
-			      SET_LIST_BIT (ch);
+                            if (iswctype (btowc (ch), wt))
+                              SET_LIST_BIT (ch);
 # endif
 
-			    if (translate && (is_upper || is_lower)
-				&& (ISUPPER (ch) || ISLOWER (ch)))
-			      SET_LIST_BIT (ch);
-			  }
+                            if (translate && (is_upper || is_lower)
+                                && (ISUPPER (ch) || ISLOWER (ch)))
+                              SET_LIST_BIT (ch);
+                          }
 
                         had_char_class = true;
 #else
@@ -2426,7 +2426,7 @@ regex_compile (pattern, size, syntax, bufp)
                         boolean is_xdigit = STREQ (str, "xdigit");
 
                         if (!IS_CHAR_CLASS (str))
-			  FREE_STACK_RETURN (REG_ECTYPE);
+                          FREE_STACK_RETURN (REG_ECTYPE);
 
                         /* Throw away the ] at the end of the character
                            class.  */
@@ -2436,29 +2436,29 @@ regex_compile (pattern, size, syntax, bufp)
 
                         for (ch = 0; ch < 1 << BYTEWIDTH; ch++)
                           {
-			    /* This was split into 3 if's to
-			       avoid an arbitrary limit in some compiler.  */
+                            /* This was split into 3 if's to
+                               avoid an arbitrary limit in some compiler.  */
                             if (   (is_alnum  && ISALNUM (ch))
                                 || (is_alpha  && ISALPHA (ch))
                                 || (is_blank  && ISBLANK (ch))
                                 || (is_cntrl  && ISCNTRL (ch)))
-			      SET_LIST_BIT (ch);
-			    if (   (is_digit  && ISDIGIT (ch))
+                              SET_LIST_BIT (ch);
+                            if (   (is_digit  && ISDIGIT (ch))
                                 || (is_graph  && ISGRAPH (ch))
                                 || (is_lower  && ISLOWER (ch))
                                 || (is_print  && ISPRINT (ch)))
-			      SET_LIST_BIT (ch);
-			    if (   (is_punct  && ISPUNCT (ch))
+                              SET_LIST_BIT (ch);
+                            if (   (is_punct  && ISPUNCT (ch))
                                 || (is_space  && ISSPACE (ch))
                                 || (is_upper  && ISUPPER (ch))
                                 || (is_xdigit && ISXDIGIT (ch)))
-			      SET_LIST_BIT (ch);
-			    if (   translate && (is_upper || is_lower)
-				&& (ISUPPER (ch) || ISLOWER (ch)))
-			      SET_LIST_BIT (ch);
+                              SET_LIST_BIT (ch);
+                            if (   translate && (is_upper || is_lower)
+                                && (ISUPPER (ch) || ISLOWER (ch)))
+                              SET_LIST_BIT (ch);
                           }
                         had_char_class = true;
-#endif	/* libc || wctype.h */
+#endif        /* libc || wctype.h */
                       }
                     else
                       {
@@ -2467,133 +2467,133 @@ regex_compile (pattern, size, syntax, bufp)
                           PATUNFETCH;
                         SET_LIST_BIT ('[');
                         SET_LIST_BIT (':');
-			range_start = ':';
+                        range_start = ':';
                         had_char_class = false;
                       }
                   }
                 else if (syntax & RE_CHAR_CLASSES && c == '[' && *p == '=')
-		  {
-		    unsigned char str[MB_LEN_MAX + 1];
+                  {
+                    unsigned char str[MB_LEN_MAX + 1];
 #ifdef _LIBC
-		    uint32_t nrules =
-		      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
+                    uint32_t nrules =
+                      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
 #endif
 
-		    PATFETCH (c);
-		    c1 = 0;
+                    PATFETCH (c);
+                    c1 = 0;
 
-		    /* If pattern is `[[='.  */
-		    if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
+                    /* If pattern is `[[='.  */
+                    if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
 
-		    for (;;)
-		      {
-			PATFETCH (c);
-			if ((c == '=' && *p == ']') || p == pend)
-			  break;
-			if (c1 < MB_LEN_MAX)
-			  str[c1++] = c;
-			else
-			  /* This is in any case an invalid class name.  */
-			  str[0] = '\0';
+                    for (;;)
+                      {
+                        PATFETCH (c);
+                        if ((c == '=' && *p == ']') || p == pend)
+                          break;
+                        if (c1 < MB_LEN_MAX)
+                          str[c1++] = c;
+                        else
+                          /* This is in any case an invalid class name.  */
+                          str[0] = '\0';
                       }
-		    str[c1] = '\0';
+                    str[c1] = '\0';
 
-		    if (c == '=' && *p == ']' && str[0] != '\0')
-		      {
-			/* If we have no collation data we use the default
-			   collation in which each character is in a class
-			   by itself.  It also means that ASCII is the
-			   character set and therefore we cannot have character
-			   with more than one byte in the multibyte
-			   representation.  */
+                    if (c == '=' && *p == ']' && str[0] != '\0')
+                      {
+                        /* If we have no collation data we use the default
+                           collation in which each character is in a class
+                           by itself.  It also means that ASCII is the
+                           character set and therefore we cannot have character
+                           with more than one byte in the multibyte
+                           representation.  */
 #ifdef _LIBC
-			if (nrules == 0)
+                        if (nrules == 0)
 #endif
-			  {
-			    if (c1 != 1)
-			      FREE_STACK_RETURN (REG_ECOLLATE);
+                          {
+                            if (c1 != 1)
+                              FREE_STACK_RETURN (REG_ECOLLATE);
 
-			    /* Throw away the ] at the end of the equivalence
-			       class.  */
-			    PATFETCH (c);
+                            /* Throw away the ] at the end of the equivalence
+                               class.  */
+                            PATFETCH (c);
 
-			    /* Set the bit for the character.  */
-			    SET_LIST_BIT (str[0]);
-			  }
+                            /* Set the bit for the character.  */
+                            SET_LIST_BIT (str[0]);
+                          }
 #ifdef _LIBC
-			else
-			  {
-			    /* Try to match the byte sequence in `str' against
-			       those known to the collate implementation.
-			       First find out whether the bytes in `str' are
-			       actually from exactly one character.  */
-			    const int32_t *table;
-			    const unsigned char *weights;
-			    const unsigned char *extra;
-			    const int32_t *indirect;
-			    int32_t idx;
-			    const unsigned char *cp = str;
-			    int ch;
+                        else
+                          {
+                            /* Try to match the byte sequence in `str' against
+                               those known to the collate implementation.
+                               First find out whether the bytes in `str' are
+                               actually from exactly one character.  */
+                            const int32_t *table;
+                            const unsigned char *weights;
+                            const unsigned char *extra;
+                            const int32_t *indirect;
+                            int32_t idx;
+                            const unsigned char *cp = str;
+                            int ch;
 
-			    /* This #include defines a local function!  */
+                            /* This #include defines a local function!  */
 # include <locale/weight.h>
 
-			    table = (const int32_t *)
-			      _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEMB);
-			    weights = (const unsigned char *)
-			      _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTMB);
-			    extra = (const unsigned char *)
-			      _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAMB);
-			    indirect = (const int32_t *)
-			      _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTMB);
+                            table = (const int32_t *)
+                              _NL_CURRENT (LC_COLLATE, _NL_COLLATE_TABLEMB);
+                            weights = (const unsigned char *)
+                              _NL_CURRENT (LC_COLLATE, _NL_COLLATE_WEIGHTMB);
+                            extra = (const unsigned char *)
+                              _NL_CURRENT (LC_COLLATE, _NL_COLLATE_EXTRAMB);
+                            indirect = (const int32_t *)
+                              _NL_CURRENT (LC_COLLATE, _NL_COLLATE_INDIRECTMB);
 
-			    idx = findidx (&cp);
-			    if (idx == 0 || cp < str + c1)
-			      /* This is no valid character.  */
-			      FREE_STACK_RETURN (REG_ECOLLATE);
+                            idx = findidx (&cp);
+                            if (idx == 0 || cp < str + c1)
+                              /* This is no valid character.  */
+                              FREE_STACK_RETURN (REG_ECOLLATE);
 
-			    /* Throw away the ] at the end of the equivalence
-			       class.  */
-			    PATFETCH (c);
+                            /* Throw away the ] at the end of the equivalence
+                               class.  */
+                            PATFETCH (c);
 
-			    /* Now we have to go throught the whole table
-			       and find all characters which have the same
-			       first level weight.
+                            /* Now we have to go throught the whole table
+                               and find all characters which have the same
+                               first level weight.
 
-			       XXX Note that this is not entirely correct.
-			       we would have to match multibyte sequences
-			       but this is not possible with the current
-			       implementation.  */
-			    for (ch = 1; ch < 256; ++ch)
-			      /* XXX This test would have to be changed if we
-				 would allow matching multibyte sequences.  */
-			      if (table[ch] > 0)
-				{
-				  int32_t idx2 = table[ch];
-				  size_t len = weights[idx2];
+                               XXX Note that this is not entirely correct.
+                               we would have to match multibyte sequences
+                               but this is not possible with the current
+                               implementation.  */
+                            for (ch = 1; ch < 256; ++ch)
+                              /* XXX This test would have to be changed if we
+                                 would allow matching multibyte sequences.  */
+                              if (table[ch] > 0)
+                                {
+                                  int32_t idx2 = table[ch];
+                                  size_t len = weights[idx2];
 
-				  /* Test whether the lenghts match.  */
-				  if (weights[idx] == len)
-				    {
-				      /* They do.  New compare the bytes of
-					 the weight.  */
-				      size_t cnt = 0;
+                                  /* Test whether the lenghts match.  */
+                                  if (weights[idx] == len)
+                                    {
+                                      /* They do.  New compare the bytes of
+                                         the weight.  */
+                                      size_t cnt = 0;
 
-				      while (cnt < len
-					     && (weights[idx + 1 + cnt]
-						 == weights[idx2 + 1 + cnt]))
-					++len;
+                                      while (cnt < len
+                                             && (weights[idx + 1 + cnt]
+                                                 == weights[idx2 + 1 + cnt]))
+                                        ++len;
 
-				      if (cnt == len)
-					/* They match.  Mark the character as
-					   acceptable.  */
-					SET_LIST_BIT (ch);
-				    }
-				}
-			  }
+                                      if (cnt == len)
+                                        /* They match.  Mark the character as
+                                           acceptable.  */
+                                        SET_LIST_BIT (ch);
+                                    }
+                                }
+                          }
 #endif
-			had_char_class = true;
-		      }
+                        had_char_class = true;
+                      }
                     else
                       {
                         c1++;
@@ -2601,142 +2601,142 @@ regex_compile (pattern, size, syntax, bufp)
                           PATUNFETCH;
                         SET_LIST_BIT ('[');
                         SET_LIST_BIT ('=');
-			range_start = '=';
+                        range_start = '=';
                         had_char_class = false;
                       }
-		  }
+                  }
                 else if (syntax & RE_CHAR_CLASSES && c == '[' && *p == '.')
-		  {
-		    unsigned char str[128];	/* Should be large enough.  */
+                  {
+                    unsigned char str[128];        /* Should be large enough.  */
 #ifdef _LIBC
-		    uint32_t nrules =
-		      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
+                    uint32_t nrules =
+                      _NL_CURRENT_WORD (LC_COLLATE, _NL_COLLATE_NRULES);
 #endif
 
-		    PATFETCH (c);
-		    c1 = 0;
+                    PATFETCH (c);
+                    c1 = 0;
 
-		    /* If pattern is `[[='.  */
-		    if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
+                    /* If pattern is `[[='.  */
+                    if (p == pend) FREE_STACK_RETURN (REG_EBRACK);
 
-		    for (;;)
-		      {
-			PATFETCH (c);
-			if ((c == '.' && *p == ']') || p == pend)
-			  break;
-			if (c1 < sizeof (str))
-			  str[c1++] = c;
-			else
-			  /* This is in any case an invalid class name.  */
-			  str[0] = '\0';
+                    for (;;)
+                      {
+                        PATFETCH (c);
+                        if ((c == '.' && *p == ']') || p == pend)
+                          break;
+                        if (c1 < sizeof (str))
+                          str[c1++] = c;
+                        else
+                          /* This is in any case an invalid class name.  */
+                          str[0] = '\0';
                       }
-		    str[c1] = '\0';
+                    str[c1] = '\0';
 
-		    if (c == '.' && *p == ']' && str[0] != '\0')
-		      {
-			/* If we have no collation data we use the default
-			   collation in which each character is the name
-			   for its own class which contains only the one
-			   character.  It also means that ASCII is the
-			   character set and therefore we cannot have character
-			   with more than one byte in the multibyte
-			   representation.  */
+                    if (c == '.' && *p == ']' && str[0] != '\0')
+                      {
+                        /* If we have no collation data we use the default
+                           collation in which each character is the name
+                           for its own class which contains only the one
+                           character.  It also means that ASCII is the
+                           character set and therefore we cannot have character
+                           with more than one byte in the multibyte
+                           representation.  */
 #ifdef _LIBC
-			if (nrules == 0)
+                        if (nrules == 0)
 #endif
-			  {
-			    if (c1 != 1)
-			      FREE_STACK_RETURN (REG_ECOLLATE);
+                          {
+                            if (c1 != 1)
+                              FREE_STACK_RETURN (REG_ECOLLATE);
 
-			    /* Throw away the ] at the end of the equivalence
-			       class.  */
-			    PATFETCH (c);
+                            /* Throw away the ] at the end of the equivalence
+                               class.  */
+                            PATFETCH (c);
 
-			    /* Set the bit for the character.  */
-			    SET_LIST_BIT (str[0]);
-			    range_start = ((const unsigned char *) str)[0];
-			  }
+                            /* Set the bit for the character.  */
+                            SET_LIST_BIT (str[0]);
+                            range_start = ((const unsigned char *) str)[0];
+                          }
 #ifdef _LIBC
-			else
-			  {
-			    /* Try to match the byte sequence in `str' against
-			       those known to the collate implementation.
-			       First find out whether the bytes in `str' are
-			       actually from exactly one character.  */
-			    int32_t table_size;
-			    const int32_t *symb_table;
-			    const unsigned char *extra;
-			    int32_t idx;
-			    int32_t elem;
-			    int32_t second;
-			    int32_t hash;
+                        else
+                          {
+                            /* Try to match the byte sequence in `str' against
+                               those known to the collate implementation.
+                               First find out whether the bytes in `str' are
+                               actually from exactly one character.  */
+                            int32_t table_size;
+                            const int32_t *symb_table;
+                            const unsigned char *extra;
+                            int32_t idx;
+                            int32_t elem;
+                            int32_t second;
+                            int32_t hash;
 
-			    table_size =
-			      _NL_CURRENT_WORD (LC_COLLATE,
-						_NL_COLLATE_SYMB_HASH_SIZEMB);
-			    symb_table = (const int32_t *)
-			      _NL_CURRENT (LC_COLLATE,
-					   _NL_COLLATE_SYMB_TABLEMB);
-			    extra = (const unsigned char *)
-			      _NL_CURRENT (LC_COLLATE,
-					   _NL_COLLATE_SYMB_EXTRAMB);
+                            table_size =
+                              _NL_CURRENT_WORD (LC_COLLATE,
+                                                _NL_COLLATE_SYMB_HASH_SIZEMB);
+                            symb_table = (const int32_t *)
+                              _NL_CURRENT (LC_COLLATE,
+                                           _NL_COLLATE_SYMB_TABLEMB);
+                            extra = (const unsigned char *)
+                              _NL_CURRENT (LC_COLLATE,
+                                           _NL_COLLATE_SYMB_EXTRAMB);
 
-			    /* Locate the character in the hashing table.  */
-			    hash = elem_hash (str, c1);
+                            /* Locate the character in the hashing table.  */
+                            hash = elem_hash (str, c1);
 
-			    idx = 0;
-			    elem = hash % table_size;
-			    second = hash % (table_size - 2);
-			    while (symb_table[2 * elem] != 0)
-			      {
-				/* First compare the hashing value.  */
-				if (symb_table[2 * elem] == hash
-				    && c1 == extra[symb_table[2 * elem + 1]]
-				    && memcmp (str,
-					       &extra[symb_table[2 * elem + 1]
-						     + 1],
-					       c1) == 0)
-				  {
-				    /* Yep, this is the entry.  */
-				    idx = symb_table[2 * elem + 1];
-				    idx += 1 + extra[idx];
-				    break;
-				  }
+                            idx = 0;
+                            elem = hash % table_size;
+                            second = hash % (table_size - 2);
+                            while (symb_table[2 * elem] != 0)
+                              {
+                                /* First compare the hashing value.  */
+                                if (symb_table[2 * elem] == hash
+                                    && c1 == extra[symb_table[2 * elem + 1]]
+                                    && memcmp (str,
+                                               &extra[symb_table[2 * elem + 1]
+                                                     + 1],
+                                               c1) == 0)
+                                  {
+                                    /* Yep, this is the entry.  */
+                                    idx = symb_table[2 * elem + 1];
+                                    idx += 1 + extra[idx];
+                                    break;
+                                  }
 
-				/* Next entry.  */
-				elem += second;
-			      }
+                                /* Next entry.  */
+                                elem += second;
+                              }
 
-			    if (symb_table[2 * elem] == 0)
-			      /* This is no valid character.  */
-			      FREE_STACK_RETURN (REG_ECOLLATE);
+                            if (symb_table[2 * elem] == 0)
+                              /* This is no valid character.  */
+                              FREE_STACK_RETURN (REG_ECOLLATE);
 
-			    /* Throw away the ] at the end of the equivalence
-			       class.  */
-			    PATFETCH (c);
+                            /* Throw away the ] at the end of the equivalence
+                               class.  */
+                            PATFETCH (c);
 
-			    /* Now add the multibyte character(s) we found
-			       to the accept list.
+                            /* Now add the multibyte character(s) we found
+                               to the accept list.
 
-			       XXX Note that this is not entirely correct.
-			       we would have to match multibyte sequences
-			       but this is not possible with the current
-			       implementation.  Also, we have to match
-			       collating symbols, which expand to more than
-			       one file, as a whole and not allow the
-			       individual bytes.  */
-			    c1 = extra[idx++];
-			    if (c1 == 1)
-			      range_start = extra[idx];
-			    while (c1-- > 0)
-			      {
-				SET_LIST_BIT (extra[idx]);
-				++idx;
-			      }
-			  }
+                               XXX Note that this is not entirely correct.
+                               we would have to match multibyte sequences
+                               but this is not possible with the current
+                               implementation.  Also, we have to match
+                               collating symbols, which expand to more than
+                               one file, as a whole and not allow the
+                               individual bytes.  */
+                            c1 = extra[idx++];
+                            if (c1 == 1)
+                              range_start = extra[idx];
+                            while (c1-- > 0)
+                              {
+                                SET_LIST_BIT (extra[idx]);
+                                ++idx;
+                              }
+                          }
 #endif
-			had_char_class = false;
-		      }
+                        had_char_class = false;
+                      }
                     else
                       {
                         c1++;
@@ -2744,15 +2744,15 @@ regex_compile (pattern, size, syntax, bufp)
                           PATUNFETCH;
                         SET_LIST_BIT ('[');
                         SET_LIST_BIT ('.');
-			range_start = '.';
+                        range_start = '.';
                         had_char_class = false;
                       }
-		  }
+                  }
                 else
                   {
                     had_char_class = false;
                     SET_LIST_BIT (c);
-		    range_start = c;
+                    range_start = c;
                   }
               }
 
@@ -2765,7 +2765,7 @@ regex_compile (pattern, size, syntax, bufp)
           break;
 
 
-	case '(':
+        case '(':
           if (syntax & RE_NO_BK_PARENS)
             goto handle_open;
           else
@@ -2786,7 +2786,7 @@ regex_compile (pattern, size, syntax, bufp)
             goto normal_char;
 
 
-	case '|':
+        case '|':
           if (syntax & RE_NO_BK_VBAR)
             goto handle_alt;
           else
@@ -2852,10 +2852,10 @@ regex_compile (pattern, size, syntax, bufp)
               fixup_alt_jump = 0;
               laststart = 0;
               begalt = b;
-	      /* If we've reached MAX_REGNUM groups, then this open
-		 won't actually generate any code, so we'll have to
-		 clear pending_exact explicitly.  */
-	      pending_exact = 0;
+              /* If we've reached MAX_REGNUM groups, then this open
+                 won't actually generate any code, so we'll have to
+                 clear pending_exact explicitly.  */
+              pending_exact = 0;
               break;
 
 
@@ -2863,12 +2863,12 @@ regex_compile (pattern, size, syntax, bufp)
               if (syntax & RE_NO_BK_PARENS) goto normal_backslash;
 
               if (COMPILE_STACK_EMPTY)
-		{
-		  if (syntax & RE_UNMATCHED_RIGHT_PAREN_ORD)
-		    goto normal_backslash;
-		  else
-		    FREE_STACK_RETURN (REG_ERPAREN);
-		}
+                {
+                  if (syntax & RE_UNMATCHED_RIGHT_PAREN_ORD)
+                    goto normal_backslash;
+                  else
+                    FREE_STACK_RETURN (REG_ERPAREN);
+                }
 
             handle_close:
               if (fixup_alt_jump)
@@ -2885,12 +2885,12 @@ regex_compile (pattern, size, syntax, bufp)
 
               /* See similar code for backslashed left paren above.  */
               if (COMPILE_STACK_EMPTY)
-		{
-		  if (syntax & RE_UNMATCHED_RIGHT_PAREN_ORD)
-		    goto normal_char;
-		  else
-		    FREE_STACK_RETURN (REG_ERPAREN);
-		}
+                {
+                  if (syntax & RE_UNMATCHED_RIGHT_PAREN_ORD)
+                    goto normal_char;
+                  else
+                    FREE_STACK_RETURN (REG_ERPAREN);
+                }
 
               /* Since we just checked for an empty stack above, this
                  ``can't happen''.  */
@@ -2909,10 +2909,10 @@ regex_compile (pattern, size, syntax, bufp)
                     : 0;
                 laststart = bufp->buffer + COMPILE_STACK_TOP.laststart_offset;
                 this_group_regnum = COMPILE_STACK_TOP.regnum;
-		/* If we've reached MAX_REGNUM groups, then this open
-		   won't actually generate any code, so we'll have to
-		   clear pending_exact explicitly.  */
-		pending_exact = 0;
+                /* If we've reached MAX_REGNUM groups, then this open
+                   won't actually generate any code, so we'll have to
+                   clear pending_exact explicitly.  */
+                pending_exact = 0;
 
                 /* We're at the end of the group, so now we know how many
                    groups were inside this one.  */
@@ -2929,7 +2929,7 @@ regex_compile (pattern, size, syntax, bufp)
               break;
 
 
-            case '|':					/* `\|'.  */
+            case '|':                                        /* `\|'.  */
               if (syntax & RE_LIMITED_OPS || syntax & RE_NO_BK_VBAR)
                 goto normal_backslash;
             handle_alt:
@@ -2979,7 +2979,7 @@ regex_compile (pattern, size, syntax, bufp)
               if (!(syntax & RE_INTERVALS)
                      /* If we're at `\{' and it's not the open-interval
                         operator.  */
-		  || (syntax & RE_NO_BK_BRACES))
+                  || (syntax & RE_NO_BK_BRACES))
                 goto normal_backslash;
 
             handle_interval:
@@ -3004,12 +3004,12 @@ regex_compile (pattern, size, syntax, bufp)
                 if (c == ',')
                   {
                     GET_UNSIGNED_NUMBER (upper_bound);
-		    if ((!(syntax & RE_NO_BK_BRACES) && c != '\\')
-			|| ((syntax & RE_NO_BK_BRACES) && c != '}'))
-		      FREE_STACK_RETURN (REG_BADBR);
+                    if ((!(syntax & RE_NO_BK_BRACES) && c != '\\')
+                        || ((syntax & RE_NO_BK_BRACES) && c != '}'))
+                      FREE_STACK_RETURN (REG_BADBR);
 
-		    if (upper_bound < 0)
-		      upper_bound = RE_DUP_MAX;
+                    if (upper_bound < 0)
+                      upper_bound = RE_DUP_MAX;
                   }
                 else
                   /* Interval such as `{1}' => match exactly once. */
@@ -3169,54 +3169,54 @@ regex_compile (pattern, size, syntax, bufp)
 
 
             case 'w':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               laststart = b;
               BUF_PUSH (wordchar);
               break;
 
 
             case 'W':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               laststart = b;
               BUF_PUSH (notwordchar);
               break;
 
 
             case '<':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (wordbeg);
               break;
 
             case '>':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (wordend);
               break;
 
             case 'b':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (wordbound);
               break;
 
             case 'B':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (notwordbound);
               break;
 
             case '`':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (begbuf);
               break;
 
             case '\'':
-	      if (syntax & RE_NO_GNU_OPS)
-		goto normal_char;
+              if (syntax & RE_NO_GNU_OPS)
+                goto normal_char;
               BUF_PUSH (endbuf);
               break;
 
@@ -3257,39 +3257,39 @@ regex_compile (pattern, size, syntax, bufp)
           break;
 
 
-	default:
+        default:
         /* Expects the character in `c'.  */
-	normal_char:
-	      /* If no exactn currently being built.  */
+        normal_char:
+              /* If no exactn currently being built.  */
           if (!pending_exact
 
               /* If last exactn not at current position.  */
               || pending_exact + *pending_exact + 1 != b
 
               /* We have only one byte following the exactn for the count.  */
-	      || *pending_exact == (1 << BYTEWIDTH) - 1
+              || *pending_exact == (1 << BYTEWIDTH) - 1
 
               /* If followed by a repetition operator.  */
               || *p == '*' || *p == '^'
-	      || ((syntax & RE_BK_PLUS_QM)
-		  ? *p == '\\' && (p[1] == '+' || p[1] == '?')
-		  : (*p == '+' || *p == '?'))
-	      || ((syntax & RE_INTERVALS)
+              || ((syntax & RE_BK_PLUS_QM)
+                  ? *p == '\\' && (p[1] == '+' || p[1] == '?')
+                  : (*p == '+' || *p == '?'))
+              || ((syntax & RE_INTERVALS)
                   && ((syntax & RE_NO_BK_BRACES)
-		      ? *p == '{'
+                      ? *p == '{'
                       : (p[0] == '\\' && p[1] == '{'))))
-	    {
-	      /* Start building a new exactn.  */
+            {
+              /* Start building a new exactn.  */
 
               laststart = b;
 
-	      BUF_PUSH_2 (exactn, 0);
-	      pending_exact = b - 1;
+              BUF_PUSH_2 (exactn, 0);
+              pending_exact = b - 1;
             }
 
-	  BUF_PUSH (c);
+          BUF_PUSH (c);
           (*pending_exact)++;
-	  break;
+          break;
         } /* switch (c) */
     } /* while p != pend */
 
@@ -3332,28 +3332,28 @@ regex_compile (pattern, size, syntax, bufp)
        is 2 * re_max_failures failure points.  */
     if (fail_stack.size < (2 * re_max_failures * MAX_FAILURE_ITEMS))
       {
-	fail_stack.size = (2 * re_max_failures * MAX_FAILURE_ITEMS);
+        fail_stack.size = (2 * re_max_failures * MAX_FAILURE_ITEMS);
 
 # ifdef emacs
-	if (! fail_stack.stack)
-	  fail_stack.stack
-	    = (fail_stack_elt_t *) xmalloc (fail_stack.size
-					    * sizeof (fail_stack_elt_t));
-	else
-	  fail_stack.stack
-	    = (fail_stack_elt_t *) xrealloc (fail_stack.stack,
-					     (fail_stack.size
-					      * sizeof (fail_stack_elt_t)));
+        if (! fail_stack.stack)
+          fail_stack.stack
+            = (fail_stack_elt_t *) xmalloc (fail_stack.size
+                                            * sizeof (fail_stack_elt_t));
+        else
+          fail_stack.stack
+            = (fail_stack_elt_t *) xrealloc (fail_stack.stack,
+                                             (fail_stack.size
+                                              * sizeof (fail_stack_elt_t)));
 # else /* not emacs */
-	if (! fail_stack.stack)
-	  fail_stack.stack
-	    = (fail_stack_elt_t *) malloc (fail_stack.size
-					   * sizeof (fail_stack_elt_t));
-	else
-	  fail_stack.stack
-	    = (fail_stack_elt_t *) realloc (fail_stack.stack,
-					    (fail_stack.size
-					     * sizeof (fail_stack_elt_t)));
+        if (! fail_stack.stack)
+          fail_stack.stack
+            = (fail_stack_elt_t *) malloc (fail_stack.size
+                                           * sizeof (fail_stack_elt_t));
+        else
+          fail_stack.stack
+            = (fail_stack_elt_t *) realloc (fail_stack.stack,
+                                            (fail_stack.size
+                                             * sizeof (fail_stack_elt_t)));
 # endif /* not emacs */
       }
 
@@ -3536,7 +3536,7 @@ compile_range (range_start_char, p_ptr, pend, translate, syntax, b)
 
 #if _LIBC
   collseq = (const unsigned char *) _NL_CURRENT (LC_COLLATE,
-						 _NL_COLLATE_COLLSEQMB);
+                                                 _NL_COLLATE_COLLSEQMB);
 
   start_colseq = collseq[(unsigned char) TRANSLATE (range_start_char)];
   end_colseq = collseq[(unsigned char) TRANSLATE (p[0])];
@@ -3545,10 +3545,10 @@ compile_range (range_start_char, p_ptr, pend, translate, syntax, b)
       unsigned int this_colseq = collseq[(unsigned char) TRANSLATE (this_char)];
 
       if (start_colseq <= this_colseq && this_colseq <= end_colseq)
-	{
-	  SET_LIST_BIT (TRANSLATE (this_char));
-	  ret = REG_NOERROR;
-	}
+        {
+          SET_LIST_BIT (TRANSLATE (this_char));
+          ret = REG_NOERROR;
+        }
     }
 #else
   /* Here we see why `this_char' has to be larger than an `unsigned
@@ -3615,130 +3615,130 @@ re_compile_fastmap (bufp)
 
   INIT_FAIL_STACK ();
   bzero (fastmap, 1 << BYTEWIDTH);  /* Assume nothing's valid.  */
-  bufp->fastmap_accurate = 1;	    /* It will be when we're done.  */
+  bufp->fastmap_accurate = 1;            /* It will be when we're done.  */
   bufp->can_be_null = 0;
 
   while (1)
     {
       if (p == pend || *p == succeed)
-	{
-	  /* We have reached the (effective) end of pattern.  */
-	  if (!FAIL_STACK_EMPTY ())
-	    {
-	      bufp->can_be_null |= path_can_be_null;
+        {
+          /* We have reached the (effective) end of pattern.  */
+          if (!FAIL_STACK_EMPTY ())
+            {
+              bufp->can_be_null |= path_can_be_null;
 
-	      /* Reset for next path.  */
-	      path_can_be_null = true;
+              /* Reset for next path.  */
+              path_can_be_null = true;
 
-	      p = fail_stack.stack[--fail_stack.avail].pointer;
+              p = fail_stack.stack[--fail_stack.avail].pointer;
 
-	      continue;
-	    }
-	  else
-	    break;
-	}
+              continue;
+            }
+          else
+            break;
+        }
 
       /* We should never be about to go beyond the end of the pattern.  */
       assert (p < pend);
 
       switch (SWITCH_ENUM_CAST ((re_opcode_t) *p++))
-	{
+        {
 
         /* I guess the idea here is to simply not bother with a fastmap
            if a backreference is used, since it's too hard to figure out
            the fastmap for the corresponding group.  Setting
            `can_be_null' stops `re_search_2' from using the fastmap, so
            that is all we do.  */
-	case duplicate:
-	  bufp->can_be_null = 1;
+        case duplicate:
+          bufp->can_be_null = 1;
           goto done;
 
 
       /* Following are the cases which match a character.  These end
          with `break'.  */
 
-	case exactn:
+        case exactn:
           fastmap[p[1]] = 1;
-	  break;
+          break;
 
 
         case charset:
           for (j = *p++ * BYTEWIDTH - 1; j >= 0; j--)
-	    if (p[j / BYTEWIDTH] & (1 << (j % BYTEWIDTH)))
-              fastmap[j] = 1;
-	  break;
-
-
-	case charset_not:
-	  /* Chars beyond end of map must be allowed.  */
-	  for (j = *p * BYTEWIDTH; j < (1 << BYTEWIDTH); j++)
-            fastmap[j] = 1;
-
-	  for (j = *p++ * BYTEWIDTH - 1; j >= 0; j--)
-	    if (!(p[j / BYTEWIDTH] & (1 << (j % BYTEWIDTH))))
+            if (p[j / BYTEWIDTH] & (1 << (j % BYTEWIDTH)))
               fastmap[j] = 1;
           break;
 
 
-	case wordchar:
-	  for (j = 0; j < (1 << BYTEWIDTH); j++)
-	    if (SYNTAX (j) == Sword)
-	      fastmap[j] = 1;
-	  break;
+        case charset_not:
+          /* Chars beyond end of map must be allowed.  */
+          for (j = *p * BYTEWIDTH; j < (1 << BYTEWIDTH); j++)
+            fastmap[j] = 1;
+
+          for (j = *p++ * BYTEWIDTH - 1; j >= 0; j--)
+            if (!(p[j / BYTEWIDTH] & (1 << (j % BYTEWIDTH))))
+              fastmap[j] = 1;
+          break;
 
 
-	case notwordchar:
-	  for (j = 0; j < (1 << BYTEWIDTH); j++)
-	    if (SYNTAX (j) != Sword)
-	      fastmap[j] = 1;
-	  break;
+        case wordchar:
+          for (j = 0; j < (1 << BYTEWIDTH); j++)
+            if (SYNTAX (j) == Sword)
+              fastmap[j] = 1;
+          break;
+
+
+        case notwordchar:
+          for (j = 0; j < (1 << BYTEWIDTH); j++)
+            if (SYNTAX (j) != Sword)
+              fastmap[j] = 1;
+          break;
 
 
         case anychar:
-	  {
-	    int fastmap_newline = fastmap['\n'];
+          {
+            int fastmap_newline = fastmap['\n'];
 
-	    /* `.' matches anything ...  */
-	    for (j = 0; j < (1 << BYTEWIDTH); j++)
-	      fastmap[j] = 1;
+            /* `.' matches anything ...  */
+            for (j = 0; j < (1 << BYTEWIDTH); j++)
+              fastmap[j] = 1;
 
-	    /* ... except perhaps newline.  */
-	    if (!(bufp->syntax & RE_DOT_NEWLINE))
-	      fastmap['\n'] = fastmap_newline;
+            /* ... except perhaps newline.  */
+            if (!(bufp->syntax & RE_DOT_NEWLINE))
+              fastmap['\n'] = fastmap_newline;
 
-	    /* Return if we have already set `can_be_null'; if we have,
-	       then the fastmap is irrelevant.  Something's wrong here.  */
-	    else if (bufp->can_be_null)
-	      goto done;
+            /* Return if we have already set `can_be_null'; if we have,
+               then the fastmap is irrelevant.  Something's wrong here.  */
+            else if (bufp->can_be_null)
+              goto done;
 
-	    /* Otherwise, have to check alternative paths.  */
-	    break;
-	  }
+            /* Otherwise, have to check alternative paths.  */
+            break;
+          }
 
 #ifdef emacs
         case syntaxspec:
-	  k = *p++;
-	  for (j = 0; j < (1 << BYTEWIDTH); j++)
-	    if (SYNTAX (j) == (enum syntaxcode) k)
-	      fastmap[j] = 1;
-	  break;
+          k = *p++;
+          for (j = 0; j < (1 << BYTEWIDTH); j++)
+            if (SYNTAX (j) == (enum syntaxcode) k)
+              fastmap[j] = 1;
+          break;
 
 
-	case notsyntaxspec:
-	  k = *p++;
-	  for (j = 0; j < (1 << BYTEWIDTH); j++)
-	    if (SYNTAX (j) != (enum syntaxcode) k)
-	      fastmap[j] = 1;
-	  break;
+        case notsyntaxspec:
+          k = *p++;
+          for (j = 0; j < (1 << BYTEWIDTH); j++)
+            if (SYNTAX (j) != (enum syntaxcode) k)
+              fastmap[j] = 1;
+          break;
 
 
       /* All cases after this match the empty string.  These end with
          `continue'.  */
 
 
-	case before_dot:
-	case at_dot:
-	case after_dot:
+        case before_dot:
+        case at_dot:
+        case after_dot:
           continue;
 #endif /* emacs */
 
@@ -3746,26 +3746,26 @@ re_compile_fastmap (bufp)
         case no_op:
         case begline:
         case endline:
-	case begbuf:
-	case endbuf:
-	case wordbound:
-	case notwordbound:
-	case wordbeg:
-	case wordend:
+        case begbuf:
+        case endbuf:
+        case wordbound:
+        case notwordbound:
+        case wordbeg:
+        case wordend:
         case push_dummy_failure:
           continue;
 
 
-	case jump_n:
+        case jump_n:
         case pop_failure_jump:
-	case maybe_pop_jump:
-	case jump:
+        case maybe_pop_jump:
+        case jump:
         case jump_past_alt:
-	case dummy_failure_jump:
+        case dummy_failure_jump:
           EXTRACT_NUMBER_AND_INCR (j, p);
-	  p += j;
-	  if (j > 0)
-	    continue;
+          p += j;
+          if (j > 0)
+            continue;
 
           /* Jump backward implies we just went through the body of a
              loop and matched nothing.  Opcode jumped to should be
@@ -3773,8 +3773,8 @@ re_compile_fastmap (bufp)
              ordinary jump.  For a * loop, it has pushed its failure
              point already; if so, discard that as redundant.  */
           if ((re_opcode_t) *p != on_failure_jump
-	      && (re_opcode_t) *p != succeed_n)
-	    continue;
+              && (re_opcode_t) *p != succeed_n)
+            continue;
 
           p++;
           EXTRACT_NUMBER_AND_INCR (j, p);
@@ -3782,7 +3782,7 @@ re_compile_fastmap (bufp)
 
           /* If what's on the stack is where we are now, pop it.  */
           if (!FAIL_STACK_EMPTY ()
-	      && fail_stack.stack[fail_stack.avail - 1].pointer == p)
+              && fail_stack.stack[fail_stack.avail - 1].pointer == p)
             fail_stack.avail--;
 
           continue;
@@ -3790,7 +3790,7 @@ re_compile_fastmap (bufp)
 
         case on_failure_jump:
         case on_failure_keep_string_jump:
-	handle_on_failure_jump:
+        handle_on_failure_jump:
           EXTRACT_NUMBER_AND_INCR (j, p);
 
           /* For some patterns, e.g., `(a?)?', `p+j' here points to the
@@ -3803,50 +3803,50 @@ re_compile_fastmap (bufp)
           if (p + j < pend)
             {
               if (!PUSH_PATTERN_OP (p + j, fail_stack))
-		{
-		  RESET_FAIL_STACK ();
-		  return -2;
-		}
+                {
+                  RESET_FAIL_STACK ();
+                  return -2;
+                }
             }
           else
             bufp->can_be_null = 1;
 
           if (succeed_n_p)
             {
-              EXTRACT_NUMBER_AND_INCR (k, p);	/* Skip the n.  */
+              EXTRACT_NUMBER_AND_INCR (k, p);        /* Skip the n.  */
               succeed_n_p = false;
-	    }
+            }
 
           continue;
 
 
-	case succeed_n:
+        case succeed_n:
           /* Get to the number of times to succeed.  */
           p += 2;
 
           /* Increment p past the n for when k != 0.  */
           EXTRACT_NUMBER_AND_INCR (k, p);
           if (k == 0)
-	    {
+            {
               p -= 4;
-  	      succeed_n_p = true;  /* Spaghetti code alert.  */
+                succeed_n_p = true;  /* Spaghetti code alert.  */
               goto handle_on_failure_jump;
             }
           continue;
 
 
-	case set_number_at:
+        case set_number_at:
           p += 4;
           continue;
 
 
-	case start_memory:
+        case start_memory:
         case stop_memory:
-	  p += 2;
-	  continue;
+          p += 2;
+          continue;
 
 
-	default:
+        default:
           abort (); /* We have listed all the cases.  */
         } /* switch *p++ */
 
@@ -3923,7 +3923,7 @@ re_search (bufp, string, size, startpos, range, regs)
      struct re_registers *regs;
 {
   return re_search_2 (bufp, NULL, 0, string, size, startpos, range,
-		      regs, size);
+                      regs, size);
 }
 #ifdef _LIBC
 weak_alias (__re_search, re_search)
@@ -3983,14 +3983,14 @@ re_search_2 (bufp, string1, size1, string2, size2, startpos, range, regs, stop)
      search for a pattern that must be anchored.  */
   if (bufp->used > 0 && range > 0
       && ((re_opcode_t) bufp->buffer[0] == begbuf
-	  /* `begline' is like `begbuf' if it cannot match at newlines.  */
-	  || ((re_opcode_t) bufp->buffer[0] == begline
-	      && !bufp->newline_anchor)))
+          /* `begline' is like `begbuf' if it cannot match at newlines.  */
+          || ((re_opcode_t) bufp->buffer[0] == begline
+              && !bufp->newline_anchor)))
     {
       if (startpos > 0)
-	return -1;
+        return -1;
       else
-	range = 1;
+        range = 1;
     }
 
 #ifdef emacs
@@ -4000,7 +4000,7 @@ re_search_2 (bufp, string1, size1, string2, size2, startpos, range, regs, stop)
     {
       range = PT - startpos;
       if (range <= 0)
-	return -1;
+        return -1;
     }
 #endif /* emacs */
 
@@ -4017,49 +4017,49 @@ re_search_2 (bufp, string1, size1, string2, size2, startpos, range, regs, stop)
          null string, however, we don't need to skip characters; we want
          the first null string.  */
       if (fastmap && startpos < total_size && !bufp->can_be_null)
-	{
-	  if (range > 0)	/* Searching forwards.  */
-	    {
-	      register const char *d;
-	      register int lim = 0;
-	      int irange = range;
+        {
+          if (range > 0)        /* Searching forwards.  */
+            {
+              register const char *d;
+              register int lim = 0;
+              int irange = range;
 
               if (startpos < size1 && startpos + range >= size1)
                 lim = range - (size1 - startpos);
 
-	      d = (startpos >= size1 ? string2 - size1 : string1) + startpos;
+              d = (startpos >= size1 ? string2 - size1 : string1) + startpos;
 
               /* Written out as an if-else to avoid testing `translate'
                  inside the loop.  */
-	      if (translate)
+              if (translate)
                 while (range > lim
                        && !fastmap[(unsigned char)
-				   translate[(unsigned char) *d++]])
+                                   translate[(unsigned char) *d++]])
                   range--;
-	      else
+              else
                 while (range > lim && !fastmap[(unsigned char) *d++])
                   range--;
 
-	      startpos += irange - range;
-	    }
-	  else				/* Searching backwards.  */
-	    {
-	      register char c = (size1 == 0 || startpos >= size1
+              startpos += irange - range;
+            }
+          else                                /* Searching backwards.  */
+            {
+              register char c = (size1 == 0 || startpos >= size1
                                  ? string2[startpos - size1]
                                  : string1[startpos]);
 
-	      if (!fastmap[(unsigned char) TRANSLATE (c)])
-		goto advance;
-	    }
-	}
+              if (!fastmap[(unsigned char) TRANSLATE (c)])
+                goto advance;
+            }
+        }
 
       /* If can't match the null string, and that's all we have left, fail.  */
       if (range >= 0 && startpos == total_size && fastmap
           && !bufp->can_be_null)
-	return -1;
+        return -1;
 
       val = re_match_2_internal (bufp, string1, size1, string2, size2,
-				 startpos, regs, stop);
+                                 startpos, regs, stop);
 #ifndef REGEX_MALLOC
 # ifdef C_ALLOCA
       alloca (0);
@@ -4067,10 +4067,10 @@ re_search_2 (bufp, string1, size1, string2, size2, startpos, range, regs, stop)
 #endif
 
       if (val >= 0)
-	return startpos;
+        return startpos;
 
       if (val == -2)
-	return -2;
+        return -2;
 
     advance:
       if (!range)
@@ -4094,9 +4094,9 @@ weak_alias (__re_search_2, re_search_2)
 
 /* This converts PTR, a pointer into one of the search strings `string1'
    and `string2' into an offset from the beginning of that string.  */
-#define POINTER_TO_OFFSET(ptr)			\
-  (FIRST_STRING_P (ptr)				\
-   ? ((regoff_t) ((ptr) - string1))		\
+#define POINTER_TO_OFFSET(ptr)                        \
+  (FIRST_STRING_P (ptr)                                \
+   ? ((regoff_t) ((ptr) - string1))                \
    : ((regoff_t) ((ptr) - string2 + size1)))
 
 /* Macros for dealing with the split strings in re_match_2.  */
@@ -4105,15 +4105,15 @@ weak_alias (__re_search_2, re_search_2)
 
 /* Call before fetching a character with *d.  This switches over to
    string2 if necessary.  */
-#define PREFETCH()							\
-  while (d == dend)						    	\
-    {									\
-      /* End of string2 => fail.  */					\
-      if (dend == end_match_2) 						\
-        goto fail;							\
-      /* End of string1 => advance to string2.  */ 			\
-      d = string2;						        \
-      dend = end_match_2;						\
+#define PREFETCH()                                                        \
+  while (d == dend)                                                            \
+    {                                                                        \
+      /* End of string2 => fail.  */                                        \
+      if (dend == end_match_2)                                                 \
+        goto fail;                                                        \
+      /* End of string1 => advance to string2.  */                         \
+      d = string2;                                                        \
+      dend = end_match_2;                                                \
     }
 
 
@@ -4127,35 +4127,35 @@ weak_alias (__re_search_2, re_search_2)
    two special cases to check for: if past the end of string1, look at
    the first character in string2; and if before the beginning of
    string2, look at the last character in string1.  */
-#define WORDCHAR_P(d)							\
-  (SYNTAX ((d) == end1 ? *string2					\
-           : (d) == string2 - 1 ? *(end1 - 1) : *(d))			\
+#define WORDCHAR_P(d)                                                        \
+  (SYNTAX ((d) == end1 ? *string2                                        \
+           : (d) == string2 - 1 ? *(end1 - 1) : *(d))                        \
    == Sword)
 
 /* Disabled due to a compiler bug -- see comment at case wordbound */
 #if 0
 /* Test if the character before D and the one at D differ with respect
    to being word-constituent.  */
-#define AT_WORD_BOUNDARY(d)						\
-  (AT_STRINGS_BEG (d) || AT_STRINGS_END (d)				\
+#define AT_WORD_BOUNDARY(d)                                                \
+  (AT_STRINGS_BEG (d) || AT_STRINGS_END (d)                                \
    || WORDCHAR_P (d - 1) != WORDCHAR_P (d))
 #endif
 
 /* Free everything we malloc.  */
 #ifdef MATCH_MAY_ALLOCATE
 # define FREE_VAR(var) if (var) REGEX_FREE (var); var = NULL
-# define FREE_VARIABLES()						\
-  do {									\
-    REGEX_FREE_STACK (fail_stack.stack);				\
-    FREE_VAR (regstart);						\
-    FREE_VAR (regend);							\
-    FREE_VAR (old_regstart);						\
-    FREE_VAR (old_regend);						\
-    FREE_VAR (best_regstart);						\
-    FREE_VAR (best_regend);						\
-    FREE_VAR (reg_info);						\
-    FREE_VAR (reg_dummy);						\
-    FREE_VAR (reg_info_dummy);						\
+# define FREE_VARIABLES()                                                \
+  do {                                                                        \
+    REGEX_FREE_STACK (fail_stack.stack);                                \
+    FREE_VAR (regstart);                                                \
+    FREE_VAR (regend);                                                        \
+    FREE_VAR (old_regstart);                                                \
+    FREE_VAR (old_regend);                                                \
+    FREE_VAR (best_regstart);                                                \
+    FREE_VAR (best_regend);                                                \
+    FREE_VAR (reg_info);                                                \
+    FREE_VAR (reg_dummy);                                                \
+    FREE_VAR (reg_info_dummy);                                                \
   } while (0)
 #else
 # define FREE_VARIABLES() ((void)0) /* Do nothing!  But inhibit gcc warning. */
@@ -4184,7 +4184,7 @@ re_match (bufp, string, size, pos, regs)
      struct re_registers *regs;
 {
   int result = re_match_2_internal (bufp, NULL, 0, string, size,
-				    pos, regs, size);
+                                    pos, regs, size);
 # ifndef REGEX_MALLOC
 #  ifdef C_ALLOCA
   alloca (0);
@@ -4198,16 +4198,16 @@ weak_alias (__re_match, re_match)
 #endif /* not emacs */
 
 static boolean group_match_null_string_p _RE_ARGS ((unsigned char **p,
-						    unsigned char *end,
-						register_info_type *reg_info));
+                                                    unsigned char *end,
+                                                register_info_type *reg_info));
 static boolean alt_match_null_string_p _RE_ARGS ((unsigned char *p,
-						  unsigned char *end,
-						register_info_type *reg_info));
+                                                  unsigned char *end,
+                                                register_info_type *reg_info));
 static boolean common_op_match_null_string_p _RE_ARGS ((unsigned char **p,
-							unsigned char *end,
-						register_info_type *reg_info));
+                                                        unsigned char *end,
+                                                register_info_type *reg_info));
 static int bcmp_translate _RE_ARGS ((const char *s1, const char *s2,
-				     int len, char *translate));
+                                     int len, char *translate));
 
 /* re_match_2 matches the compiled pattern in BUFP against the
    the (virtual) concatenation of STRING1 and STRING2 (of length SIZE1
@@ -4232,7 +4232,7 @@ re_match_2 (bufp, string1, size1, string2, size2, pos, regs, stop)
      int stop;
 {
   int result = re_match_2_internal (bufp, string1, size1, string2, size2,
-				    pos, regs, stop);
+                                    pos, regs, stop);
 #ifndef REGEX_MALLOC
 # ifdef C_ALLOCA
   alloca (0);
@@ -4494,26 +4494,26 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 #endif
 
       if (p == pend)
-	{ /* End of pattern means we might have succeeded.  */
+        { /* End of pattern means we might have succeeded.  */
           DEBUG_PRINT1 ("end of pattern ... ");
 
-	  /* If we haven't matched the entire string, and we want the
+          /* If we haven't matched the entire string, and we want the
              longest match, try backtracking.  */
           if (d != end_match_2)
-	    {
-	      /* 1 if this match ends in the same string (string1 or string2)
-		 as the best previous match.  */
-	      boolean same_str_p = (FIRST_STRING_P (match_end)
-				    == MATCHING_IN_FIRST_STRING);
-	      /* 1 if this match is the best seen so far.  */
-	      boolean best_match_p;
+            {
+              /* 1 if this match ends in the same string (string1 or string2)
+                 as the best previous match.  */
+              boolean same_str_p = (FIRST_STRING_P (match_end)
+                                    == MATCHING_IN_FIRST_STRING);
+              /* 1 if this match is the best seen so far.  */
+              boolean best_match_p;
 
-	      /* AIX compiler got confused when this was combined
-		 with the previous declaration.  */
-	      if (same_str_p)
-		best_match_p = d > match_end;
-	      else
-		best_match_p = !MATCHING_IN_FIRST_STRING;
+              /* AIX compiler got confused when this was combined
+                 with the previous declaration.  */
+              if (same_str_p)
+                best_match_p = d > match_end;
+              else
+                best_match_p = !MATCHING_IN_FIRST_STRING;
 
               DEBUG_PRINT1 ("backtracking.\n");
 
@@ -4542,7 +4542,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                  best one. */
               else if (best_regs_set && !best_match_p)
                 {
-  	        restore_best_regs:
+                  restore_best_regs:
                   /* Restore best match.  It may happen that `dend ==
                      end_match_1' while the restored d is in string2.
                      For example, the pattern `x.*y.*z' against the
@@ -4552,22 +4552,22 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
                   d = match_end;
                   dend = ((d >= string1 && d <= end1)
-		           ? end_match_1 : end_match_2);
+                           ? end_match_1 : end_match_2);
 
-		  for (mcnt = 1; (unsigned) mcnt < num_regs; mcnt++)
-		    {
-		      regstart[mcnt] = best_regstart[mcnt];
-		      regend[mcnt] = best_regend[mcnt];
-		    }
+                  for (mcnt = 1; (unsigned) mcnt < num_regs; mcnt++)
+                    {
+                      regstart[mcnt] = best_regstart[mcnt];
+                      regend[mcnt] = best_regend[mcnt];
+                    }
                 }
             } /* d != end_match_2 */
 
-	succeed_label:
+        succeed_label:
           DEBUG_PRINT1 ("Accepting match.\n");
 
           /* If caller wants register contents data back, do it.  */
           if (regs && !bufp->no_sub)
-	    {
+            {
               /* Have the register data arrays been allocated?  */
               if (bufp->regs_allocated == REGS_UNALLOCATED)
                 { /* No.  So allocate them with malloc.  We need one
@@ -4577,10 +4577,10 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                   regs->start = TALLOC (regs->num_regs, regoff_t);
                   regs->end = TALLOC (regs->num_regs, regoff_t);
                   if (regs->start == NULL || regs->end == NULL)
-		    {
-		      FREE_VARIABLES ();
-		      return -2;
-		    }
+                    {
+                      FREE_VARIABLES ();
+                      return -2;
+                    }
                   bufp->regs_allocated = REGS_REALLOCATE;
                 }
               else if (bufp->regs_allocated == REGS_REALLOCATE)
@@ -4593,18 +4593,18 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                       RETALLOC (regs->start, regs->num_regs, regoff_t);
                       RETALLOC (regs->end, regs->num_regs, regoff_t);
                       if (regs->start == NULL || regs->end == NULL)
-			{
-			  FREE_VARIABLES ();
-			  return -2;
-			}
+                        {
+                          FREE_VARIABLES ();
+                          return -2;
+                        }
                     }
                 }
               else
-		{
-		  /* These braces fend off a "empty body in an else-statement"
-		     warning under GCC when assert expands to nothing.  */
-		  assert (bufp->regs_allocated == REGS_FIXED);
-		}
+                {
+                  /* These braces fend off a "empty body in an else-statement"
+                     warning under GCC when assert expands to nothing.  */
+                  assert (bufp->regs_allocated == REGS_FIXED);
+                }
 
               /* Convert the pointer data in `regstart' and `regend' to
                  indices.  Register zero has to be set differently,
@@ -4613,25 +4613,25 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                 {
                   regs->start[0] = pos;
                   regs->end[0] = (MATCHING_IN_FIRST_STRING
-				  ? ((regoff_t) (d - string1))
-			          : ((regoff_t) (d - string2 + size1)));
+                                  ? ((regoff_t) (d - string1))
+                                  : ((regoff_t) (d - string2 + size1)));
                 }
 
               /* Go through the first `min (num_regs, regs->num_regs)'
                  registers, since that is all we initialized.  */
-	      for (mcnt = 1; (unsigned) mcnt < MIN (num_regs, regs->num_regs);
-		   mcnt++)
-		{
+              for (mcnt = 1; (unsigned) mcnt < MIN (num_regs, regs->num_regs);
+                   mcnt++)
+                {
                   if (REG_UNSET (regstart[mcnt]) || REG_UNSET (regend[mcnt]))
                     regs->start[mcnt] = regs->end[mcnt] = -1;
                   else
                     {
-		      regs->start[mcnt]
-			= (regoff_t) POINTER_TO_OFFSET (regstart[mcnt]);
+                      regs->start[mcnt]
+                        = (regoff_t) POINTER_TO_OFFSET (regstart[mcnt]);
                       regs->end[mcnt]
-			= (regoff_t) POINTER_TO_OFFSET (regend[mcnt]);
+                        = (regoff_t) POINTER_TO_OFFSET (regend[mcnt]);
                     }
-		}
+                }
 
               /* If the regs structure we return has more elements than
                  were in the pattern, set the extra elements to -1.  If
@@ -4640,7 +4640,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                  -1 at the end.  */
               for (mcnt = num_regs; (unsigned) mcnt < regs->num_regs; mcnt++)
                 regs->start[mcnt] = regs->end[mcnt] = -1;
-	    } /* regs && !bufp->no_sub */
+            } /* regs && !bufp->no_sub */
 
           DEBUG_PRINT4 ("%u failure points pushed, %u popped (%u remain).\n",
                         nfailure_points_pushed, nfailure_points_popped,
@@ -4648,8 +4648,8 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           DEBUG_PRINT2 ("%u registers pushed.\n", num_regs_pushed);
 
           mcnt = d - pos - (MATCHING_IN_FIRST_STRING
-			    ? string1
-			    : string2 - size1);
+                            ? string1
+                            : string2 - size1);
 
           DEBUG_PRINT2 ("Returning %d from re_match_2.\n", mcnt);
 
@@ -4659,91 +4659,91 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
       /* Otherwise match next pattern command.  */
       switch (SWITCH_ENUM_CAST ((re_opcode_t) *p++))
-	{
+        {
         /* Ignore these.  Used to ignore the n of succeed_n's which
            currently have n == 0.  */
         case no_op:
           DEBUG_PRINT1 ("EXECUTING no_op.\n");
           break;
 
-	case succeed:
+        case succeed:
           DEBUG_PRINT1 ("EXECUTING succeed.\n");
-	  goto succeed_label;
+          goto succeed_label;
 
         /* Match the next n pattern characters exactly.  The following
            byte in the pattern defines n, and the n bytes after that
            are the characters to match.  */
-	case exactn:
-	  mcnt = *p++;
+        case exactn:
+          mcnt = *p++;
           DEBUG_PRINT2 ("EXECUTING exactn %d.\n", mcnt);
 
           /* This is written out as an if-else so we don't waste time
              testing `translate' inside the loop.  */
           if (translate)
-	    {
-	      do
-		{
-		  PREFETCH ();
-		  if ((unsigned char) translate[(unsigned char) *d++]
-		      != (unsigned char) *p++)
+            {
+              do
+                {
+                  PREFETCH ();
+                  if ((unsigned char) translate[(unsigned char) *d++]
+                      != (unsigned char) *p++)
                     goto fail;
-		}
-	      while (--mcnt);
-	    }
-	  else
-	    {
-	      do
-		{
-		  PREFETCH ();
-		  if (*d++ != (char) *p++) goto fail;
-		}
-	      while (--mcnt);
-	    }
-	  SET_REGS_MATCHED ();
+                }
+              while (--mcnt);
+            }
+          else
+            {
+              do
+                {
+                  PREFETCH ();
+                  if (*d++ != (char) *p++) goto fail;
+                }
+              while (--mcnt);
+            }
+          SET_REGS_MATCHED ();
           break;
 
 
         /* Match any character except possibly a newline or a null.  */
-	case anychar:
+        case anychar:
           DEBUG_PRINT1 ("EXECUTING anychar.\n");
 
           PREFETCH ();
 
           if ((!(bufp->syntax & RE_DOT_NEWLINE) && TRANSLATE (*d) == '\n')
               || (bufp->syntax & RE_DOT_NOT_NULL && TRANSLATE (*d) == '\000'))
-	    goto fail;
+            goto fail;
 
           SET_REGS_MATCHED ();
           DEBUG_PRINT2 ("  Matched `%d'.\n", *d);
           d++;
-	  break;
+          break;
 
 
-	case charset:
-	case charset_not:
-	  {
-	    register unsigned char c;
-	    boolean not = (re_opcode_t) *(p - 1) == charset_not;
+        case charset:
+        case charset_not:
+          {
+            register unsigned char c;
+            boolean not = (re_opcode_t) *(p - 1) == charset_not;
 
             DEBUG_PRINT2 ("EXECUTING charset%s.\n", not ? "_not" : "");
 
-	    PREFETCH ();
-	    c = TRANSLATE (*d); /* The character to match.  */
+            PREFETCH ();
+            c = TRANSLATE (*d); /* The character to match.  */
 
             /* Cast to `unsigned' instead of `unsigned char' in case the
                bit list is a full 32 bytes long.  */
-	    if (c < (unsigned) (*p * BYTEWIDTH)
-		&& p[1 + c / BYTEWIDTH] & (1 << (c % BYTEWIDTH)))
-	      not = !not;
+            if (c < (unsigned) (*p * BYTEWIDTH)
+                && p[1 + c / BYTEWIDTH] & (1 << (c % BYTEWIDTH)))
+              not = !not;
 
-	    p += 1 + *p;
+            p += 1 + *p;
 
-	    if (!not) goto fail;
+            if (!not) goto fail;
 
-	    SET_REGS_MATCHED ();
+            SET_REGS_MATCHED ();
             d++;
-	    break;
-	  }
+            break;
+          }
 
 
         /* The beginning of a group is represented by start_memory.
@@ -4752,10 +4752,10 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
            matched within the group is recorded (in the internal
            registers data structure) under the register number.  */
         case start_memory:
-	  DEBUG_PRINT3 ("EXECUTING start_memory %d (%d):\n", *p, p[1]);
+          DEBUG_PRINT3 ("EXECUTING start_memory %d (%d):\n", *p, p[1]);
 
           /* Find out if this group can match the empty string.  */
-	  p1 = p;		/* To send to group_match_null_string_p.  */
+          p1 = p;                /* To send to group_match_null_string_p.  */
 
           if (REG_MATCH_NULL_STRING_P (reg_info[*p]) == MATCH_NULL_UNSET_VALUE)
             REG_MATCH_NULL_STRING_P (reg_info[*p])
@@ -4769,17 +4769,17 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           old_regstart[*p] = REG_MATCH_NULL_STRING_P (reg_info[*p])
                              ? REG_UNSET (regstart[*p]) ? d : regstart[*p]
                              : regstart[*p];
-	  DEBUG_PRINT2 ("  old_regstart: %d\n",
-			 POINTER_TO_OFFSET (old_regstart[*p]));
+          DEBUG_PRINT2 ("  old_regstart: %d\n",
+                         POINTER_TO_OFFSET (old_regstart[*p]));
 
           regstart[*p] = d;
-	  DEBUG_PRINT2 ("  regstart: %d\n", POINTER_TO_OFFSET (regstart[*p]));
+          DEBUG_PRINT2 ("  regstart: %d\n", POINTER_TO_OFFSET (regstart[*p]));
 
           IS_ACTIVE (reg_info[*p]) = 1;
           MATCHED_SOMETHING (reg_info[*p]) = 0;
 
-	  /* Clear this whenever we change the register activity status.  */
-	  set_regs_matched_done = 0;
+          /* Clear this whenever we change the register activity status.  */
+          set_regs_matched_done = 0;
 
           /* This is the new highest active register.  */
           highest_active_reg = *p;
@@ -4791,7 +4791,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
           /* Move past the register number and inner group count.  */
           p += 2;
-	  just_past_start_mem = p;
+          just_past_start_mem = p;
 
           break;
 
@@ -4799,8 +4799,8 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
         /* The stop_memory opcode represents the end of a group.  Its
            arguments are the same as start_memory's: the register
            number, and the number of inner groups.  */
-	case stop_memory:
-	  DEBUG_PRINT3 ("EXECUTING stop_memory %d (%d):\n", *p, p[1]);
+        case stop_memory:
+          DEBUG_PRINT3 ("EXECUTING stop_memory %d (%d):\n", *p, p[1]);
 
           /* We need to save the string position the last time we were at
              this close-group operator in case the group is operated
@@ -4809,18 +4809,18 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
              the string in case this attempt to match fails.  */
           old_regend[*p] = REG_MATCH_NULL_STRING_P (reg_info[*p])
                            ? REG_UNSET (regend[*p]) ? d : regend[*p]
-			   : regend[*p];
-	  DEBUG_PRINT2 ("      old_regend: %d\n",
-			 POINTER_TO_OFFSET (old_regend[*p]));
+                           : regend[*p];
+          DEBUG_PRINT2 ("      old_regend: %d\n",
+                         POINTER_TO_OFFSET (old_regend[*p]));
 
           regend[*p] = d;
-	  DEBUG_PRINT2 ("      regend: %d\n", POINTER_TO_OFFSET (regend[*p]));
+          DEBUG_PRINT2 ("      regend: %d\n", POINTER_TO_OFFSET (regend[*p]));
 
           /* This register isn't active anymore.  */
           IS_ACTIVE (reg_info[*p]) = 0;
 
-	  /* Clear this whenever we change the register activity status.  */
-	  set_regs_matched_done = 0;
+          /* Clear this whenever we change the register activity status.  */
+          set_regs_matched_done = 0;
 
           /* If this was the only register active, nothing is active
              anymore.  */
@@ -4845,7 +4845,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                  registers 1 and 2 as a result of the *, but when we pop
                  back to the second ), we are at the stop_memory 1.
                  Thus, nothing is active.  */
-	      if (r == 0)
+              if (r == 0)
                 {
                   lowest_active_reg = NO_LOWEST_ACTIVE_REG;
                   highest_active_reg = NO_HIGHEST_ACTIVE_REG;
@@ -4861,7 +4861,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
              last match.  */
           if ((!MATCHED_SOMETHING (reg_info[*p])
                || just_past_start_mem == p - 1)
-	      && (p + 2) < pend)
+              && (p + 2) < pend)
             {
               boolean is_a_jump_n = false;
 
@@ -4870,29 +4870,29 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
               switch ((re_opcode_t) *p1++)
                 {
                   case jump_n:
-		    is_a_jump_n = true;
+                    is_a_jump_n = true;
                   case pop_failure_jump:
-		  case maybe_pop_jump:
-		  case jump:
-		  case dummy_failure_jump:
+                  case maybe_pop_jump:
+                  case jump:
+                  case dummy_failure_jump:
                     EXTRACT_NUMBER_AND_INCR (mcnt, p1);
-		    if (is_a_jump_n)
-		      p1 += 2;
+                    if (is_a_jump_n)
+                      p1 += 2;
                     break;
 
                   default:
                     /* do nothing */ ;
                 }
-	      p1 += mcnt;
+              p1 += mcnt;
 
               /* If the next operation is a jump backwards in the pattern
-	         to an on_failure_jump right before the start_memory
+                 to an on_failure_jump right before the start_memory
                  corresponding to this stop_memory, exit from the loop
                  by forcing a failure after pushing on the stack the
                  on_failure_jump's jump in the pattern, and d.  */
               if (mcnt < 0 && (re_opcode_t) *p1 == on_failure_jump
                   && (re_opcode_t) p1[3] == start_memory && p1[4] == *p)
-		{
+                {
                   /* If this group ever matched anything, then restore
                      what its registers were before trying this last
                      failed match, e.g., with `(a*)*b' against `ab' for
@@ -4904,14 +4904,14 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                      otherwise get trashed).  */
 
                   if (EVER_MATCHED_SOMETHING (reg_info[*p]))
-		    {
-		      unsigned r;
+                    {
+                      unsigned r;
 
                       EVER_MATCHED_SOMETHING (reg_info[*p]) = 0;
 
-		      /* Restore this and inner groups' (if any) registers.  */
+                      /* Restore this and inner groups' (if any) registers.  */
                       for (r = *p; r < (unsigned) *p + (unsigned) *(p + 1);
-			   r++)
+                           r++)
                         {
                           regstart[r] = old_regstart[r];
 
@@ -4920,7 +4920,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                             regend[r] = old_regend[r];
                         }
                     }
-		  p1++;
+                  p1++;
                   EXTRACT_NUMBER_AND_INCR (mcnt, p1);
                   PUSH_FAILURE_POINT (p1 + mcnt, d, -2);
 
@@ -4933,15 +4933,15 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           break;
 
 
-	/* \<digit> has been turned into a `duplicate' command which is
+        /* \<digit> has been turned into a `duplicate' command which is
            followed by the numeric value of <digit> as the register number.  */
         case duplicate:
-	  {
-	    register const char *d2, *dend2;
-	    int regno = *p++;   /* Get which register to match against.  */
-	    DEBUG_PRINT2 ("EXECUTING duplicate %d.\n", regno);
+          {
+            register const char *d2, *dend2;
+            int regno = *p++;   /* Get which register to match against.  */
+            DEBUG_PRINT2 ("EXECUTING duplicate %d.\n", regno);
 
-	    /* Can't back reference a group which we've never matched.  */
+            /* Can't back reference a group which we've never matched.  */
             if (REG_UNSET (regstart[regno]) || REG_UNSET (regend[regno]))
               goto fail;
 
@@ -4954,54 +4954,54 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                the end of the first string.  */
 
             dend2 = ((FIRST_STRING_P (regstart[regno])
-		      == FIRST_STRING_P (regend[regno]))
-		     ? regend[regno] : end_match_1);
-	    for (;;)
-	      {
-		/* If necessary, advance to next segment in register
+                      == FIRST_STRING_P (regend[regno]))
+                     ? regend[regno] : end_match_1);
+            for (;;)
+              {
+                /* If necessary, advance to next segment in register
                    contents.  */
-		while (d2 == dend2)
-		  {
-		    if (dend2 == end_match_2) break;
-		    if (dend2 == regend[regno]) break;
+                while (d2 == dend2)
+                  {
+                    if (dend2 == end_match_2) break;
+                    if (dend2 == regend[regno]) break;
 
                     /* End of string1 => advance to string2. */
                     d2 = string2;
                     dend2 = regend[regno];
-		  }
-		/* At end of register contents => success */
-		if (d2 == dend2) break;
+                  }
+                /* At end of register contents => success */
+                if (d2 == dend2) break;
 
-		/* If necessary, advance to next segment in data.  */
-		PREFETCH ();
+                /* If necessary, advance to next segment in data.  */
+                PREFETCH ();
 
-		/* How many characters left in this segment to match.  */
-		mcnt = dend - d;
+                /* How many characters left in this segment to match.  */
+                mcnt = dend - d;
 
-		/* Want how many consecutive characters we can match in
+                /* Want how many consecutive characters we can match in
                    one shot, so, if necessary, adjust the count.  */
                 if (mcnt > dend2 - d2)
-		  mcnt = dend2 - d2;
+                  mcnt = dend2 - d2;
 
-		/* Compare that many; failure if mismatch, else move
+                /* Compare that many; failure if mismatch, else move
                    past them.  */
-		if (translate
+                if (translate
                     ? bcmp_translate (d, d2, mcnt, translate)
                     : memcmp (d, d2, mcnt))
-		  goto fail;
-		d += mcnt, d2 += mcnt;
+                  goto fail;
+                d += mcnt, d2 += mcnt;
 
-		/* Do this because we've match some characters.  */
-		SET_REGS_MATCHED ();
-	      }
-	  }
-	  break;
+                /* Do this because we've match some characters.  */
+                SET_REGS_MATCHED ();
+              }
+          }
+          break;
 
 
         /* begline matches the empty string at the beginning of the string
            (unless `not_bol' is set in `bufp'), and, if
            `newline_anchor' is set, after newlines.  */
-	case begline:
+        case begline:
           DEBUG_PRINT1 ("EXECUTING begline.\n");
 
           if (AT_STRINGS_BEG (d))
@@ -5017,7 +5017,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
 
         /* endline is the dual of begline.  */
-	case endline:
+        case endline:
           DEBUG_PRINT1 ("EXECUTING endline.\n");
 
           if (AT_STRINGS_END (d))
@@ -5034,7 +5034,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           goto fail;
 
 
-	/* Match at the very beginning of the data.  */
+        /* Match at the very beginning of the data.  */
         case begbuf:
           DEBUG_PRINT1 ("EXECUTING begbuf.\n");
           if (AT_STRINGS_BEG (d))
@@ -5042,11 +5042,11 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           goto fail;
 
 
-	/* Match at the very end of the data.  */
+        /* Match at the very end of the data.  */
         case endbuf:
           DEBUG_PRINT1 ("EXECUTING endbuf.\n");
-	  if (AT_STRINGS_END (d))
-	    break;
+          if (AT_STRINGS_END (d))
+            break;
           goto fail;
 
 
@@ -5080,7 +5080,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           break;
 
 
-	/* Uses of on_failure_jump:
+        /* Uses of on_failure_jump:
 
            Each alternative starts with an on_failure_jump that points
            to the beginning of the next alternative.  Each alternative
@@ -5092,7 +5092,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
            Repeats start with an on_failure_jump that points past both
            the repetition text and either the following jump or
            pop_failure_jump back to this on_failure_jump.  */
-	case on_failure_jump:
+        case on_failure_jump:
         on_failure:
           DEBUG_PRINT1 ("EXECUTING on_failure_jump");
 
@@ -5138,12 +5138,12 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
 
         /* A smart repeat ends with `maybe_pop_jump'.
-	   We change it to either `pop_failure_jump' or `jump'.  */
+           We change it to either `pop_failure_jump' or `jump'.  */
         case maybe_pop_jump:
           EXTRACT_NUMBER_AND_INCR (mcnt, p);
           DEBUG_PRINT2 ("EXECUTING maybe_pop_jump %d.\n", mcnt);
           {
-	    register unsigned char *p2 = p;
+            register unsigned char *p2 = p;
 
             /* Compare the beginning of the repeat with what in the
                pattern follows its end. If we can establish that there
@@ -5158,130 +5158,130 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                detect that here, the alternative has put on a dummy
                failure point which is what we will end up popping.  */
 
-	    /* Skip over open/close-group commands.
-	       If what follows this loop is a ...+ construct,
-	       look at what begins its body, since we will have to
-	       match at least one of that.  */
-	    while (1)
-	      {
-		if (p2 + 2 < pend
-		    && ((re_opcode_t) *p2 == stop_memory
-			|| (re_opcode_t) *p2 == start_memory))
-		  p2 += 3;
-		else if (p2 + 6 < pend
-			 && (re_opcode_t) *p2 == dummy_failure_jump)
-		  p2 += 6;
-		else
-		  break;
-	      }
+            /* Skip over open/close-group commands.
+               If what follows this loop is a ...+ construct,
+               look at what begins its body, since we will have to
+               match at least one of that.  */
+            while (1)
+              {
+                if (p2 + 2 < pend
+                    && ((re_opcode_t) *p2 == stop_memory
+                        || (re_opcode_t) *p2 == start_memory))
+                  p2 += 3;
+                else if (p2 + 6 < pend
+                         && (re_opcode_t) *p2 == dummy_failure_jump)
+                  p2 += 6;
+                else
+                  break;
+              }
 
-	    p1 = p + mcnt;
-	    /* p1[0] ... p1[2] are the `on_failure_jump' corresponding
-	       to the `maybe_finalize_jump' of this case.  Examine what
-	       follows.  */
+            p1 = p + mcnt;
+            /* p1[0] ... p1[2] are the `on_failure_jump' corresponding
+               to the `maybe_finalize_jump' of this case.  Examine what
+               follows.  */
 
             /* If we're at the end of the pattern, we can change.  */
             if (p2 == pend)
-	      {
-		/* Consider what happens when matching ":\(.*\)"
-		   against ":/".  I don't really understand this code
-		   yet.  */
-  	        p[-3] = (unsigned char) pop_failure_jump;
+              {
+                /* Consider what happens when matching ":\(.*\)"
+                   against ":/".  I don't really understand this code
+                   yet.  */
+                  p[-3] = (unsigned char) pop_failure_jump;
                 DEBUG_PRINT1
                   ("  End of pattern: change to `pop_failure_jump'.\n");
               }
 
             else if ((re_opcode_t) *p2 == exactn
-		     || (bufp->newline_anchor && (re_opcode_t) *p2 == endline))
-	      {
-		register unsigned char c
+                     || (bufp->newline_anchor && (re_opcode_t) *p2 == endline))
+              {
+                register unsigned char c
                   = *p2 == (unsigned char) endline ? '\n' : p2[2];
 
                 if ((re_opcode_t) p1[3] == exactn && p1[5] != c)
                   {
-  		    p[-3] = (unsigned char) pop_failure_jump;
+                      p[-3] = (unsigned char) pop_failure_jump;
                     DEBUG_PRINT3 ("  %c != %c => pop_failure_jump.\n",
                                   c, p1[5]);
                   }
 
-		else if ((re_opcode_t) p1[3] == charset
-			 || (re_opcode_t) p1[3] == charset_not)
-		  {
-		    int not = (re_opcode_t) p1[3] == charset_not;
+                else if ((re_opcode_t) p1[3] == charset
+                         || (re_opcode_t) p1[3] == charset_not)
+                  {
+                    int not = (re_opcode_t) p1[3] == charset_not;
 
-		    if (c < (unsigned char) (p1[4] * BYTEWIDTH)
-			&& p1[5 + c / BYTEWIDTH] & (1 << (c % BYTEWIDTH)))
-		      not = !not;
+                    if (c < (unsigned char) (p1[4] * BYTEWIDTH)
+                        && p1[5 + c / BYTEWIDTH] & (1 << (c % BYTEWIDTH)))
+                      not = !not;
 
                     /* `not' is equal to 1 if c would match, which means
                         that we can't change to pop_failure_jump.  */
-		    if (!not)
+                    if (!not)
                       {
-  		        p[-3] = (unsigned char) pop_failure_jump;
+                          p[-3] = (unsigned char) pop_failure_jump;
                         DEBUG_PRINT1 ("  No match => pop_failure_jump.\n");
                       }
-		  }
-	      }
+                  }
+              }
             else if ((re_opcode_t) *p2 == charset)
-	      {
-		/* We win if the first character of the loop is not part
+              {
+                /* We win if the first character of the loop is not part
                    of the charset.  */
                 if ((re_opcode_t) p1[3] == exactn
- 		    && ! ((int) p2[1] * BYTEWIDTH > (int) p1[5]
- 			  && (p2[2 + p1[5] / BYTEWIDTH]
- 			      & (1 << (p1[5] % BYTEWIDTH)))))
-		  {
-		    p[-3] = (unsigned char) pop_failure_jump;
-		    DEBUG_PRINT1 ("  No match => pop_failure_jump.\n");
+                     && ! ((int) p2[1] * BYTEWIDTH > (int) p1[5]
+                           && (p2[2 + p1[5] / BYTEWIDTH]
+                               & (1 << (p1[5] % BYTEWIDTH)))))
+                  {
+                    p[-3] = (unsigned char) pop_failure_jump;
+                    DEBUG_PRINT1 ("  No match => pop_failure_jump.\n");
                   }
 
-		else if ((re_opcode_t) p1[3] == charset_not)
-		  {
-		    int idx;
-		    /* We win if the charset_not inside the loop
-		       lists every character listed in the charset after.  */
-		    for (idx = 0; idx < (int) p2[1]; idx++)
-		      if (! (p2[2 + idx] == 0
-			     || (idx < (int) p1[4]
-				 && ((p2[2 + idx] & ~ p1[5 + idx]) == 0))))
-			break;
+                else if ((re_opcode_t) p1[3] == charset_not)
+                  {
+                    int idx;
+                    /* We win if the charset_not inside the loop
+                       lists every character listed in the charset after.  */
+                    for (idx = 0; idx < (int) p2[1]; idx++)
+                      if (! (p2[2 + idx] == 0
+                             || (idx < (int) p1[4]
+                                 && ((p2[2 + idx] & ~ p1[5 + idx]) == 0))))
+                        break;
 
-		    if (idx == p2[1])
+                    if (idx == p2[1])
                       {
-  		        p[-3] = (unsigned char) pop_failure_jump;
+                          p[-3] = (unsigned char) pop_failure_jump;
                         DEBUG_PRINT1 ("  No match => pop_failure_jump.\n");
                       }
-		  }
-		else if ((re_opcode_t) p1[3] == charset)
-		  {
-		    int idx;
-		    /* We win if the charset inside the loop
-		       has no overlap with the one after the loop.  */
-		    for (idx = 0;
-			 idx < (int) p2[1] && idx < (int) p1[4];
-			 idx++)
-		      if ((p2[2 + idx] & p1[5 + idx]) != 0)
-			break;
+                  }
+                else if ((re_opcode_t) p1[3] == charset)
+                  {
+                    int idx;
+                    /* We win if the charset inside the loop
+                       has no overlap with the one after the loop.  */
+                    for (idx = 0;
+                         idx < (int) p2[1] && idx < (int) p1[4];
+                         idx++)
+                      if ((p2[2 + idx] & p1[5 + idx]) != 0)
+                        break;
 
-		    if (idx == p2[1] || idx == p1[4])
+                    if (idx == p2[1] || idx == p1[4])
                       {
-  		        p[-3] = (unsigned char) pop_failure_jump;
+                          p[-3] = (unsigned char) pop_failure_jump;
                         DEBUG_PRINT1 ("  No match => pop_failure_jump.\n");
                       }
-		  }
-	      }
-	  }
-	  p -= 2;		/* Point at relative address again.  */
-	  if ((re_opcode_t) p[-1] != pop_failure_jump)
-	    {
-	      p[-1] = (unsigned char) jump;
+                  }
+              }
+          }
+          p -= 2;                /* Point at relative address again.  */
+          if ((re_opcode_t) p[-1] != pop_failure_jump)
+            {
+              p[-1] = (unsigned char) jump;
               DEBUG_PRINT1 ("  Match => jump.\n");
-	      goto unconditional_jump;
-	    }
+              goto unconditional_jump;
+            }
         /* Note fall through.  */
 
 
-	/* The end of a simple repeat has a pop_failure_jump back to
+        /* The end of a simple repeat has a pop_failure_jump back to
            its matching on_failure_jump, where the latter will push a
            failure point.  The pop_failure_jump takes off failure
            points put on by this pop_failure_jump's matching
@@ -5303,27 +5303,27 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                                dummy_low_reg, dummy_high_reg,
                                reg_dummy, reg_dummy, reg_info_dummy);
           }
-	  /* Note fall through.  */
+          /* Note fall through.  */
 
-	unconditional_jump:
+        unconditional_jump:
 #ifdef _LIBC
-	  DEBUG_PRINT2 ("\n%p: ", p);
+          DEBUG_PRINT2 ("\n%p: ", p);
 #else
-	  DEBUG_PRINT2 ("\n0x%x: ", p);
+          DEBUG_PRINT2 ("\n0x%x: ", p);
 #endif
           /* Note fall through.  */
 
         /* Unconditionally jump (without popping any failure points).  */
         case jump:
-	  EXTRACT_NUMBER_AND_INCR (mcnt, p);	/* Get the amount to jump.  */
+          EXTRACT_NUMBER_AND_INCR (mcnt, p);        /* Get the amount to jump.  */
           DEBUG_PRINT2 ("EXECUTING jump %d ", mcnt);
-	  p += mcnt;				/* Do the jump.  */
+          p += mcnt;                                /* Do the jump.  */
 #ifdef _LIBC
           DEBUG_PRINT2 ("(to %p).\n", p);
 #else
           DEBUG_PRINT2 ("(to 0x%x).\n", p);
 #endif
-	  break;
+          break;
 
 
         /* We need this opcode so we can detect where alternatives end
@@ -5369,7 +5369,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
           if (mcnt > 0)
             {
                mcnt--;
-	       p += 2;
+               p += 2;
                STORE_NUMBER_AND_INCR (p, mcnt);
 #ifdef _LIBC
                DEBUG_PRINT3 ("  Setting %p to %d.\n", p - 2, mcnt);
@@ -5377,14 +5377,14 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
                DEBUG_PRINT3 ("  Setting 0x%x to %d.\n", p - 2, mcnt);
 #endif
             }
-	  else if (mcnt == 0)
+          else if (mcnt == 0)
             {
 #ifdef _LIBC
               DEBUG_PRINT2 ("  Setting two bytes from %p to no_op.\n", p+2);
 #else
               DEBUG_PRINT2 ("  Setting two bytes from 0x%x to no_op.\n", p+2);
 #endif
-	      p[2] = (unsigned char) no_op;
+              p[2] = (unsigned char) no_op;
               p[3] = (unsigned char) no_op;
               goto on_failure;
             }
@@ -5404,15 +5404,15 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 #else
                DEBUG_PRINT3 ("  Setting 0x%x to %d.\n", p + 2, mcnt);
 #endif
-	       goto unconditional_jump;
+               goto unconditional_jump;
             }
           /* If don't have to jump any more, skip over the rest of command.  */
-	  else
-	    p += 4;
+          else
+            p += 4;
           break;
 
-	case set_number_at:
-	  {
+        case set_number_at:
+          {
             DEBUG_PRINT1 ("EXECUTING set_number_at.\n");
 
             EXTRACT_NUMBER_AND_INCR (mcnt, p);
@@ -5423,155 +5423,155 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 #else
             DEBUG_PRINT3 ("  Setting 0x%x to %d.\n", p1, mcnt);
 #endif
-	    STORE_NUMBER (p1, mcnt);
+            STORE_NUMBER (p1, mcnt);
             break;
           }
 
 #if 0
-	/* The DEC Alpha C compiler 3.x generates incorrect code for the
-	   test  WORDCHAR_P (d - 1) != WORDCHAR_P (d)  in the expansion of
-	   AT_WORD_BOUNDARY, so this code is disabled.  Expanding the
-	   macro and introducing temporary variables works around the bug.  */
+        /* The DEC Alpha C compiler 3.x generates incorrect code for the
+           test  WORDCHAR_P (d - 1) != WORDCHAR_P (d)  in the expansion of
+           AT_WORD_BOUNDARY, so this code is disabled.  Expanding the
+           macro and introducing temporary variables works around the bug.  */
 
-	case wordbound:
-	  DEBUG_PRINT1 ("EXECUTING wordbound.\n");
-	  if (AT_WORD_BOUNDARY (d))
-	    break;
-	  goto fail;
-
-	case notwordbound:
-	  DEBUG_PRINT1 ("EXECUTING notwordbound.\n");
-	  if (AT_WORD_BOUNDARY (d))
-	    goto fail;
-	  break;
-#else
-	case wordbound:
-	{
-	  boolean prevchar, thischar;
-
-	  DEBUG_PRINT1 ("EXECUTING wordbound.\n");
-	  if (AT_STRINGS_BEG (d) || AT_STRINGS_END (d))
-	    break;
-
-	  prevchar = WORDCHAR_P (d - 1);
-	  thischar = WORDCHAR_P (d);
-	  if (prevchar != thischar)
-	    break;
-	  goto fail;
-	}
-
-      case notwordbound:
-	{
-	  boolean prevchar, thischar;
-
-	  DEBUG_PRINT1 ("EXECUTING notwordbound.\n");
-	  if (AT_STRINGS_BEG (d) || AT_STRINGS_END (d))
-	    goto fail;
-
-	  prevchar = WORDCHAR_P (d - 1);
-	  thischar = WORDCHAR_P (d);
-	  if (prevchar != thischar)
-	    goto fail;
-	  break;
-	}
-#endif
-
-	case wordbeg:
-          DEBUG_PRINT1 ("EXECUTING wordbeg.\n");
-	  if (WORDCHAR_P (d) && (AT_STRINGS_BEG (d) || !WORDCHAR_P (d - 1)))
-	    break;
+        case wordbound:
+          DEBUG_PRINT1 ("EXECUTING wordbound.\n");
+          if (AT_WORD_BOUNDARY (d))
+            break;
           goto fail;
 
-	case wordend:
+        case notwordbound:
+          DEBUG_PRINT1 ("EXECUTING notwordbound.\n");
+          if (AT_WORD_BOUNDARY (d))
+            goto fail;
+          break;
+#else
+        case wordbound:
+        {
+          boolean prevchar, thischar;
+
+          DEBUG_PRINT1 ("EXECUTING wordbound.\n");
+          if (AT_STRINGS_BEG (d) || AT_STRINGS_END (d))
+            break;
+
+          prevchar = WORDCHAR_P (d - 1);
+          thischar = WORDCHAR_P (d);
+          if (prevchar != thischar)
+            break;
+          goto fail;
+        }
+
+      case notwordbound:
+        {
+          boolean prevchar, thischar;
+
+          DEBUG_PRINT1 ("EXECUTING notwordbound.\n");
+          if (AT_STRINGS_BEG (d) || AT_STRINGS_END (d))
+            goto fail;
+
+          prevchar = WORDCHAR_P (d - 1);
+          thischar = WORDCHAR_P (d);
+          if (prevchar != thischar)
+            goto fail;
+          break;
+        }
+#endif
+
+        case wordbeg:
+          DEBUG_PRINT1 ("EXECUTING wordbeg.\n");
+          if (WORDCHAR_P (d) && (AT_STRINGS_BEG (d) || !WORDCHAR_P (d - 1)))
+            break;
+          goto fail;
+
+        case wordend:
           DEBUG_PRINT1 ("EXECUTING wordend.\n");
-	  if (!AT_STRINGS_BEG (d) && WORDCHAR_P (d - 1)
+          if (!AT_STRINGS_BEG (d) && WORDCHAR_P (d - 1)
               && (!WORDCHAR_P (d) || AT_STRINGS_END (d)))
-	    break;
+            break;
           goto fail;
 
 #ifdef emacs
-  	case before_dot:
+          case before_dot:
           DEBUG_PRINT1 ("EXECUTING before_dot.\n");
- 	  if (PTR_CHAR_POS ((unsigned char *) d) >= point)
-  	    goto fail;
-  	  break;
+           if (PTR_CHAR_POS ((unsigned char *) d) >= point)
+              goto fail;
+            break;
 
-  	case at_dot:
+          case at_dot:
           DEBUG_PRINT1 ("EXECUTING at_dot.\n");
- 	  if (PTR_CHAR_POS ((unsigned char *) d) != point)
-  	    goto fail;
-  	  break;
+           if (PTR_CHAR_POS ((unsigned char *) d) != point)
+              goto fail;
+            break;
 
-  	case after_dot:
+          case after_dot:
           DEBUG_PRINT1 ("EXECUTING after_dot.\n");
           if (PTR_CHAR_POS ((unsigned char *) d) <= point)
-  	    goto fail;
-  	  break;
+              goto fail;
+            break;
 
-	case syntaxspec:
+        case syntaxspec:
           DEBUG_PRINT2 ("EXECUTING syntaxspec %d.\n", mcnt);
-	  mcnt = *p++;
-	  goto matchsyntax;
+          mcnt = *p++;
+          goto matchsyntax;
 
         case wordchar:
           DEBUG_PRINT1 ("EXECUTING Emacs wordchar.\n");
-	  mcnt = (int) Sword;
+          mcnt = (int) Sword;
         matchsyntax:
-	  PREFETCH ();
-	  /* Can't use *d++ here; SYNTAX may be an unsafe macro.  */
-	  d++;
-	  if (SYNTAX (d[-1]) != (enum syntaxcode) mcnt)
-	    goto fail;
+          PREFETCH ();
+          /* Can't use *d++ here; SYNTAX may be an unsafe macro.  */
+          d++;
+          if (SYNTAX (d[-1]) != (enum syntaxcode) mcnt)
+            goto fail;
           SET_REGS_MATCHED ();
-	  break;
+          break;
 
-	case notsyntaxspec:
+        case notsyntaxspec:
           DEBUG_PRINT2 ("EXECUTING notsyntaxspec %d.\n", mcnt);
-	  mcnt = *p++;
-	  goto matchnotsyntax;
+          mcnt = *p++;
+          goto matchnotsyntax;
 
         case notwordchar:
           DEBUG_PRINT1 ("EXECUTING Emacs notwordchar.\n");
-	  mcnt = (int) Sword;
+          mcnt = (int) Sword;
         matchnotsyntax:
-	  PREFETCH ();
-	  /* Can't use *d++ here; SYNTAX may be an unsafe macro.  */
-	  d++;
-	  if (SYNTAX (d[-1]) == (enum syntaxcode) mcnt)
-	    goto fail;
-	  SET_REGS_MATCHED ();
+          PREFETCH ();
+          /* Can't use *d++ here; SYNTAX may be an unsafe macro.  */
+          d++;
+          if (SYNTAX (d[-1]) == (enum syntaxcode) mcnt)
+            goto fail;
+          SET_REGS_MATCHED ();
           break;
 
 #else /* not emacs */
-	case wordchar:
+        case wordchar:
           DEBUG_PRINT1 ("EXECUTING non-Emacs wordchar.\n");
-	  PREFETCH ();
+          PREFETCH ();
           if (!WORDCHAR_P (d))
-            goto fail;
-	  SET_REGS_MATCHED ();
-          d++;
-	  break;
-
-	case notwordchar:
-          DEBUG_PRINT1 ("EXECUTING non-Emacs notwordchar.\n");
-	  PREFETCH ();
-	  if (WORDCHAR_P (d))
             goto fail;
           SET_REGS_MATCHED ();
           d++;
-	  break;
+          break;
+
+        case notwordchar:
+          DEBUG_PRINT1 ("EXECUTING non-Emacs notwordchar.\n");
+          PREFETCH ();
+          if (WORDCHAR_P (d))
+            goto fail;
+          SET_REGS_MATCHED ();
+          d++;
+          break;
 #endif /* not emacs */
 
         default:
           abort ();
-	}
+        }
       continue;  /* Successfully executed one pattern command; keep going.  */
 
 
     /* We goto here if a matching operation fails. */
     fail:
       if (!FAIL_STACK_EMPTY ())
-	{ /* A restart point is known.  Restore to that state.  */
+        { /* A restart point is known.  Restore to that state.  */
           DEBUG_PRINT1 ("\nFAIL:\n");
           POP_FAILURE_POINT (d, p,
                              lowest_active_reg, highest_active_reg,
@@ -5579,10 +5579,10 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
           /* If this failure point is a dummy, try the next one.  */
           if (!p)
-	    goto fail;
+            goto fail;
 
           /* If we failed to the end of the pattern, don't examine *p.  */
-	  assert (p <= pend);
+          assert (p <= pend);
           if (p < pend)
             {
               boolean is_a_jump_n = false;
@@ -5611,7 +5611,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
             }
 
           if (d >= string1 && d <= end1)
-	    dend = end_match_1;
+            dend = end_match_1;
         }
       else
         break;   /* Matching at this starting point really fails.  */
@@ -5622,7 +5622,7 @@ re_match_2_internal (bufp, string1, size1, string2, size2, pos, regs, stop)
 
   FREE_VARIABLES ();
 
-  return -1;         			/* Failure to match.  */
+  return -1;                                 /* Failure to match.  */
 } /* re_match_2 */
 
 /* Subroutine definitions for re_match_2.  */
@@ -5650,7 +5650,7 @@ group_match_null_string_p (p, end, reg_info)
   while (p1 < end)
     {
       /* Skip over opcodes that can match nothing, and return true or
-	 false, as appropriate, when we get to one that can't, or to the
+         false, as appropriate, when we get to one that can't, or to the
          matching stop_memory.  */
 
       switch ((re_opcode_t) *p1)
@@ -5661,10 +5661,10 @@ group_match_null_string_p (p, end, reg_info)
           EXTRACT_NUMBER_AND_INCR (mcnt, p1);
 
           /* If the next operation is not a jump backwards in the
-	     pattern.  */
+             pattern.  */
 
-	  if (mcnt >= 0)
-	    {
+          if (mcnt >= 0)
+            {
               /* Go through the on_failure_jumps of the alternatives,
                  seeing if any of the alternatives cannot match nothing.
                  The last alternative starts with only a jump,
@@ -5690,11 +5690,11 @@ group_match_null_string_p (p, end, reg_info)
                      its number.  */
 
                   if (!alt_match_null_string_p (p1, p1 + mcnt - 3,
-				                      reg_info))
+                                                      reg_info))
                     return false;
 
                   /* Move to right after this alternative, including the
-		     jump_past_alt.  */
+                     jump_past_alt.  */
                   p1 += mcnt;
 
                   /* Break if it's the beginning of an n-th alternative
@@ -5702,13 +5702,13 @@ group_match_null_string_p (p, end, reg_info)
                   if ((re_opcode_t) *p1 != on_failure_jump)
                     break;
 
-		  /* Still have to check that it's not an n-th
-		     alternative that starts with an on_failure_jump.  */
-		  p1++;
+                  /* Still have to check that it's not an n-th
+                     alternative that starts with an on_failure_jump.  */
+                  p1++;
                   EXTRACT_NUMBER_AND_INCR (mcnt, p1);
                   if ((re_opcode_t) p1[mcnt-3] != jump_past_alt)
                     {
-		      /* Get to the beginning of the n-th alternative.  */
+                      /* Get to the beginning of the n-th alternative.  */
                       p1 -= 3;
                       break;
                     }
@@ -5722,13 +5722,13 @@ group_match_null_string_p (p, end, reg_info)
               if (!alt_match_null_string_p (p1, p1 + mcnt, reg_info))
                 return false;
 
-              p1 += mcnt;	/* Get past the n-th alternative.  */
+              p1 += mcnt;        /* Get past the n-th alternative.  */
             } /* if mcnt > 0 */
           break;
 
 
         case stop_memory:
-	  assert (p1[1] == **p);
+          assert (p1[1] == **p);
           *p = p1 + 2;
           return true;
 
@@ -5762,14 +5762,14 @@ alt_match_null_string_p (p, end, reg_info)
 
       switch ((re_opcode_t) *p1)
         {
-	/* It's a loop.  */
+        /* It's a loop.  */
         case on_failure_jump:
           p1++;
           EXTRACT_NUMBER_AND_INCR (mcnt, p1);
           p1 += mcnt;
           break;
 
-	default:
+        default:
           if (!common_op_match_null_string_p (&p1, end, reg_info))
             return false;
         }
@@ -5952,7 +5952,7 @@ re_comp (s)
   if (!s)
     {
       if (!re_comp_buf.buffer)
-	return gettext ("No previous regular expression");
+        return gettext ("No previous regular expression");
       return 0;
     }
 
@@ -5961,13 +5961,13 @@ re_comp (s)
       re_comp_buf.buffer = (unsigned char *) malloc (200);
       if (re_comp_buf.buffer == NULL)
         return (char *) gettext (re_error_msgid
-				 + re_error_msgid_idx[(int) REG_ESPACE]);
+                                 + re_error_msgid_idx[(int) REG_ESPACE]);
       re_comp_buf.allocated = 200;
 
       re_comp_buf.fastmap = (char *) malloc (1 << BYTEWIDTH);
       if (re_comp_buf.fastmap == NULL)
-	return (char *) gettext (re_error_msgid
-				 + re_error_msgid_idx[(int) REG_ESPACE]);
+        return (char *) gettext (re_error_msgid
+                                 + re_error_msgid_idx[(int) REG_ESPACE]);
     }
 
   /* Since `re_exec' always passes NULL for the `regs' argument, we
@@ -6063,8 +6063,8 @@ regcomp (preg, pattern, cflags)
       unsigned i;
 
       preg->translate
-	= (RE_TRANSLATE_TYPE) malloc (CHAR_SET_SIZE
-				      * sizeof (*(RE_TRANSLATE_TYPE)0));
+        = (RE_TRANSLATE_TYPE) malloc (CHAR_SET_SIZE
+                                      * sizeof (*(RE_TRANSLATE_TYPE)0));
       if (preg->translate == NULL)
         return (int) REG_ESPACE;
 
@@ -6099,14 +6099,14 @@ regcomp (preg, pattern, cflags)
   if (ret == REG_NOERROR && preg->fastmap)
     {
       /* Compute the fastmap now, since regexec cannot modify the pattern
-	 buffer.  */
+         buffer.  */
       if (re_compile_fastmap (preg) == -2)
-	{
-	  /* Some error occurred while computing the fastmap, just forget
-	     about it.  */
-	  free (preg->fastmap);
-	  preg->fastmap = NULL;
-	}
+        {
+          /* Some error occurred while computing the fastmap, just forget
+             about it.  */
+          free (preg->fastmap);
+          preg->fastmap = NULL;
+        }
     }
 
   return (int) ret;
@@ -6209,7 +6209,7 @@ regerror (errcode, preg, errbuf, errbuf_size)
 
   if (errcode < 0
       || errcode >= (int) (sizeof (re_error_msgid_idx)
-			   / sizeof (re_error_msgid_idx[0])))
+                           / sizeof (re_error_msgid_idx[0])))
     /* Only error codes returned by the rest of the code should be passed
        to this routine.  If we are given anything else, or if other regex
        code generates an invalid error code, then the program has a bug.
@@ -6225,7 +6225,7 @@ regerror (errcode, preg, errbuf, errbuf_size)
       if (msg_size > errbuf_size)
         {
 #if defined HAVE_MEMPCPY || defined _LIBC
-	  *((char *) __mempcpy (errbuf, msg, errbuf_size - 1)) = '\0';
+          *((char *) __mempcpy (errbuf, msg, errbuf_size - 1)) = '\0';
 #else
           memcpy (errbuf, msg, errbuf_size - 1);
           errbuf[errbuf_size - 1] = 0;

--- a/src/libcompat/regex/regex.h
+++ b/src/libcompat/regex/regex.h
@@ -172,33 +172,33 @@ extern reg_syntax_t re_syntax_options;
 /* [[[begin syntaxes]]] */
 #define RE_SYNTAX_EMACS 0
 
-#define RE_SYNTAX_AWK							\
-  (RE_BACKSLASH_ESCAPE_IN_LISTS   | RE_DOT_NOT_NULL			\
-   | RE_NO_BK_PARENS              | RE_NO_BK_REFS			\
-   | RE_NO_BK_VBAR                | RE_NO_EMPTY_RANGES			\
-   | RE_DOT_NEWLINE		  | RE_CONTEXT_INDEP_ANCHORS		\
+#define RE_SYNTAX_AWK                                                        \
+  (RE_BACKSLASH_ESCAPE_IN_LISTS   | RE_DOT_NOT_NULL                        \
+   | RE_NO_BK_PARENS              | RE_NO_BK_REFS                        \
+   | RE_NO_BK_VBAR                | RE_NO_EMPTY_RANGES                        \
+   | RE_DOT_NEWLINE                  | RE_CONTEXT_INDEP_ANCHORS                \
    | RE_UNMATCHED_RIGHT_PAREN_ORD | RE_NO_GNU_OPS)
 
-#define RE_SYNTAX_GNU_AWK						\
-  ((RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS | RE_DEBUG)	\
+#define RE_SYNTAX_GNU_AWK                                                \
+  ((RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS | RE_DEBUG)        \
    & ~(RE_DOT_NOT_NULL | RE_INTERVALS | RE_CONTEXT_INDEP_OPS))
 
-#define RE_SYNTAX_POSIX_AWK 						\
-  (RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS		\
-   | RE_INTERVALS	    | RE_NO_GNU_OPS)
+#define RE_SYNTAX_POSIX_AWK                                                 \
+  (RE_SYNTAX_POSIX_EXTENDED | RE_BACKSLASH_ESCAPE_IN_LISTS                \
+   | RE_INTERVALS            | RE_NO_GNU_OPS)
 
-#define RE_SYNTAX_GREP							\
-  (RE_BK_PLUS_QM              | RE_CHAR_CLASSES				\
-   | RE_HAT_LISTS_NOT_NEWLINE | RE_INTERVALS				\
+#define RE_SYNTAX_GREP                                                        \
+  (RE_BK_PLUS_QM              | RE_CHAR_CLASSES                                \
+   | RE_HAT_LISTS_NOT_NEWLINE | RE_INTERVALS                                \
    | RE_NEWLINE_ALT)
 
-#define RE_SYNTAX_EGREP							\
-  (RE_CHAR_CLASSES        | RE_CONTEXT_INDEP_ANCHORS			\
-   | RE_CONTEXT_INDEP_OPS | RE_HAT_LISTS_NOT_NEWLINE			\
-   | RE_NEWLINE_ALT       | RE_NO_BK_PARENS				\
+#define RE_SYNTAX_EGREP                                                        \
+  (RE_CHAR_CLASSES        | RE_CONTEXT_INDEP_ANCHORS                        \
+   | RE_CONTEXT_INDEP_OPS | RE_HAT_LISTS_NOT_NEWLINE                        \
+   | RE_NEWLINE_ALT       | RE_NO_BK_PARENS                                \
    | RE_NO_BK_VBAR)
 
-#define RE_SYNTAX_POSIX_EGREP						\
+#define RE_SYNTAX_POSIX_EGREP                                                \
   (RE_SYNTAX_EGREP | RE_INTERVALS | RE_NO_BK_BRACES)
 
 /* P1003.2/D11.2, section 4.20.7.1, lines 5078ff.  */
@@ -207,32 +207,32 @@ extern reg_syntax_t re_syntax_options;
 #define RE_SYNTAX_SED RE_SYNTAX_POSIX_BASIC
 
 /* Syntax bits common to both basic and extended POSIX regex syntax.  */
-#define _RE_SYNTAX_POSIX_COMMON						\
-  (RE_CHAR_CLASSES | RE_DOT_NEWLINE      | RE_DOT_NOT_NULL		\
+#define _RE_SYNTAX_POSIX_COMMON                                                \
+  (RE_CHAR_CLASSES | RE_DOT_NEWLINE      | RE_DOT_NOT_NULL                \
    | RE_INTERVALS  | RE_NO_EMPTY_RANGES)
 
-#define RE_SYNTAX_POSIX_BASIC						\
+#define RE_SYNTAX_POSIX_BASIC                                                \
   (_RE_SYNTAX_POSIX_COMMON | RE_BK_PLUS_QM)
 
 /* Differs from ..._POSIX_BASIC only in that RE_BK_PLUS_QM becomes
    RE_LIMITED_OPS, i.e., \? \+ \| are not recognized.  Actually, this
    isn't minimal, since other operators, such as \`, aren't disabled.  */
-#define RE_SYNTAX_POSIX_MINIMAL_BASIC					\
+#define RE_SYNTAX_POSIX_MINIMAL_BASIC                                        \
   (_RE_SYNTAX_POSIX_COMMON | RE_LIMITED_OPS)
 
-#define RE_SYNTAX_POSIX_EXTENDED					\
-  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS			\
-   | RE_CONTEXT_INDEP_OPS   | RE_NO_BK_BRACES				\
-   | RE_NO_BK_PARENS        | RE_NO_BK_VBAR				\
+#define RE_SYNTAX_POSIX_EXTENDED                                        \
+  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS                        \
+   | RE_CONTEXT_INDEP_OPS   | RE_NO_BK_BRACES                                \
+   | RE_NO_BK_PARENS        | RE_NO_BK_VBAR                                \
    | RE_CONTEXT_INVALID_OPS | RE_UNMATCHED_RIGHT_PAREN_ORD)
 
 /* Differs from ..._POSIX_EXTENDED in that RE_CONTEXT_INDEP_OPS is
    removed and RE_NO_BK_REFS is added.  */
-#define RE_SYNTAX_POSIX_MINIMAL_EXTENDED				\
-  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS			\
-   | RE_CONTEXT_INVALID_OPS | RE_NO_BK_BRACES				\
-   | RE_NO_BK_PARENS        | RE_NO_BK_REFS				\
-   | RE_NO_BK_VBAR	    | RE_UNMATCHED_RIGHT_PAREN_ORD)
+#define RE_SYNTAX_POSIX_MINIMAL_EXTENDED                                \
+  (_RE_SYNTAX_POSIX_COMMON  | RE_CONTEXT_INDEP_ANCHORS                        \
+   | RE_CONTEXT_INVALID_OPS | RE_NO_BK_BRACES                                \
+   | RE_NO_BK_PARENS        | RE_NO_BK_REFS                                \
+   | RE_NO_BK_VBAR            | RE_UNMATCHED_RIGHT_PAREN_ORD)
 /* [[[end syntaxes]]] */
 
 /* Maximum number of duplicates an interval can allow.  Some systems
@@ -283,31 +283,31 @@ extern reg_syntax_t re_syntax_options;
 typedef enum
 {
 #ifdef _XOPEN_SOURCE
-  REG_ENOSYS = -1,	/* This will never happen for this implementation.  */
+  REG_ENOSYS = -1,        /* This will never happen for this implementation.  */
 #endif
 
-  REG_NOERROR = 0,	/* Success.  */
-  REG_NOMATCH,		/* Didn't find a match (for regexec).  */
+  REG_NOERROR = 0,        /* Success.  */
+  REG_NOMATCH,                /* Didn't find a match (for regexec).  */
 
   /* POSIX regcomp return error codes.  (In the order listed in the
      standard.)  */
-  REG_BADPAT,		/* Invalid pattern.  */
-  REG_ECOLLATE,		/* Not implemented.  */
-  REG_ECTYPE,		/* Invalid character class name.  */
-  REG_EESCAPE,		/* Trailing backslash.  */
-  REG_ESUBREG,		/* Invalid back reference.  */
-  REG_EBRACK,		/* Unmatched left bracket.  */
-  REG_EPAREN,		/* Parenthesis imbalance.  */
-  REG_EBRACE,		/* Unmatched \{.  */
-  REG_BADBR,		/* Invalid contents of \{\}.  */
-  REG_ERANGE,		/* Invalid range end.  */
-  REG_ESPACE,		/* Ran out of memory.  */
-  REG_BADRPT,		/* No preceding re for repetition op.  */
+  REG_BADPAT,                /* Invalid pattern.  */
+  REG_ECOLLATE,                /* Not implemented.  */
+  REG_ECTYPE,                /* Invalid character class name.  */
+  REG_EESCAPE,                /* Trailing backslash.  */
+  REG_ESUBREG,                /* Invalid back reference.  */
+  REG_EBRACK,                /* Unmatched left bracket.  */
+  REG_EPAREN,                /* Parenthesis imbalance.  */
+  REG_EBRACE,                /* Unmatched \{.  */
+  REG_BADBR,                /* Invalid contents of \{\}.  */
+  REG_ERANGE,                /* Invalid range end.  */
+  REG_ESPACE,                /* Ran out of memory.  */
+  REG_BADRPT,                /* No preceding re for repetition op.  */
 
   /* Error codes we've added.  */
-  REG_EEND,		/* Premature end.  */
-  REG_ESIZE,		/* Compiled pattern bigger than 2^16 bytes.  */
-  REG_ERPAREN		/* Unmatched ) or \); not returned from regcomp.  */
+  REG_EEND,                /* Premature end.  */
+  REG_ESIZE,                /* Compiled pattern bigger than 2^16 bytes.  */
+  REG_ERPAREN                /* Unmatched ) or \); not returned from regcomp.  */
 } reg_errcode_t;
 
 /* This data structure represents a compiled pattern.  Before calling
@@ -323,15 +323,15 @@ typedef enum
 struct re_pattern_buffer
 {
 /* [[[begin pattern_buffer]]] */
-	/* Space that holds the compiled pattern.  It is declared as
+        /* Space that holds the compiled pattern.  It is declared as
           `unsigned char *' because its elements are
            sometimes used as array indexes.  */
   unsigned char *buffer;
 
-	/* Number of bytes to which `buffer' points.  */
+        /* Number of bytes to which `buffer' points.  */
   unsigned long int allocated;
 
-	/* Number of bytes actually used in `buffer'.  */
+        /* Number of bytes actually used in `buffer'.  */
   unsigned long int used;
 
         /* Syntax setting with which the pattern was compiled.  */
@@ -348,7 +348,7 @@ struct re_pattern_buffer
            when it is matched.  */
   RE_TRANSLATE_TYPE translate;
 
-	/* Number of subexpressions found by the compiler.  */
+        /* Number of subexpressions found by the compiler.  */
   size_t re_nsub;
 
         /* Zero if this pattern cannot match the empty string, one else.
@@ -531,23 +531,23 @@ extern int re_exec _RE_ARGS ((const char *));
 
 /* POSIX compatibility.  */
 extern int regcomp _RE_ARGS ((regex_t *__restrict __preg,
-			      const char *__restrict __pattern,
-			      int __cflags));
+                              const char *__restrict __pattern,
+                              int __cflags));
 
 extern int regexec _RE_ARGS ((const regex_t *__restrict __preg,
-			      const char *__restrict __string, size_t __nmatch,
-			      regmatch_t __pmatch[__restrict_arr],
-			      int __eflags));
+                              const char *__restrict __string, size_t __nmatch,
+                              regmatch_t __pmatch[__restrict_arr],
+                              int __eflags));
 
 extern size_t regerror _RE_ARGS ((int __errcode, const regex_t *__preg,
-				  char *__errbuf, size_t __errbuf_size));
+                                  char *__errbuf, size_t __errbuf_size));
 
 extern void regfree _RE_ARGS ((regex_t *__preg));
 
 
 #ifdef __cplusplus
 }
-#endif	/* C++ */
+#endif        /* C++ */
 
 #endif /* regex.h */
 

--- a/src/libcompat/regions.c
+++ b/src/libcompat/regions.c
@@ -230,14 +230,14 @@ char *rstrdup(region r, const char *s)
 
 inline static 
 char *internal_rstrextend(region r, const char *old, size_t newsize,
-			  int needsclear)
+                          int needsclear)
 {
   /* For now we don't attempt to extend the old storage area */
   void *newmem, *hdr;
   unsigned long *oldhdr, oldsize;
 
   qalloc(r, &r->normal, &hdr, sizeof(unsigned long), ALIGNMENT_LONG,
-	 &newmem, newsize, RALIGNMENT, 0);
+         &newmem, newsize, RALIGNMENT, 0);
 
   /* If we don't do this we can't find the header: */
   hdr = (char *)newmem - sizeof(unsigned long);
@@ -250,9 +250,9 @@ char *internal_rstrextend(region r, const char *old, size_t newsize,
       oldsize = *oldhdr;
 
       if (oldsize > newsize)
-	oldsize = newsize;
+        oldsize = newsize;
       else if (needsclear)
-	clear((char *)newmem + oldsize, newsize - oldsize);
+        clear((char *)newmem + oldsize, newsize - oldsize);
       memcpy(newmem, old, oldsize);
     }
   else if (needsclear)

--- a/src/libcompat/stats.c
+++ b/src/libcompat/stats.c
@@ -15,7 +15,7 @@
 register unsigned long long tscr asm("%o0");
 #define tsc() ({ \
     __asm__ __volatile__("rd %%tick,%%o1; srlx %%o1,32,%%o0" \
-			  : : : "%o0", "%o1"); \
+                          : : : "%o0", "%o1"); \
     tscr; })
 #else
 #define tsc() 0
@@ -36,8 +36,8 @@ static double proc_frequency(void)
 #define tsc() ({unsigned long long x; rdtscll(x); x; })
 #define rdpmcll(counter,x) \
      __asm__ __volatile__("rdpmc" \
-			  : "=A" (x) \
-			  : "c" (counter))
+                          : "=A" (x) \
+                          : "c" (counter))
 #define pmc0() ({unsigned long long x; rdpmcll(0, x); x; })
 #define pmc1() ({unsigned long long x; rdpmcll(1, x); x; })
 
@@ -57,13 +57,13 @@ static void print_memory_usage(void)
 {
 #if 0
   fprintf(stderr, "blocks alloced: %lu, %.1f%% 8K\n",
-	  (unsigned long)(total_8kblocks + total_otherblocks),
-	  (100.0 * total_8kblocks) / (total_8kblocks + total_otherblocks));
+          (unsigned long)(total_8kblocks + total_otherblocks),
+          (100.0 * total_8kblocks) / (total_8kblocks + total_otherblocks));
 
   fprintf(stderr, "system bytes(kB): %lu\n",
-	  ((unsigned long)total_system_bytes + 512) / 1024);
+          ((unsigned long)total_system_bytes + 512) / 1024);
   fprintf(stderr, "overhead: %.1f%%\n",
-	  total_system_bytes * 100.0 / bytes.max - 100);
+          total_system_bytes * 100.0 / bytes.max - 100);
 
 #endif
   { extern void malloc_stats(void); malloc_stats(); }

--- a/src/machine.c
+++ b/src/machine.c
@@ -51,14 +51,14 @@ bool select_target(const char *targetname)
   for (scan = machines; *scan; scan++)
     if (!strcmp(targetname, (*scan)->machine_name))
       {
-	if (*scan == &env_machine &&
-	    scan_env_machine(&env_machine, "NESC_MACHINE") == FALSE)
-	  {
-	    error("invalid target described in env NESC_MACHINE");
-	    return FALSE;
-	  }
-	target = *scan;
-	return TRUE;
+        if (*scan == &env_machine &&
+            scan_env_machine(&env_machine, "NESC_MACHINE") == FALSE)
+          {
+            error("invalid target described in env NESC_MACHINE");
+            return FALSE;
+          }
+        target = *scan;
+        return TRUE;
       }
 
   error("unknown target %s", targetname);

--- a/src/machine.h
+++ b/src/machine.h
@@ -36,7 +36,7 @@ typedef struct {
 
   /* A Keil C for 8051 special... */
   declaration (*keilc_definition)(location loc, cstring keyword, cstring name,
-				  expression address);
+                                  expression address);
 
   /* Called once when compilation starts. Should:
      - setup system-specific include paths

--- a/src/machine/avr.c
+++ b/src/machine/avr.c
@@ -21,32 +21,32 @@ static bool avr_decl_attribute(gcc_attribute attr, data_declaration ddecl)
 static machine_spec avr_machine = {
   "avr", 
   gcc_save_machine_options,
-  FALSE,			/* big_endian */
-  FALSE,			/* pcc_bitfield_type_matters */
-  8,				/* empty field boundary - in bits */
-  8,				/* structure size boundary - in bits */
-  1,				/* word size */
-  { 2, 1 },			/* pointer type */
-  { 4, 1 },			/* float */
-  { 4, 1 },			/* double */
-  { 4, 1 },			/* long double */
-  { 2, 1 },			/* short */
-  { 2, 1 },			/* int */
-  { 4, 1 },			/* long */
-  { 8, 1 },			/* long long (unsupported in avr-gcc) */
-  1, 1, 1, 1,			/* int1/2/4/8 align */
-  2, 2,				/* wchar_t, size_t size */
-  TRUE, TRUE,			/* char, wchar_t signed */
-  NULL,				/* no attribute for async functions */
+  FALSE,                        /* big_endian */
+  FALSE,                        /* pcc_bitfield_type_matters */
+  8,                                /* empty field boundary - in bits */
+  8,                                /* structure size boundary - in bits */
+  1,                                /* word size */
+  { 2, 1 },                        /* pointer type */
+  { 4, 1 },                        /* float */
+  { 4, 1 },                        /* double */
+  { 4, 1 },                        /* long double */
+  { 2, 1 },                        /* short */
+  { 2, 1 },                        /* int */
+  { 4, 1 },                        /* long */
+  { 8, 1 },                        /* long long (unsupported in avr-gcc) */
+  1, 1, 1, 1,                        /* int1/2/4/8 align */
+  2, 2,                                /* wchar_t, size_t size */
+  TRUE, TRUE,                        /* char, wchar_t signed */
+  NULL,                                /* no attribute for async functions */
 
-  NULL,				/* adjust_field_align */
+  NULL,                                /* adjust_field_align */
 
-  avr_decl_attribute,		/* Attribute handling: declarations */
-  NULL, NULL, NULL,		/* Attribute handling: tag, field, type */
-  NULL, NULL,			/* preint, init */
-  NULL,				/* token */
-  NULL,				/* keil special */
-  gcc_global_cpp_init,		/* global cpp support */
-  NULL				/* per-file cpp support */
+  avr_decl_attribute,                /* Attribute handling: declarations */
+  NULL, NULL, NULL,                /* Attribute handling: tag, field, type */
+  NULL, NULL,                        /* preint, init */
+  NULL,                                /* token */
+  NULL,                                /* keil special */
+  gcc_global_cpp_init,                /* global cpp support */
+  NULL                                /* per-file cpp support */
 };
 

--- a/src/machine/env_machine.c
+++ b/src/machine/env_machine.c
@@ -33,32 +33,32 @@ static machine_spec env_machine = {
   "env", 
   gcc_save_machine_options,
   /* [default] */       /* [keyname] */
-  FALSE,		/* big_endian */
-  FALSE,		/* pcc_bitfield_type_matters */
-  8,			/* empty_field_boundary */
-  8,			/* structure_size_boundary */
-  1,			/* word size */
-  {2, 1},		/* pointer */
-  {4, 1},		/* float */
-  {4, 1},		/* double */
-  {4, 1},		/* long_double */
-  {2, 1},		/* short */
-  {2, 1},		/* int */
-  {4, 1},		/* long */
-  {8, 1},		/* long_long */
-  1, 1, 1, 1,		/* int1248_align */
-  2, 2,			/* wchar_size_size */
-  TRUE, TRUE,		/* char_wchar_signed */
-  NULL,			/* no attribute for async functions */
+  FALSE,                /* big_endian */
+  FALSE,                /* pcc_bitfield_type_matters */
+  8,                        /* empty_field_boundary */
+  8,                        /* structure_size_boundary */
+  1,                        /* word size */
+  {2, 1},                /* pointer */
+  {4, 1},                /* float */
+  {4, 1},                /* double */
+  {4, 1},                /* long_double */
+  {2, 1},                /* short */
+  {2, 1},                /* int */
+  {4, 1},                /* long */
+  {8, 1},                /* long_long */
+  1, 1, 1, 1,                /* int1248_align */
+  2, 2,                        /* wchar_size_size */
+  TRUE, TRUE,                /* char_wchar_signed */
+  NULL,                        /* no attribute for async functions */
 
-  NULL,				/* adjust_field_align */
+  NULL,                                /* adjust_field_align */
 
-  NULL, NULL, NULL, NULL,	/* Attributes: need some way to specify this */
-  NULL, NULL,			/* preinit, init */
-  NULL,				/* token */
-  NULL,				/* keil special */
-  gcc_global_cpp_init,		/* global cpp support */
-  NULL				/* per-file cpp support */
+  NULL, NULL, NULL, NULL,        /* Attributes: need some way to specify this */
+  NULL, NULL,                        /* preinit, init */
+  NULL,                                /* token */
+  NULL,                                /* keil special */
+  gcc_global_cpp_init,                /* global cpp support */
+  NULL                                /* per-file cpp support */
 };
 
 static const char *find_char(const char *str, const char *strend, char ch)
@@ -93,12 +93,12 @@ static int scan_boolean(const char *str, const char *strend)
 }
 
 static bool scan_intlist(const char *str, const char *strend, int *intlist,
-			 int count)
+                         int count)
 {
   while (count-- > 0)
     {
       if (str == strend)
-	return FALSE;
+        return FALSE;
       *intlist++ = atoi(str);
       str = find_not_char(find_char(str, strend, ','), strend, ',');
     }
@@ -144,160 +144,160 @@ static bool scan_env_machine(machine_spec * machine, const char *envname)
       int intlist[4] = { 0, 0, 0, 0 };
 
       if (is_literali(name = "pcc_bitfield_type_matters", begin, equal))
-	{
-	  int b = scan_boolean(value, space);
-	  if (b != -1)
-	    {
-	      machine->pcc_bitfield_type_matters = b ? TRUE : FALSE;
-	    }
-	  else
-	    {
-	      error("%s.%s, expected 'false' or 'true'", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          int b = scan_boolean(value, space);
+          if (b != -1)
+            {
+              machine->pcc_bitfield_type_matters = b ? TRUE : FALSE;
+            }
+          else
+            {
+              error("%s.%s, expected 'false' or 'true'", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "big_endian", begin, equal))
-	{
-	  int b = scan_boolean(value, space);
-	  if (b != -1)
-	    {
-	      machine->big_endian = b ? TRUE : FALSE;
-	    }
-	  else
-	    {
-	      error("%s.%s, expected 'false' or 'true'", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          int b = scan_boolean(value, space);
+          if (b != -1)
+            {
+              machine->big_endian = b ? TRUE : FALSE;
+            }
+          else
+            {
+              error("%s.%s, expected 'false' or 'true'", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "empty_field_boundary", begin, equal))
-	{
-	  if (scan_intlist(value, space, intlist, 1) == TRUE)
-	    {
-	      machine->empty_field_boundary = intlist[0];
-	    }
-	  else
-	    {
-	      error("%s.%s, expected one int", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          if (scan_intlist(value, space, intlist, 1) == TRUE)
+            {
+              machine->empty_field_boundary = intlist[0];
+            }
+          else
+            {
+              error("%s.%s, expected one int", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "structure_size_boundary", begin, equal))
-	{
-	  if (scan_intlist(value, space, intlist, 1) == TRUE)
-	    {
-	      machine->structure_size_boundary = intlist[0];
-	    }
-	  else
-	    {
-	      error("%s.%s, expected one int", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          if (scan_intlist(value, space, intlist, 1) == TRUE)
+            {
+              machine->structure_size_boundary = intlist[0];
+            }
+          else
+            {
+              error("%s.%s, expected one int", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "word_size", begin, equal))
-	{
-	  if (scan_intlist(value, space, intlist, 1) == TRUE)
-	    {
-	      machine->word_size = intlist[0];
-	    }
-	  else
-	    {
-	      error("%s.%s, expected one int", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          if (scan_intlist(value, space, intlist, 1) == TRUE)
+            {
+              machine->word_size = intlist[0];
+            }
+          else
+            {
+              error("%s.%s, expected one int", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "int1248_align", begin, equal))
-	{
-	  if (scan_intlist(value, space, intlist, 4) == TRUE)
-	    {
-	      machine->int1_align = intlist[0];
-	      machine->int2_align = intlist[1];
-	      machine->int4_align = intlist[2];
-	      machine->int8_align = intlist[3];
-	    }
-	  else
-	    {
-	      error("%s.%s, expected 4 ints", envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          if (scan_intlist(value, space, intlist, 4) == TRUE)
+            {
+              machine->int1_align = intlist[0];
+              machine->int2_align = intlist[1];
+              machine->int4_align = intlist[2];
+              machine->int8_align = intlist[3];
+            }
+          else
+            {
+              error("%s.%s, expected 4 ints", envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "wchar_size_size", begin, equal))
-	{
-	  if (scan_intlist(value, space, intlist, 2) == TRUE)
-	    {
-	      machine->wchar_t_size = intlist[0];
-	      machine->size_t_size = intlist[1];
-	    }
-	  else
-	    {
-	      error("%s.%s, expected 2 ints, wchar_t size and size_t size",
-		     envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          if (scan_intlist(value, space, intlist, 2) == TRUE)
+            {
+              machine->wchar_t_size = intlist[0];
+              machine->size_t_size = intlist[1];
+            }
+          else
+            {
+              error("%s.%s, expected 2 ints, wchar_t size and size_t size",
+                     envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "char_wchar_signed", begin, equal))
-	{
-	  const char *comma = find_char(value, space, ',');
-	  if (comma != space)
-	    {
-	      int b1 = scan_boolean(value, comma);
-	      int b2 =
-		scan_boolean(find_not_char(comma, space, ','), space);
-	      if (b1 != -1 && b2 != -1)
-		{
-		  machine->char_signed = b1 ? TRUE : FALSE;
-		  machine->wchar_t_signed = b2 ? TRUE : FALSE;
-		}
-	      else
-		{
-		  error("%s.%s, bools must be 'false' or 'true'", envname,
-			 name);
-		  n_errors++;
-		}
-	    }
-	  else
-	    {
-	      error("%s.%s, expected 2 bools, char and wchar signed",
-		     envname, name);
-	      n_errors++;
-	    }
-	}
+        {
+          const char *comma = find_char(value, space, ',');
+          if (comma != space)
+            {
+              int b1 = scan_boolean(value, comma);
+              int b2 =
+                scan_boolean(find_not_char(comma, space, ','), space);
+              if (b1 != -1 && b2 != -1)
+                {
+                  machine->char_signed = b1 ? TRUE : FALSE;
+                  machine->wchar_t_signed = b2 ? TRUE : FALSE;
+                }
+              else
+                {
+                  error("%s.%s, bools must be 'false' or 'true'", envname,
+                         name);
+                  n_errors++;
+                }
+            }
+          else
+            {
+              error("%s.%s, expected 2 bools, char and wchar signed",
+                     envname, name);
+              n_errors++;
+            }
+        }
       else if (is_literali(name = "async_functions", begin, equal))
-	{
-	  int l = space - value;
-	  char *s = rstralloc(permanent, l + 1);
+        {
+          int l = space - value;
+          char *s = rstralloc(permanent, l + 1);
 
-	  memcpy(s, value, l);
-	  s[l] = '\0';
-	  machine->async_functions_atribute = s;
-	}
+          memcpy(s, value, l);
+          s[l] = '\0';
+          machine->async_functions_atribute = s;
+        }
       else
-	{
-	  int i = 0;
-	  for (i = 0; typespecs[i].name != NULL; i++)
-	    {
-	      if (is_literali(name = typespecs[i].name, begin, equal))
-		{
-		  if (scan_intlist(value, space, intlist, 2) == TRUE)
-		    {
-		      typespecs[i].spec->size = intlist[0];
-		      typespecs[i].spec->align = intlist[1];
-		      break;
-		    }
-		  else
-		    {
-		      error("%s.%s, expected 2 ints, size and align",
-			     envname, name);
-		      n_errors++;
-		    }
-		}
-	    }
+        {
+          int i = 0;
+          for (i = 0; typespecs[i].name != NULL; i++)
+            {
+              if (is_literali(name = typespecs[i].name, begin, equal))
+                {
+                  if (scan_intlist(value, space, intlist, 2) == TRUE)
+                    {
+                      typespecs[i].spec->size = intlist[0];
+                      typespecs[i].spec->align = intlist[1];
+                      break;
+                    }
+                  else
+                    {
+                      error("%s.%s, expected 2 ints, size and align",
+                             envname, name);
+                      n_errors++;
+                    }
+                }
+            }
 
-	  if (typespecs[i].name == NULL)
-	    {
-	      error("%s, unknown field name starting at %s", envname, begin);
-	      n_errors++;
-	    }
-	}
+          if (typespecs[i].name == NULL)
+            {
+              error("%s, unknown field name starting at %s", envname, begin);
+              n_errors++;
+            }
+        }
 
       begin = find_not_char(space, end, ' ');
     }

--- a/src/machine/keil.c
+++ b/src/machine/keil.c
@@ -51,7 +51,7 @@ static int keil_token(const char *token, int len, struct yystype *lvalp)
 }
 
 declaration keil_special(location loc, cstring keyword, cstring name,
-			 expression address)
+                         expression address)
 {
   /* I just love this kind of code. */
   region r = parse_region;
@@ -85,30 +85,30 @@ declaration keil_special(location loc, cstring keyword, cstring name,
 /* Basic pointer sizes and alignments for the 8051's compiled w/ Keil C51 */
 static machine_spec keil_machine = {
   "keil51", NULL,
-  TRUE,				/* big_endian */
-  FALSE,			/* pcc_bitfield_type_matters */
-  8,				/* empty field boundary - in bits */
-  8,				/* structure size boundary - in bits */
-  1,				/* word size */
-  { 2, 1 },			/* pointer type */
-  { 4, 1 },			/* float */
-  { 4, 1 },			/* double */
-  { 4, 1 },			/* long double */
-  { 2, 1 },			/* short */
-  { 2, 1 },			/* int */
-  { 4, 1 },			/* long */
-  { 8, 1 },			/* long long (unsupported in avr-gcc) */
-  1, 1, 1, 1,			/* int1/2/4/8 align */
-  2, 2,				/* wchar_t, size_t size */
-  TRUE, TRUE,			/* char, wchar_t signed */
-  "reentrant",			/* attribute for async functions */
+  TRUE,                                /* big_endian */
+  FALSE,                        /* pcc_bitfield_type_matters */
+  8,                                /* empty field boundary - in bits */
+  8,                                /* structure size boundary - in bits */
+  1,                                /* word size */
+  { 2, 1 },                        /* pointer type */
+  { 4, 1 },                        /* float */
+  { 4, 1 },                        /* double */
+  { 4, 1 },                        /* long double */
+  { 2, 1 },                        /* short */
+  { 2, 1 },                        /* int */
+  { 4, 1 },                        /* long */
+  { 8, 1 },                        /* long long (unsupported in avr-gcc) */
+  1, 1, 1, 1,                        /* int1/2/4/8 align */
+  2, 2,                                /* wchar_t, size_t size */
+  TRUE, TRUE,                        /* char, wchar_t signed */
+  "reentrant",                        /* attribute for async functions */
 
-  NULL,				/* adjust_field_align function */
-  NULL, NULL, NULL, NULL, 	/* attribute handling functions */
+  NULL,                                /* adjust_field_align function */
+  NULL, NULL, NULL, NULL,         /* attribute handling functions */
   NULL, keil_init,
   keil_token,
-  keil_special,			/* Keil C special */
-  gcc_global_cpp_init,		/* global cpp support: this should be tailored to keil
-				   to get correct behaviour */
-  NULL				/* per-file cpp support */
+  keil_special,                        /* Keil C special */
+  gcc_global_cpp_init,                /* global cpp support: this should be tailored to keil
+                                   to get correct behaviour */
+  NULL                                /* per-file cpp support */
 };

--- a/src/machine/msp430.c
+++ b/src/machine/msp430.c
@@ -13,7 +13,7 @@ static bool msp430_decl_attribute(gcc_attribute attr, data_declaration ddecl)
       ddecl->async = TRUE;
       /* The signal attribute may have come first */
       if (ddecl->spontaneous != c_call_nonatomic)
-	ddecl->spontaneous = c_call_atomic;
+        ddecl->spontaneous = c_call_atomic;
       return TRUE;
     }
   return FALSE;
@@ -23,31 +23,31 @@ static bool msp430_decl_attribute(gcc_attribute attr, data_declaration ddecl)
 static machine_spec msp430_machine = {
   "msp430", 
   gcc_save_machine_options,
-  FALSE,			/* big_endian */
-  FALSE,			/* pcc_bitfield_type_matters */
-  16,				/* empty field boundary - in bits */
-  8,				/* structure size boundary - in bits */
-  2,				/* word size */
-  { 2, 2 },			/* pointer type */
-  { 4, 2 },			/* float */
-  { 4, 2 },			/* double */
-  { 4, 2 },			/* long double */
-  { 2, 2 },			/* short */
-  { 2, 2 },			/* int */
-  { 4, 2 },			/* long */
-  { 8, 2 },			/* long long */
-  1, 2, 2, 2,			/* int1/2/4/8 align */
-  2, 2,				/* wchar_t, size_t size */
-  TRUE, TRUE,			/* char, wchar_t signed */
-  NULL,				/* no attribute for async functions */
+  FALSE,                        /* big_endian */
+  FALSE,                        /* pcc_bitfield_type_matters */
+  16,                                /* empty field boundary - in bits */
+  8,                                /* structure size boundary - in bits */
+  2,                                /* word size */
+  { 2, 2 },                        /* pointer type */
+  { 4, 2 },                        /* float */
+  { 4, 2 },                        /* double */
+  { 4, 2 },                        /* long double */
+  { 2, 2 },                        /* short */
+  { 2, 2 },                        /* int */
+  { 4, 2 },                        /* long */
+  { 8, 2 },                        /* long long */
+  1, 2, 2, 2,                        /* int1/2/4/8 align */
+  2, 2,                                /* wchar_t, size_t size */
+  TRUE, TRUE,                        /* char, wchar_t signed */
+  NULL,                                /* no attribute for async functions */
 
-  NULL,				/* adjust_field_align */
+  NULL,                                /* adjust_field_align */
 
-  msp430_decl_attribute,	/* Attribute handling: declarations */
-  NULL, NULL, NULL,		/* Attribute handling: tag, field, type */
-  NULL, NULL,			/* preint, init */
-  NULL,				/* token */
-  NULL,				/* keil special */
-  gcc_global_cpp_init,		/* global cpp support */
-  NULL				/* per-file cpp support */
+  msp430_decl_attribute,        /* Attribute handling: declarations */
+  NULL, NULL, NULL,                /* Attribute handling: tag, field, type */
+  NULL, NULL,                        /* preint, init */
+  NULL,                                /* token */
+  NULL,                                /* keil special */
+  gcc_global_cpp_init,                /* global cpp support */
+  NULL                                /* per-file cpp support */
 };

--- a/src/machine/sdcc.c
+++ b/src/machine/sdcc.c
@@ -54,30 +54,30 @@ static int sdcc_token(const char *token, int len, struct yystype *lvalp)
 
 static machine_spec sdcc_machine = {
   "sdcc51", NULL,
-  FALSE,			/* big_endian */
-  FALSE,			/* pcc_bitfield_type_matters */
-  8,				/* empty field boundary - in bits */
-  8,				/* structure size boundary - in bits */
-  1,				/* word size */
-  { 2, 1 },			/* pointer type */
-  { 4, 1 },			/* float */
-  { 4, 1 },			/* double */
-  { 4, 1 },			/* long double */
-  { 2, 1 },			/* short */
-  { 2, 1 },			/* int */
-  { 4, 1 },			/* long */
-  { 8, 1 },			/* long long */
-  1, 1, 1, 1,			/* int1/2/4/8 align */
-  2, 2,				/* wchar_t, size_t size */
-  TRUE, TRUE,			/* char, wchar_t signed */
-  NULL,				/* no attribute for async functions */
+  FALSE,                        /* big_endian */
+  FALSE,                        /* pcc_bitfield_type_matters */
+  8,                                /* empty field boundary - in bits */
+  8,                                /* structure size boundary - in bits */
+  1,                                /* word size */
+  { 2, 1 },                        /* pointer type */
+  { 4, 1 },                        /* float */
+  { 4, 1 },                        /* double */
+  { 4, 1 },                        /* long double */
+  { 2, 1 },                        /* short */
+  { 2, 1 },                        /* int */
+  { 4, 1 },                        /* long */
+  { 8, 1 },                        /* long long */
+  1, 1, 1, 1,                        /* int1/2/4/8 align */
+  2, 2,                                /* wchar_t, size_t size */
+  TRUE, TRUE,                        /* char, wchar_t signed */
+  NULL,                                /* no attribute for async functions */
 
-  NULL,				/* adjust_field_align function */
-  NULL, NULL, NULL, NULL, 	/* attribute handling functions */
+  NULL,                                /* adjust_field_align function */
+  NULL, NULL, NULL, NULL,         /* attribute handling functions */
   NULL, sdcc_init,
   sdcc_token,
-  NULL,				/* Keil C special */
-  gcc_global_cpp_init,		/* global cpp support: this should be tailored to sdcc
-				   to get correct behaviour */
-  NULL				/* per-file cpp support */
+  NULL,                                /* Keil C special */
+  gcc_global_cpp_init,                /* global cpp support: this should be tailored to sdcc
+                                   to get correct behaviour */
+  NULL                                /* per-file cpp support */
 };

--- a/src/machine/self.c
+++ b/src/machine/self.c
@@ -64,10 +64,10 @@ static void self_handle_option(const char *arg)
 static machine_spec self_machine = {
   "pc", SELF_HANDLE_OPTION,
 
-  FALSE,			/* big_endian, set in preinit */
+  FALSE,                        /* big_endian, set in preinit */
 
   /* pcc_bitfield_type_matters */
-  sizeof(struct self_pcc1) != sizeof(struct self_pcc2),	
+  sizeof(struct self_pcc1) != sizeof(struct self_pcc2),        
 
   /* empty field boundary */
   sizeof(struct self_efb) * BITSPERBYTE, 
@@ -75,29 +75,29 @@ static machine_spec self_machine = {
   /* structure size boundary */
   sizeof(struct self_smallest) * BITSPERBYTE, 
 
-  sizeof(myword),				     /* word size */
-  { sizeof(void *),      __alignof__(void *) },	     /* pointer type */
-  { sizeof(float),       __alignof__(float) },	     /* float */
-  { sizeof(double),      __alignof__(double) },	     /* double */
+  sizeof(myword),                                     /* word size */
+  { sizeof(void *),      __alignof__(void *) },             /* pointer type */
+  { sizeof(float),       __alignof__(float) },             /* float */
+  { sizeof(double),      __alignof__(double) },             /* double */
   { sizeof(long double), __alignof__(long double) }, /* long double */
-  { sizeof(short),       __alignof__(short) },	     /* short */
-  { sizeof(int),         __alignof__(int) },	     /* int */
-  { sizeof(long),        __alignof__(long) },	     /* long */
+  { sizeof(short),       __alignof__(short) },             /* short */
+  { sizeof(int),         __alignof__(int) },             /* int */
+  { sizeof(long),        __alignof__(long) },             /* long */
   { sizeof(long long),   __alignof__(long long) },   /* long long */
   __alignof__(myint1), __alignof__(myint2),
-  __alignof__(myint4), __alignof__(myint8),	     /* int1/2/4/8 align */
-  sizeof(wchar_t), sizeof(size_t),		     /* wchar_t, size_t size */
-  (char)-1 < 0, (wchar_t)-1 < 0,		     /* char, wchar_t signed */
-  NULL,				/* no attribute for async functions */
+  __alignof__(myint4), __alignof__(myint8),             /* int1/2/4/8 align */
+  sizeof(wchar_t), sizeof(size_t),                     /* wchar_t, size_t size */
+  (char)-1 < 0, (wchar_t)-1 < 0,                     /* char, wchar_t signed */
+  NULL,                                /* no attribute for async functions */
 
-  SELF_ADJUST_FIELD_ALIGN,			     /* adjust_field_align */
+  SELF_ADJUST_FIELD_ALIGN,                             /* adjust_field_align */
 
-  NULL, NULL, NULL, NULL,	/* No special attributes */
-  self_preinit, NULL,		/* init */
-  NULL,				/* token */
-  NULL,				/* keil special */
-  gcc_global_cpp_init,		/* global cpp support */
-  NULL				/* per-file cpp support */
+  NULL, NULL, NULL, NULL,        /* No special attributes */
+  self_preinit, NULL,                /* init */
+  NULL,                                /* token */
+  NULL,                                /* keil special */
+  gcc_global_cpp_init,                /* global cpp support */
+  NULL                                /* per-file cpp support */
 };
 
 static void self_preinit(void)

--- a/src/nesc-abstract.c
+++ b/src/nesc-abstract.c
@@ -123,25 +123,25 @@ static void clone_ddecl(data_declaration ddecl)
       (!hack_interface || ddecl->instantiation->interface == hack_interface))
     {
       /* If the instantiation's context matches the current one, the
-	 instantiation was already done. */
+         instantiation was already done. */
       if (ddecl->container &&
-	  ddecl->instantiation->container == current.container)
-	return;
+          ddecl->instantiation->container == current.container)
+        return;
       if (ddecl->container_function && 
-	  ddecl->instantiation->container_function == current.function_decl->ddecl)
-	return;
+          ddecl->instantiation->container_function == current.function_decl->ddecl)
+        return;
     }
 
   /* Copy module functions (incl. tasks) and variables */
 
   if (!(ddecl->kind == decl_variable || ddecl->kind == decl_function ||
-	ddecl->kind == decl_constant || ddecl->kind == decl_typedef ||
-	ddecl->kind == decl_interface_ref))
+        ddecl->kind == decl_constant || ddecl->kind == decl_typedef ||
+        ddecl->kind == decl_interface_ref))
     return;
 
   /* Instantiate decls in modules */
   if (!(ddecl->container ||
-	(ddecl->container_function && ddecl->container_function->container)))
+        (ddecl->container_function && ddecl->container_function->container)))
     return;
 
   copy = declare(current.env, ddecl, TRUE);
@@ -187,7 +187,7 @@ static void copy_fields(region r, tag_declaration copy, tag_declaration orig)
       ofield->instantiation = cfield;
       cfield->instantiation = NULL;
       if (cfield->name)
-	env_add(copy->fields, cfield->name, cfield);
+        env_add(copy->fields, cfield->name, cfield);
       *nextfield = cfield;
       nextfield = &cfield->next;
     }
@@ -199,21 +199,21 @@ static void forward_tdecl(region r, tag_ref tref)
 
   /* Ignore non-module tags */
   if (!(tdecl->container ||
-	(tdecl->container_function && tdecl->container_function->container)))
+        (tdecl->container_function && tdecl->container_function->container)))
     return;
 
   /* If already cloned, use instance & return */
   if (tdecl->instantiation)
     {
       /* If the instantiation's context matches the current one, the
-	 instantiation was already done. */
+         instantiation was already done. */
       tref->tdecl = tdecl->instantiation;
       if (tdecl->container &&
-	  tdecl->instantiation->container == current.container)
-	return;
+          tdecl->instantiation->container == current.container)
+        return;
       if (tdecl->container_function && 
-	  tdecl->instantiation->container_function == current.function_decl->ddecl)
-	return;
+          tdecl->instantiation->container_function == current.function_decl->ddecl)
+        return;
     }
 
   copy = declare_tag(tref);
@@ -277,9 +277,9 @@ static void instantiate_ivalue_structured(region r, ivalue copy, ivalue value)
       new_fields = &copy_field->next;
 
       if (field->field->instantiation)
-	copy_field->field = field->field->instantiation;
+        copy_field->field = field->field->instantiation;
       else
-	copy_field->field = field->field;
+        copy_field->field = field->field;
       copy_field->value = instantiate_ivalue(r, field->value);
     }
 }
@@ -355,7 +355,7 @@ static type unary_type(unary e)
       return type_complex(etype) ? make_base_type(etype) : etype;
     }
     default: /* ++, --, cast, address of, dereference, field ref, 
-		component deref, not, sizeof expr, alignof expr */
+                component deref, not, sizeof expr, alignof expr */
       return instantiate_type(e->type);
     }
 }
@@ -375,11 +375,11 @@ static type binary_type(binary e)
       type t2 = type_default_conversion(e->arg2->type);
 
       /* Detect the various pointer arithmetic cases. These cannot lead to
-	 an unknown type, and don't want to be passed to common type */
+         an unknown type, and don't want to be passed to common type */
       if (type_pointer(t1) || type_pointer(t2))
-	return instantiate_type(e->type);
+        return instantiate_type(e->type);
       else
-	return common_type(t1, t2);
+        return common_type(t1, t2);
     }
     case kind_leq: case kind_geq: case kind_lt: case kind_gt:
     case kind_eq: case kind_ne:
@@ -411,19 +411,19 @@ static type conditional_type(conditional e)
       type tpointsto = type_points_to(ttype), fpointsto = type_points_to(ftype);
 
       if (type_compatible_unqualified(tpointsto, fpointsto))
-	rtype = common_type(tpointsto, fpointsto);
+        rtype = common_type(tpointsto, fpointsto);
       else if (definite_null(e->arg1) && type_void(tpointsto))
-	rtype = fpointsto;
+        rtype = fpointsto;
       else if (definite_null(e->arg2) && type_void(fpointsto))
-	rtype = tpointsto;
+        rtype = tpointsto;
       else if (type_void(tpointsto))
-	rtype = tpointsto; /* void * result */
+        rtype = tpointsto; /* void * result */
       else if (type_void(fpointsto))
-	rtype = fpointsto; /* void * result */
+        rtype = fpointsto; /* void * result */
       else
-	/* Slight difference from GCC: I qualify the result type with
-	   the appropriate qualifiers */
-	rtype = void_type;
+        /* Slight difference from GCC: I qualify the result type with
+           the appropriate qualifiers */
+        rtype = void_type;
 
       /* Qualifiers depend on both types */
       rtype = make_pointer_type(qualify_type2(rtype, tpointsto, fpointsto));
@@ -447,11 +447,11 @@ static type expression_type(expression e)
     {
     default:
       if (is_binary(e))
-	return binary_type(CAST(binary, e));
+        return binary_type(CAST(binary, e));
       if (is_unary(e))
-	return unary_type(CAST(unary, e));
+        return unary_type(CAST(unary, e));
       /* constants, label address, sizeof type, alignof type, identifier,
-	 function call: these cannot be unknown type */
+         function call: these cannot be unknown type */
       return instantiate_type(e->type); 
 
     case kind_comma:
@@ -465,7 +465,7 @@ static type expression_type(expression e)
 }
 
 static AST_walker_result clone_expression(AST_walker spec, void *data,
-					  expression *n)
+                                          expression *n)
 {
   expression new = clone(data, n);
   ivalue old_ivalue = NULL;
@@ -477,7 +477,7 @@ static AST_walker_result clone_expression(AST_walker spec, void *data,
       old_ivalue = new->ivalue;
       new->ivalue = copy;
       if (copy->kind == iv_base)
-	copy->u.base.expr = new;
+        copy->u.base.expr = new;
     }
 
   AST_walk_children(spec, data, CAST(node, new));
@@ -518,7 +518,7 @@ static AST_walker_result clone_asttype(AST_walker spec, void *data, asttype *n)
 }
 
 static AST_walker_result clone_function_decl(AST_walker spec, void *data,
-					     function_decl *n)
+                                             function_decl *n)
 {
   declaration old = CAST(declaration, *n);
   function_decl new = clone(data, n);
@@ -530,13 +530,13 @@ static AST_walker_result clone_function_decl(AST_walker spec, void *data,
       data_declaration instance = new->ddecl->instantiation;
 
       /* We need to forward the ddecl *and* update the definition field in
-	 the instantiated data_declaration. */
+         the instantiated data_declaration. */
       instance->definition = CAST(declaration, new);
       /* We update the ast field if it pointed to this function_decl
-	 (note that command and event data_declarations assume that the
-	 ast field points to the original variable_decl) */
+         (note that command and event data_declarations assume that the
+         ast field points to the original variable_decl) */
       if (instance->ast == old)
-	instance->ast = CAST(declaration, new);
+        instance->ast = CAST(declaration, new);
       new->ddecl = instance;
     }
 
@@ -550,7 +550,7 @@ static AST_walker_result clone_function_decl(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_identifier(AST_walker spec, void *data,
-					  identifier *n)
+                                          identifier *n)
 {
   clone_expression(spec, data, CASTPTR(expression, n));
   forward(&(*n)->ddecl);
@@ -559,7 +559,7 @@ static AST_walker_result clone_identifier(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_interface_deref(AST_walker spec, void *data,
-					       interface_deref *n)
+                                               interface_deref *n)
 {
   clone_expression(spec, data, CASTPTR(expression, n));
   forward(&(*n)->ddecl);
@@ -568,7 +568,7 @@ static AST_walker_result clone_interface_deref(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_component_deref(AST_walker spec, void *data,
-					       component_deref *n)
+                                               component_deref *n)
 {
   component_deref new = clone(data, n);
 
@@ -579,7 +579,7 @@ static AST_walker_result clone_component_deref(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_variable_decl(AST_walker spec, void *data,
-					     variable_decl *n)
+                                             variable_decl *n)
 {
   declaration old = CAST(declaration, *n);
   variable_decl new = clone(data, n);
@@ -589,23 +589,23 @@ static AST_walker_result clone_variable_decl(AST_walker spec, void *data,
       clone_ddecl(new->ddecl);
 
       if (new->ddecl->instantiation)
-	{
-	  data_declaration instance = new->ddecl->instantiation;
+        {
+          data_declaration instance = new->ddecl->instantiation;
 
-	  /* Forward the ddecl and update the ast and definition fields */
-	  if (instance->definition == old)
-	    instance->definition = CAST(declaration, new);
-	  if (instance->ast == old)
-	    instance->ast = CAST(declaration, new);
-	  new->ddecl = instance;
-	}
+          /* Forward the ddecl and update the ast and definition fields */
+          if (instance->definition == old)
+            instance->definition = CAST(declaration, new);
+          if (instance->ast == old)
+            instance->ast = CAST(declaration, new);
+          new->ddecl = instance;
+        }
     }
 
   return aw_walk;
 }
 
 static AST_walker_result clone_type_parm_decl(AST_walker spec, void *data,
-					     type_parm_decl *n)
+                                             type_parm_decl *n)
 {
   type_parm_decl new = clone(data, n);
   data_declaration instance;
@@ -620,7 +620,7 @@ static AST_walker_result clone_type_parm_decl(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_typename(AST_walker spec, void *data,
-					typename *n)
+                                        typename *n)
 {
   typename new = clone(data, n);
 
@@ -630,7 +630,7 @@ static AST_walker_result clone_typename(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_enumerator(AST_walker spec, void *data,
-					  enumerator *n)
+                                          enumerator *n)
 {
   enumerator new = clone(data, n);
 
@@ -650,7 +650,7 @@ static AST_walker_result clone_enumerator(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_tag_ref(AST_walker spec, void *data,
-				       tag_ref *n)
+                                       tag_ref *n)
 {
   tag_ref new = clone(data, n);
 
@@ -663,7 +663,7 @@ static AST_walker_result clone_tag_ref(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_field_decl(AST_walker spec, void *data,
-				       field_decl *n)
+                                       field_decl *n)
 {
   field_decl new = clone(data, n);
 
@@ -676,7 +676,7 @@ static AST_walker_result clone_field_decl(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_field_ref(AST_walker spec, void *data,
-					 field_ref *n)
+                                         field_ref *n)
 {
   field_ref new;
 
@@ -792,21 +792,21 @@ static void instantiate_cg(cgraph copy, cgraph original)
       cfrom = endpoint_lookup(copy, &from);
 
       graph_scan_out (connection, n)
-	{
-	  struct endp to = *NODE_GET(endp, graph_edge_to(connection));
-	  gnode cto;
+        {
+          struct endp to = *NODE_GET(endp, graph_edge_to(connection));
+          gnode cto;
 
-	  instantiate_endp(&to);
-	  cto = endpoint_lookup(copy, &to);
+          instantiate_endp(&to);
+          cto = endpoint_lookup(copy, &to);
 
-	  /* User graphs have locations on the edges */
-	  graph_add_edge(cfrom, cto, EDGE_GET(location, connection));
-	}
+          /* User graphs have locations on the edges */
+          graph_add_edge(cfrom, cto, EDGE_GET(location, connection));
+        }
     }
 }
 
 static AST_walker_result clone_component_ref(AST_walker spec, void *data,
-					     component_ref *n)
+                                             component_ref *n)
 {
   component_ref new = clone(data, n);
 
@@ -822,7 +822,7 @@ static AST_walker_result clone_component_ref(AST_walker spec, void *data,
 }
 
 static AST_walker_result clone_interface_ref(AST_walker spec, void *data,
-					     interface_ref *n)
+                                             interface_ref *n)
 {
   interface_ref new = clone(data, n);
 
@@ -838,13 +838,13 @@ static AST_walker_result clone_interface_ref(AST_walker spec, void *data,
     }
   else
     copy_interface_functions(data, current.container, 
-			     new->ddecl, new->ddecl->functions);
+                             new->ddecl, new->ddecl->functions);
 
   return aw_done;
 }
 
 static AST_walker_result clone_implementation(AST_walker spec, void *data,
-					      implementation *n)
+                                              implementation *n)
 {
   implementation new = clone(data, n);
   nesc_declaration comp = current.container, orig = original_component(comp);
@@ -861,11 +861,11 @@ static AST_walker_result clone_implementation(AST_walker spec, void *data,
       region r = regionof(comp->local_statics);
 
       dd_scan (scan, orig->local_statics)
-	{
-	  data_declaration localsd = DD_GET(data_declaration, scan);
+        {
+          data_declaration localsd = DD_GET(data_declaration, scan);
 
-	  dd_add_last(r, comp->local_statics, localsd->instantiation);
-	}
+          dd_add_last(r, comp->local_statics, localsd->instantiation);
+        }
     }
 
   /* Copy the connection graph
@@ -916,78 +916,78 @@ void set_parameter_values(nesc_declaration cdecl, expression args)
   scan_declaration (parm, cdecl->parameters)
     {
       if (is_data_decl(parm))
-	{
-	  variable_decl vd = CAST(variable_decl, CAST(data_decl, parm)->decls);
-	  cst_kind k = type_real(vd->ddecl->type) ?
-	    cst_numerical : cst_address;
+        {
+          variable_decl vd = CAST(variable_decl, CAST(data_decl, parm)->decls);
+          cst_kind k = type_real(vd->ddecl->type) ?
+            cst_numerical : cst_address;
 
-	  if (!args)
-	    {
-	      vd->ddecl->value = make_unknown_cst(k == cst_numerical ?
-						  cval_unknown_number :
-						  cval_unknown_address,
-						  vd->ddecl->type);
-	      continue;
-	    }
+          if (!args)
+            {
+              vd->ddecl->value = make_unknown_cst(k == cst_numerical ?
+                                                  cval_unknown_number :
+                                                  cval_unknown_address,
+                                                  vd->ddecl->type);
+              continue;
+            }
 
-	  if (!is_type_argument(args) && check_constant_once(args, k))
-	    {
-	      location l = args->location;
+          if (!is_type_argument(args) && check_constant_once(args, k))
+            {
+              location l = args->location;
 
-	      /* We can assume the type is arithmetic (for now at least)
-		 (see declare_template_parameter) */
-	      if (!args->cst)
-		{
-		  /* avoid duplicate error messages */
-		  if (args->type != error_type)
-		    error_with_location(l, "component arguments must be constants");
-		}
-	      else if (type_integer(vd->ddecl->type))
-		{
-		  if (!constant_integral(args->cst))
-		    error_with_location(l, "integer constant expected");
-		  else if (!cval_inrange(args->cst->cval, vd->ddecl->type))
-		    error_with_location(l, "constant out of range for argument type");
-		}
-	      else if (type_floating(vd->ddecl->type))
-		{
-		  if (!constant_float(args->cst))
-		    error_with_location(l, "floating-point constant expected");
-		}
-	      else if (type_charstar(vd->ddecl->type))
-		{
-		  /* Check that it's an actual string */
-		  data_declaration sym;
-		  bool ok = FALSE;
+              /* We can assume the type is arithmetic (for now at least)
+                 (see declare_template_parameter) */
+              if (!args->cst)
+                {
+                  /* avoid duplicate error messages */
+                  if (args->type != error_type)
+                    error_with_location(l, "component arguments must be constants");
+                }
+              else if (type_integer(vd->ddecl->type))
+                {
+                  if (!constant_integral(args->cst))
+                    error_with_location(l, "integer constant expected");
+                  else if (!cval_inrange(args->cst->cval, vd->ddecl->type))
+                    error_with_location(l, "constant out of range for argument type");
+                }
+              else if (type_floating(vd->ddecl->type))
+                {
+                  if (!constant_float(args->cst))
+                    error_with_location(l, "floating-point constant expected");
+                }
+              else if (type_charstar(vd->ddecl->type))
+                {
+                  /* Check that it's an actual string */
+                  data_declaration sym;
+                  bool ok = FALSE;
 
-		  if (constant_address(args->cst))
-		    {
-		      sym = cval_ddecl(args->cst->cval);
-		      /* We don't want any offset to the string either
-			 (could lift this restriction) */
-		      ok = sym && sym->kind == decl_magic_string &&
-			cval_knownbool(args->cst->cval);
-		    }
-		  if (!ok)
-		    error_with_location(l, "string argument expected");
-		}
-	    }
+                  if (constant_address(args->cst))
+                    {
+                      sym = cval_ddecl(args->cst->cval);
+                      /* We don't want any offset to the string either
+                         (could lift this restriction) */
+                      ok = sym && sym->kind == decl_magic_string &&
+                        cval_knownbool(args->cst->cval);
+                    }
+                  if (!ok)
+                    error_with_location(l, "string argument expected");
+                }
+            }
 
-	  vd->ddecl->value = args->cst;
-	}
+          vd->ddecl->value = args->cst;
+        }
       else /* type */
-	{
-	  type_parm_decl td = CAST(type_parm_decl, parm);
+        {
+          type_parm_decl td = CAST(type_parm_decl, parm);
 
-	  if (!args)
-	    {
-	      td->ddecl->type = error_type;
-	      continue;
-	    }
+          if (!args)
+            {
+              td->ddecl->type = error_type;
+              continue;
+            }
 
-	  td->ddecl->type = args->type;
-	  td->ddecl->initialiser = args;
-	}
+          td->ddecl->type = args->type;
+          td->ddecl->initialiser = args;
+        }
 
       args = CAST(expression, args->next);
     }
@@ -1096,7 +1096,7 @@ void push_instance(nesc_declaration component)
   if (component->original)
     {
       /* Instantiated component names is parent name (currently at the top
-	 of the stack) . name-in-configuration (currently in instance_name) */
+         of the stack) . name-in-configuration (currently in instance_name) */
       const char *oldname = component->instance_name;
       const char *parentname = stack->component->instance_name;
       int namelen = strlen(parentname) + strlen(oldname) + 2;
@@ -1133,10 +1133,10 @@ nesc_declaration abstract_recursion(void)
     {
       /* If we hit a non-instance component there isn't a loop */
       if (!i->component->original)
-	return NULL;
+        return NULL;
 
       if (original_component(i->component) == component)
-	return i->component;
+        return i->component;
     }
   return NULL;
 }
@@ -1166,7 +1166,7 @@ static void check_cg(cgraph connections)
       endp ep = NODE_GET(endp, n);
 
       if (ep->args_node)
-	check_generic_arguments(ep->args_node, endpoint_args(ep));
+        check_generic_arguments(ep->args_node, endpoint_args(ep));
     }
 }
 
@@ -1195,13 +1195,13 @@ static bool fold_components(nesc_declaration cdecl, int pass)
       check_cg(cdecl->connections);
 
       scan_declaration (d, c->decls)
-	if (is_component_ref(d))
-	  {
-	    component_ref comp = CAST(component_ref, d);
+        if (is_component_ref(d))
+          {
+            component_ref comp = CAST(component_ref, d);
 
-	    set_parameter_values(comp->cdecl, comp->args);
-	    done = fold_components(comp->cdecl, pass) && done;
-	  }
+            set_parameter_values(comp->cdecl, comp->args);
+            done = fold_components(comp->cdecl, pass) && done;
+          }
     }
   return done;
 }
@@ -1215,9 +1215,9 @@ void fold_program(nesc_declaration program, nesc_declaration scheduler)
     {
       done = fold_constants_list(CAST(node, all_cdecls), pass);
       if (program)
-	done = fold_components(program, pass) && done;
+        done = fold_components(program, pass) && done;
       if (scheduler)
-	done = fold_components(scheduler, pass) && done;
+        done = fold_components(scheduler, pass) && done;
       pass++;
     }
   while (!done);
@@ -1226,7 +1226,7 @@ void fold_program(nesc_declaration program, nesc_declaration scheduler)
 }
 
 void check_abstract_arguments(const char *kind, data_declaration ddecl,
-			      declaration parms, expression arglist)
+                              declaration parms, expression arglist)
 {
   location loc = ddecl->ast->location;
   int parmnum = 1;
@@ -1236,54 +1236,54 @@ void check_abstract_arguments(const char *kind, data_declaration ddecl,
       const char *errmsg = NULL;
 
       if (arglist->type == error_type)
-	;
+        ;
       else if (is_data_decl(parms))
-	{
-	  variable_decl vparm = CAST(variable_decl, CAST(data_decl, parms)->decls);
-	  type parmtype = vparm->ddecl->type;
+        {
+          variable_decl vparm = CAST(variable_decl, CAST(data_decl, parms)->decls);
+          type parmtype = vparm->ddecl->type;
 
-	  if (type_incomplete(parmtype))
-	    errmsg = "type of formal parameter %d is incomplete";
-	  else if (is_type_argument(arglist))
-	    errmsg = "formal parameter %d must be a value";
-	  else 
-	    {
-	      set_error_location(arglist->location);
-	      check_assignment(parmtype, arglist->type, arglist, NULL,
-			       ddecl, parmnum);
-	    }
-	}
+          if (type_incomplete(parmtype))
+            errmsg = "type of formal parameter %d is incomplete";
+          else if (is_type_argument(arglist))
+            errmsg = "formal parameter %d must be a value";
+          else 
+            {
+              set_error_location(arglist->location);
+              check_assignment(parmtype, arglist->type, arglist, NULL,
+                               ddecl, parmnum);
+            }
+        }
       else /* type argument */
-	{
-	  type_parm_decl tparm = CAST(type_parm_decl, parms);
+        {
+          type_parm_decl tparm = CAST(type_parm_decl, parms);
 
-	  if (!is_type_argument(arglist))
-	    errmsg = "formal parameter %d must be a type";
-	  else switch (tparm->ddecl->typevar_kind)
-	    {
-	    case typevar_normal: 
-	      /* These tests ensure the type can be used in assignments 
-	         and as a function argument. */
-	      if (type_array(arglist->type))
-		errmsg = "type parameter cannot be an array type (parameter %d)";
-	      else if (type_function(arglist->type))
-		errmsg = "type parameter cannot be a function type (parameter %d)";
-	      else if (type_incomplete(arglist->type))
-		errmsg = "type parameter %d is an incomplete type";
-	      break;
-	    case typevar_integer:
-	      if (!type_integer(arglist->type))
-		errmsg = "parameter %d must be an integer type";
-	      break;
-	    case typevar_number:
-	      if (!type_real(arglist->type))
-		errmsg = "parameter %d must be a numerical type";
-	      break;
-	    default: assert(0); break;
-	    }
-	}
+          if (!is_type_argument(arglist))
+            errmsg = "formal parameter %d must be a type";
+          else switch (tparm->ddecl->typevar_kind)
+            {
+            case typevar_normal: 
+              /* These tests ensure the type can be used in assignments 
+                 and as a function argument. */
+              if (type_array(arglist->type))
+                errmsg = "type parameter cannot be an array type (parameter %d)";
+              else if (type_function(arglist->type))
+                errmsg = "type parameter cannot be a function type (parameter %d)";
+              else if (type_incomplete(arglist->type))
+                errmsg = "type parameter %d is an incomplete type";
+              break;
+            case typevar_integer:
+              if (!type_integer(arglist->type))
+                errmsg = "parameter %d must be an integer type";
+              break;
+            case typevar_number:
+              if (!type_real(arglist->type))
+                errmsg = "parameter %d must be a numerical type";
+              break;
+            default: assert(0); break;
+            }
+        }
       if (errmsg)
-	error_with_location(loc, errmsg, parmnum);
+        error_with_location(loc, errmsg, parmnum);
       parmnum++;
       arglist = CAST(expression, arglist->next);
       parms = CAST(declaration, parms->next);
@@ -1292,15 +1292,15 @@ void check_abstract_arguments(const char *kind, data_declaration ddecl,
 
   if (parms)
     error_with_location(loc, "too few arguments to %s `%s'",
-			kind, ddecl->name);
+                        kind, ddecl->name);
   else if (arglist)
     error_with_location(loc, "too many arguments to %s `%s'",
-			kind, ddecl->name);
+                        kind, ddecl->name);
 }
 
 static nesc_declaration 
 nesc_declaration_copy(region r, nesc_declaration old, expression args,
-		      bool copy_is_abstract, data_declaration ddecl)
+                      bool copy_is_abstract, data_declaration ddecl)
 {
   nesc_declaration copy;
 
@@ -1327,7 +1327,7 @@ nesc_declaration_copy(region r, nesc_declaration old, expression args,
 }
 
 nesc_declaration interface_copy(region r, interface_ref iref,
-				bool copy_is_abstract)
+                                bool copy_is_abstract)
 /* Returns: A copy of abstract interface intf, instantiated with arguments
      in arglist.
 */
@@ -1338,7 +1338,7 @@ nesc_declaration interface_copy(region r, interface_ref iref,
   assert(intf->kind == l_interface);
 
   copy = nesc_declaration_copy(r, intf, iref->args, copy_is_abstract,
-			       iref->ddecl);
+                               iref->ddecl);
   hack_required = 1 + iref->ddecl->required;
   copy->ast = CAST(nesc_decl, instantiate_ast_list(r, CAST(node, intf->ast)));
   hack_required = 0;
@@ -1349,7 +1349,7 @@ nesc_declaration interface_copy(region r, interface_ref iref,
 }
 
 nesc_declaration specification_copy(region r, component_ref cref,
-				    bool copy_is_abstract)
+                                    bool copy_is_abstract)
 /* Returns: A copy of the parameters and specification of the
      component specified by cref, with arguments specified by cref
 */
@@ -1366,13 +1366,13 @@ nesc_declaration specification_copy(region r, component_ref cref,
     {
       /* Give it a new name */
       /* component may itself be a copy of the real original abstract
-	 component */
+         component */
       nesc_declaration abs_comp = comp->original ? comp->original : comp;
       char *newname = rstralloc(r, strlen(copy->name) + 20);
 
       copy->instance_number = abs_comp->instance_count++;
       sprintf(newname, "%s%s%d", copy->name, get_function_separator(),
-	      copy->instance_number);
+              copy->instance_number);
       copy->name = newname;
     }
 
@@ -1382,7 +1382,7 @@ nesc_declaration specification_copy(region r, component_ref cref,
   /* Copy the specification into the copy's env */
   spec = CAST(component, copy->ast);
   spec->decls = CAST(declaration,
-		     instantiate_ast_list(r, CAST(node, spec->decls)));
+                     instantiate_ast_list(r, CAST(node, spec->decls)));
   current = old;
 
   /* Give the copy an "empty" specification graph */
@@ -1392,7 +1392,7 @@ nesc_declaration specification_copy(region r, component_ref cref,
 }
 
 static void typevar_attr(nesc_attribute attr, data_declaration ddecl,
-			 int kind)
+                         int kind)
 {
   if (ddecl->typevar_kind != typevar_normal)
     ignored_nesc_attribute(attr);
@@ -1414,7 +1414,7 @@ void init_abstract(void)
 {
   init_clone();
   define_internal_attribute("integer", NULL, handle_integer_decl, NULL, NULL,
-			    NULL, NULL);
+                            NULL, NULL);
   define_internal_attribute("number", NULL, handle_number_decl, NULL, NULL,
-			    NULL, NULL);
+                            NULL, NULL);
 }

--- a/src/nesc-abstract.h
+++ b/src/nesc-abstract.h
@@ -46,16 +46,16 @@ void pop_instance(void);
 void init_abstract(void);
 
 void check_abstract_arguments(const char *kind, data_declaration ddecl,
-			      declaration parms, expression arglist);
+                              declaration parms, expression arglist);
 
 nesc_declaration interface_copy(region r, interface_ref iref,
-				bool copy_is_abstract);
+                                bool copy_is_abstract);
 /* Returns: A copy of abstract interface intf, instantiated with arguments
      in arglist.
 */
 
 nesc_declaration specification_copy(region r, component_ref cref,
-				    bool copy_is_abstract);
+                                    bool copy_is_abstract);
 /* Returns: A copy of the parameters and specification of the
      component specified by cref, with arguments specified by cref
 */

--- a/src/nesc-atomic.c
+++ b/src/nesc-atomic.c
@@ -57,7 +57,7 @@ static atomic_t aaccess(type t)
       cval tsize = type_size(t);
 
       if (cval_isinteger(tsize) && cval_uint_value(tsize) == 1)
-	return ATOMIC_SINGLE;
+        return ATOMIC_SINGLE;
     }
   return NOT_ATOMIC;
 }
@@ -160,7 +160,7 @@ static atomic_t acall(data_declaration ddecl)
     {
       a = acall_connected(ddecl);
       if (!ddecl->definition || ddecl->suppress_definition) /* no default */
-	return a;
+        return a;
     }
   else
     a = ATOMIC_ANY;
@@ -203,10 +203,10 @@ static atomic_t isatomic_expr(expression expr)
 
       a = isatomic_expr(fref->arg1);
       /* Bit field r/w's are not atomic. Could try and be more
-	 optimistic (e.g., non-byte-boundary crossing bitfield reads
-	 are presumably atomic) */
+         optimistic (e.g., non-byte-boundary crossing bitfield reads
+         are presumably atomic) */
       if (!cval_istop(fref->fdecl->bitwidth))
-	a = NOT_ATOMIC;
+        a = NOT_ATOMIC;
       break;
     }
     case kind_interface_deref:
@@ -222,17 +222,17 @@ static atomic_t isatomic_expr(expression expr)
       a2 = isatomic_expr(ce->arg2);
 
       if (ce->condition->cst)
-	{
-	  if (definite_zero(ce->condition))
-	    a = a2;
-	  else
-	    a = a1;
-	}
+        {
+          if (definite_zero(ce->condition))
+            a = a2;
+          else
+            a = a1;
+        }
       else
-	a = aseq(ac, aalt(a1, a2));
+        a = aseq(ac, aalt(a1, a2));
       break;
     }
-	
+        
     case kind_array_ref: {
       array_ref are = CAST(array_ref, expr);
       atomic_t a1, a2;
@@ -251,14 +251,14 @@ static atomic_t isatomic_expr(expression expr)
 
       /* Some heuristics for atomicity of & */
       while (is_field_ref(arg) || is_extension_expr(arg))
-	arg = CAST(unary, arg)->arg1;
+        arg = CAST(unary, arg)->arg1;
 
       if (is_dereference(arg))
-	a = isatomic_expr(CAST(dereference, arg)->arg1);
+        a = isatomic_expr(CAST(dereference, arg)->arg1);
       else if (is_identifier(arg))
-	a = ATOMIC_ANY;
+        a = ATOMIC_ANY;
       else
-	a = isatomic_expr(arg);
+        a = isatomic_expr(arg);
       break;
     }
 
@@ -286,14 +286,14 @@ static atomic_t isatomic_expr(expression expr)
       expression called = fce->arg1;
 
       if (is_generic_call(called))
-	called = CAST(generic_call, called)->arg1;
+        called = CAST(generic_call, called)->arg1;
 
       if (is_identifier(called))
-	a = acall(CAST(identifier, called)->ddecl);
+        a = acall(CAST(identifier, called)->ddecl);
       else if (is_interface_deref(called))
-	a = acall(CAST(interface_deref, called)->ddecl);
+        a = acall(CAST(interface_deref, called)->ddecl);
       else
-	a = NOT_ATOMIC;
+        a = NOT_ATOMIC;
 
       a = aseq(a, isatomic_children(expr));
       break;
@@ -344,14 +344,14 @@ static atomic_t isatomic_stmt(statement stmt)
       a2 = isatomic_stmt(is->stmt2);
 
       if (is->condition->cst)
-	{
-	  if (definite_zero(is->condition))
-	    a = a2;
-	  else
-	    a = a1;
-	}
+        {
+          if (definite_zero(is->condition))
+            a = a2;
+          else
+            a = a1;
+        }
       else
-	a = aseq(ac, aalt(a1, a2));
+        a = aseq(ac, aalt(a1, a2));
       break;
     }
     case kind_while_stmt: case kind_dowhile_stmt: case kind_switch_stmt: {
@@ -362,10 +362,10 @@ static atomic_t isatomic_stmt(statement stmt)
       as = isatomic_stmt(cs->stmt);
 
       if (cs->condition->cst && stmt->kind == kind_while_stmt &&
-	  definite_zero(cs->condition))
-	a = ATOMIC_ANY;
+          definite_zero(cs->condition))
+        a = ATOMIC_ANY;
       else
-	a = amany(aseq(ac, as));
+        a = amany(aseq(ac, as));
       break;
     }
     case kind_for_stmt: {
@@ -378,9 +378,9 @@ static atomic_t isatomic_stmt(statement stmt)
       as = isatomic_stmt(fs->stmt);
 
       if (fs->arg2 && fs->arg2->cst && definite_zero(fs->arg2))
-	a = ATOMIC_ANY;
+        a = ATOMIC_ANY;
       else
-	a = amany(aseq(a2, aseq(as, a3)));
+        a = amany(aseq(a2, aseq(as, a3)));
 
       a = aseq(a1, a);
       break;
@@ -402,7 +402,7 @@ static atomic_t isatomic_stmt(statement stmt)
 }
 
 static AST_walker_result isatomic_ast_expr(AST_walker spec, void *data,
-					   expression *e)
+                                           expression *e)
 {
   atomic_t *a = data;
   *a = aseq(*a, isatomic_expr(*e));
@@ -410,7 +410,7 @@ static AST_walker_result isatomic_ast_expr(AST_walker spec, void *data,
 }
 
 static AST_walker_result isatomic_ast_stmt(AST_walker spec, void *data,
-					   statement *s)
+                                           statement *s)
 {
   atomic_t *a = data;
   *a = aseq(*a, isatomic_stmt(*s));
@@ -418,7 +418,7 @@ static AST_walker_result isatomic_ast_stmt(AST_walker spec, void *data,
 }
 
 static AST_walker_result isatomic_ast_vdecl(AST_walker spec, void *data,
-					    variable_decl *vdp)
+                                            variable_decl *vdp)
 {
   variable_decl vd = *vdp;
   atomic_t *a = data, ainit;
@@ -446,17 +446,17 @@ void isatomic(cgraph g)
     {
       data_declaration fn = NODE_GET(endp, n)->function;
       if (fn->definition)
-	CAST(function_decl, fn->definition)->stmt->isatomic = ATOMIC_ANY;
+        CAST(function_decl, fn->definition)->stmt->isatomic = ATOMIC_ANY;
     }
   do
     {
       dirty = FALSE;
       graph_scan_nodes (n, cg)
-	{
-	  data_declaration fn = NODE_GET(endp, n)->function;
-	  if (fn->definition)
-	    isatomic_stmt(CAST(function_decl, fn->definition)->stmt);
-	}
+        {
+          data_declaration fn = NODE_GET(endp, n)->function;
+          if (fn->definition)
+            isatomic_stmt(CAST(function_decl, fn->definition)->stmt);
+        }
     }
   while (dirty);
 }

--- a/src/nesc-attributes.c
+++ b/src/nesc-attributes.c
@@ -12,15 +12,15 @@ typedef struct internal_attribute
   const char *name;
 
   void (*handle_ndecl)(nesc_attribute attr,
-		       nesc_declaration ndecl);
+                       nesc_declaration ndecl);
   void (*handle_decl)(nesc_attribute attr,
-		      data_declaration ddecl);
+                      data_declaration ddecl);
   void (*handle_tag)(nesc_attribute attr,
-		     tag_declaration tdecl);
+                     tag_declaration tdecl);
   void (*handle_field)(nesc_attribute attr,
-		       field_declaration fdecl);
+                       field_declaration fdecl);
   void (*handle_type)(nesc_attribute attr,
-		      type *t);
+                      type *t);
 } *iattr;
 
 static env internal_attributes;
@@ -30,12 +30,12 @@ static env internal_attributes;
 tag_ref lookup_attribute(word tag)
 {
   tag_ref tref = newkind_tag_ref(parse_region, kind_attribute_ref,
-				 tag->location, tag, NULL, NULL, FALSE);
+                                 tag->location, tag, NULL, NULL, FALSE);
   tag_declaration tdecl = lookup_tag(tref, FALSE);
 
   if (!tdecl)
     error_with_location(tag->location, "unknown attribute `%s'",
-			tag->cstring.data);
+                        tag->cstring.data);
   tref->tdecl = tdecl;
 
   return tref;
@@ -46,7 +46,7 @@ nesc_attribute start_attribute_use(word name)
   /* Prepare to read an initialiser for the attribute definition 
      specified by name */
   nesc_attribute attr = new_nesc_attribute(parse_region, name->location, name,
-					   NULL);
+                                           NULL);
   tag_ref aref = lookup_attribute(name); /* XXX: aref leaks */
   type atype = error_type;
 
@@ -61,7 +61,7 @@ nesc_attribute start_attribute_use(word name)
     {
       atype = make_tagged_type(aref->tdecl);
       if (aref->tdecl->deputy_scope)
-	current.env->deputy_scope = TRUE;
+        current.env->deputy_scope = TRUE;
     }
 
   start_init(NULL, attr);
@@ -80,17 +80,17 @@ attribute finish_attribute_use(nesc_attribute attr, expression init)
 }
 
 void define_internal_attribute(const char *name,
-			       void (*handle_ndecl)(nesc_attribute attr,
-						    nesc_declaration ndecl),
-			       void (*handle_decl)(nesc_attribute attr,
-						   data_declaration ddecl),
-			       void (*handle_tag)(nesc_attribute attr,
-						  tag_declaration tdecl),
-			       void (*handle_field)(nesc_attribute attr,
-						    field_declaration fdecl),
-			       void (*handle_type)(nesc_attribute attr,
-						   type *t),
-			       ...)
+                               void (*handle_ndecl)(nesc_attribute attr,
+                                                    nesc_declaration ndecl),
+                               void (*handle_decl)(nesc_attribute attr,
+                                                   data_declaration ddecl),
+                               void (*handle_tag)(nesc_attribute attr,
+                                                  tag_declaration tdecl),
+                               void (*handle_field)(nesc_attribute attr,
+                                                    field_declaration fdecl),
+                               void (*handle_type)(nesc_attribute attr,
+                                                   type *t),
+                               ...)
 {
   va_list args;
   field_declaration *next_field;
@@ -117,7 +117,7 @@ void define_internal_attribute(const char *name,
       field_declaration field;
 
       if (!field_name)
-	break;
+        break;
       field = ralloc(parse_region, struct field_declaration);
       field->containing_tag = attr_decl;
       *next_field = field;
@@ -176,9 +176,9 @@ void handle_nesc_type_attribute(nesc_attribute attr, type *t)
   if (handler)
     {
       if (handler->handle_type)
-	handler->handle_type(attr, t);
+        handler->handle_type(attr, t);
       else
-	ignored_nesc_attribute(attr);
+        ignored_nesc_attribute(attr);
     }
   /* In the future, we might want to record the attribute on the type,
      and support dumping this information in nesc-dump.c. For now,
@@ -193,9 +193,9 @@ void handle_nesc_decl_attribute(nesc_attribute attr, data_declaration ddecl)
   if (handler)
     {
       if (handler->handle_decl)
-	handler->handle_decl(attr, ddecl);
+        handler->handle_decl(attr, ddecl);
       else
-	ignored_nesc_attribute(attr);
+        ignored_nesc_attribute(attr);
     }
   else
     save_user_attribute(attr, &ddecl->attributes);
@@ -208,9 +208,9 @@ void handle_nesc_field_attribute(nesc_attribute attr, field_declaration fdecl)
   if (handler)
     {
       if (handler->handle_field)
-	handler->handle_field(attr, fdecl);
+        handler->handle_field(attr, fdecl);
       else
-	ignored_nesc_attribute(attr);
+        ignored_nesc_attribute(attr);
     }
   else
     save_user_attribute(attr, &fdecl->attributes);
@@ -223,9 +223,9 @@ void handle_nesc_tag_attribute(nesc_attribute attr, tag_declaration tdecl)
   if (handler)
     {
       if (handler->handle_tag)
-	handler->handle_tag(attr, tdecl);
+        handler->handle_tag(attr, tdecl);
       else
-	ignored_nesc_attribute(attr);
+        ignored_nesc_attribute(attr);
     }
   else
   save_user_attribute(attr, &tdecl->attributes);
@@ -238,9 +238,9 @@ void handle_nesc_nescdecl_attribute(nesc_attribute attr, nesc_declaration ndecl)
   if (handler)
     {
       if (handler->handle_ndecl)
-	handler->handle_ndecl(attr, ndecl);
+        handler->handle_ndecl(attr, ndecl);
       else
-	ignored_nesc_attribute(attr);
+        ignored_nesc_attribute(attr);
     }
   else
     save_user_attribute(attr, &ndecl->attributes);

--- a/src/nesc-attributes.h
+++ b/src/nesc-attributes.h
@@ -7,17 +7,17 @@ nesc_attribute start_attribute_use(word name);
 attribute finish_attribute_use(nesc_attribute attr, expression init);
 
 void define_internal_attribute(const char *name,
-			       void (*handle_ndecl)(nesc_attribute attr,
-						    nesc_declaration ndecl),
-			       void (*handle_decl)(nesc_attribute attr,
-						    data_declaration ddecl),
-			       void (*handle_tag)(nesc_attribute attr,
-						  tag_declaration tdecl),
-			       void (*handle_field)(nesc_attribute attr,
-						    field_declaration fdecl),
-			       void (*handle_type)(nesc_attribute attr,
-						   type *t),
-			       ...);
+                               void (*handle_ndecl)(nesc_attribute attr,
+                                                    nesc_declaration ndecl),
+                               void (*handle_decl)(nesc_attribute attr,
+                                                    data_declaration ddecl),
+                               void (*handle_tag)(nesc_attribute attr,
+                                                  tag_declaration tdecl),
+                               void (*handle_field)(nesc_attribute attr,
+                                                    field_declaration fdecl),
+                               void (*handle_type)(nesc_attribute attr,
+                                                   type *t),
+                               ...);
 /* Effects: Declare an internal (compiler) @-style attribute called 'name',
      handled by the handle functions. Functions can be NULL if the
      attribute cannot be used on that kind of entity.     

--- a/src/nesc-component.c
+++ b/src/nesc-component.c
@@ -44,10 +44,10 @@ data_declaration interface_lookup(data_declaration iref, const char *name)
 }
 
 void component_spec_iterate(nesc_declaration c,
-			    void (*iterator)(data_declaration fndecl,
-					     void *data),
-			    void *data,
-			    bool interfaces, bool otherdecls)
+                            void (*iterator)(data_declaration fndecl,
+                                             void *data),
+                            void *data,
+                            bool interfaces, bool otherdecls)
 {
   const char *ifname;
   void *ifentry;
@@ -59,29 +59,29 @@ void component_spec_iterate(nesc_declaration c,
       data_declaration idecl = ifentry;
 
       if (!otherdecls && !(idecl->kind == decl_interface_ref ||
-			    idecl->kind == decl_function))
-	continue;
+                            idecl->kind == decl_function))
+        continue;
 
       if (idecl->kind != decl_interface_ref || interfaces)
-	iterator(idecl, data);
+        iterator(idecl, data);
 
       if (idecl->kind == decl_interface_ref)
-	{
-	  env_scanner scanfns;
-	  const char *fnname;
-	  void *fnentry;
+        {
+          env_scanner scanfns;
+          const char *fnname;
+          void *fnentry;
 
-	  interface_scan(idecl, &scanfns);
-	  while (env_next(&scanfns, &fnname, &fnentry))
-	    iterator(fnentry, data);
-	}
+          interface_scan(idecl, &scanfns);
+          while (env_next(&scanfns, &fnname, &fnentry))
+            iterator(fnentry, data);
+        }
     }
 }
 
 void component_functions_iterate(nesc_declaration c,
-				 void (*iterator)(data_declaration fndecl,
-						  void *data),
-				 void *data)
+                                 void (*iterator)(data_declaration fndecl,
+                                                  void *data),
+                                 void *data)
 {
   component_spec_iterate(c, iterator, data, FALSE, FALSE);
 }
@@ -94,17 +94,17 @@ static typelist make_gparm_typelist(declaration gparms)
   scan_declaration (gparm, gparms)
     if (is_data_decl(gparm))
       {
-	data_decl gd = CAST(data_decl, gparm);
-	variable_decl gv = CAST(variable_decl, gd->decls);
+        data_decl gd = CAST(data_decl, gparm);
+        variable_decl gv = CAST(variable_decl, gd->decls);
 
-	typelist_append(gtypes, gv->ddecl->type);
+        typelist_append(gtypes, gv->ddecl->type);
       }
 
   return gtypes;
 }
 
 void copy_interface_functions(region r, nesc_declaration container,
-			      data_declaration iref, environment fns)
+                              data_declaration iref, environment fns)
 {
   environment icopy = new_environment(r, NULL, TRUE, FALSE);
   env_scanner scanif;
@@ -117,11 +117,11 @@ void copy_interface_functions(region r, nesc_declaration container,
       data_declaration fndecl = fnentry, fncopy;
 
       /* Strings acquire a magic_string decl which we don't care about
-	 legal example: 
-	  command int (*init())[sizeof "aa"];
+         legal example: 
+          command int (*init())[sizeof "aa"];
       */
       if (fndecl->kind == decl_magic_string)
-	continue;
+        continue;
 
       fncopy = declare(icopy, fndecl, FALSE);
       fncopy->fn_uses = NULL;
@@ -154,7 +154,7 @@ void set_interface_functions_gparms(environment fns, typelist gparms)
 }
 
 void declare_interface_ref(interface_ref iref, declaration gparms,
-			   environment env, attribute attribs)
+                           environment env, attribute attribs)
 {
   const char *iname = (iref->word2 ? iref->word2 : iref->word1)->cstring.data;
   nesc_declaration idecl = 
@@ -184,17 +184,17 @@ void declare_interface_ref(interface_ref iref, declaration gparms,
       generic_used = TRUE;
 
       check_abstract_arguments("interface", ddecl,
-			       idecl->parameters, iref->args);
+                               idecl->parameters, iref->args);
       ddecl->itype = interface_copy(parse_region, iref,
-				    current.container->abstract);
+                                    current.container->abstract);
       ddecl->functions = ddecl->itype->env;
     }
   else
     {
       copy_interface_functions(parse_region, current.container, ddecl,
-			       ddecl->itype->env);
+                               ddecl->itype->env);
       if (iref->args)
-	error("unexpected type arguments");
+        error("unexpected type arguments");
     }
 
   /* We don't make the interface type generic. Instead, we push the generic
@@ -216,18 +216,18 @@ void check_interface_parameter_types(declaration parms)
       variable_decl vd = CAST(variable_decl, dd->decls);
 
       if (!vd->ddecl)
-	{
-	  error_with_location(vd->location,
-			      "integral type required for generic parameter");
-	  vd->ddecl = bad_decl;
-	}
+        {
+          error_with_location(vd->location,
+                              "integral type required for generic parameter");
+          vd->ddecl = bad_decl;
+        }
       else if (!type_integral(vd->ddecl->type))
-      	{
-	  error_with_location(vd->location,
-			      "integral type required for generic parameter `%s'",
-			      vd->ddecl->name);
-	  vd->ddecl->type = int_type;
-	}
+              {
+          error_with_location(vd->location,
+                              "integral type required for generic parameter `%s'",
+                              vd->ddecl->name);
+          vd->ddecl->type = int_type;
+        }
     }
 }
 
@@ -260,7 +260,7 @@ void beg_iterator(data_declaration ddecl, void *data)
       node.function = ddecl;
       endpoint_lookup(d->cg, &node);
       if (!node.interface)
-	endpoint_lookup(d->userg, &node);
+        endpoint_lookup(d->userg, &node);
     }
 }
 
@@ -300,7 +300,7 @@ void build_component(region r, nesc_declaration cdecl)
 environment start_implementation(void)
 {
   start_semantics(l_implementation, current.container, 
-		  new_environment(parse_region, current.env, TRUE, FALSE));
+                  new_environment(parse_region, current.env, TRUE, FALSE));
 
   return current.env;
 }

--- a/src/nesc-component.h
+++ b/src/nesc-component.h
@@ -20,10 +20,10 @@ Boston, MA 02111-1307, USA.  */
 void build_component(region r, nesc_declaration cdecl);
 
 void declare_interface_ref(interface_ref iref, declaration gparms,
-			   environment genv, attribute attribs);
+                           environment genv, attribute attribs);
 
 void make_implicit_interface(data_declaration fndecl,
-			     function_declarator fdeclarator);
+                             function_declarator fdeclarator);
 
 void check_interface_parameter_types(declaration parms);
 
@@ -33,19 +33,19 @@ void interface_scan(data_declaration iref, env_scanner *scan);
 data_declaration interface_lookup(data_declaration iref, const char *name);
 
 void component_spec_iterate(nesc_declaration c,
-			    void (*iterator)(data_declaration fndecl,
-					     void *data),
-			    void *data,
-			    bool interfaces,
-			    bool otherdecls);
+                            void (*iterator)(data_declaration fndecl,
+                                             void *data),
+                            void *data,
+                            bool interfaces,
+                            bool otherdecls);
 
 void component_functions_iterate(nesc_declaration c,
-				 void (*iterator)(data_declaration fndecl,
-						  void *data),
-				 void *data);
+                                 void (*iterator)(data_declaration fndecl,
+                                                  void *data),
+                                 void *data);
 
 nesc_declaration specification_copy(region r, component_ref cref,
-				    bool copy_is_abstract);
+                                    bool copy_is_abstract);
 /* Effects: Make a "shallow" copy of component specified by `cref' in region r,
      i.e., identical to cref->cdecl except that it has a copy of the
      specification (including a copy of each interface instance)
@@ -56,10 +56,10 @@ nesc_declaration specification_copy(region r, component_ref cref,
 void build_external_graph(region r, nesc_declaration cdecl);
 
 void copy_interface_functions(region r, nesc_declaration container,
-			      data_declaration iref, environment fns);
+                              data_declaration iref, environment fns);
 
 
-extern bool generic_used;	/* Hack to prevent doc generation until
-				   new doc system built */
+extern bool generic_used;        /* Hack to prevent doc generation until
+                                   new doc system built */
 
 #endif

--- a/src/nesc-configuration.c
+++ b/src/nesc-configuration.c
@@ -59,7 +59,7 @@ static void connect_cg(cgraph cg, struct endp from, struct endp to)
 }
 
 static void connect_function(location l, cgraph cg, cgraph userg,
-			     struct endp from, struct endp to)
+                             struct endp from, struct endp to)
 {
   connect_cg(cg, from, to);
   connect_userg(l, userg, from, to);
@@ -72,23 +72,23 @@ static type endpoint_type(endp p)
   if (p->args_node)
     {
       if (p->function)
-	t = type_function_return_type(p->function->type);
+        t = type_function_return_type(p->function->type);
       else if (p->interface)
-	t = p->interface->type;
+        t = p->interface->type;
     }
   else
     {
       if (p->function)
-	t = p->function->type;
+        t = p->function->type;
       else if (p->interface)
-	{
-	  t = p->interface->type;
+        {
+          t = p->interface->type;
 
-	  /* We don't normally include the generic parameters in the 
-	     interface's type, but we do here to allow correct matching */
-	  if (p->interface->gparms)
-	    t = make_generic_type(t, p->interface->gparms);
-	}
+          /* We don't normally include the generic parameters in the 
+             interface's type, but we do here to allow correct matching */
+          if (p->interface->gparms)
+            t = make_generic_type(t, p->interface->gparms);
+        }
     }
   return t;
 }
@@ -100,7 +100,7 @@ typelist endpoint_args(endp p)
       type t = p->function->type;
 
       if (type_generic(t))
-	return type_function_arguments(t);
+        return type_function_arguments(t);
     }
   else if (p->interface)
     return p->interface->gparms;
@@ -109,8 +109,8 @@ typelist endpoint_args(endp p)
 }
 
 void connect_interface(location l, cgraph cg, cgraph userg,
-		       struct endp from, struct endp to,
-		       bool reverse)
+                       struct endp from, struct endp to,
+                       bool reverse)
 {
   env_scanner scanfns;
   const char *fnname;
@@ -122,7 +122,7 @@ void connect_interface(location l, cgraph cg, cgraph userg,
     connect_userg(l, userg, from, to);
 
   assert(!from.function && !to.function
-	 /*&& from.interface->itype == to.interface->itype*/);
+         /*&& from.interface->itype == to.interface->itype*/);
 
   /* All functions */
   interface_scan(to.interface, &scanfns);
@@ -134,9 +134,9 @@ void connect_interface(location l, cgraph cg, cgraph userg,
       to.function = fndecl;
       from.function = env_lookup(from.interface->functions->id_env, fndecl->name, TRUE);
       if (fndecl->defined ^ reverse)
-	connect_cg(cg, from, to);
+        connect_cg(cg, from, to);
       else
-	connect_cg(cg, to, from);
+        connect_cg(cg, to, from);
     }
 }
 
@@ -149,7 +149,7 @@ int match_endpoints(endp p1, endp p2, endp amatch)
   if (type_compatible(endpoint_type(p1), endpoint_type(p2)))
     {
       if (amatch)
-	*amatch = *p2;
+        *amatch = *p2;
       return 1;
     }
   else
@@ -157,7 +157,7 @@ int match_endpoints(endp p1, endp p2, endp amatch)
 }
 
 int match_function_interface(bool eqconnection,
-			     struct endp f, struct endp i, endp amatch)
+                             struct endp f, struct endp i, endp amatch)
 {
 #ifdef NO_FUNCTION_INTERFACE_MATCHING
   return 0;
@@ -178,7 +178,7 @@ int match_function_interface(bool eqconnection,
     {
       i.function = fnentry;
       if (i.function->defined == want_defined)
-	matched += match_endpoints(&f, &i, amatch); 
+        matched += match_endpoints(&f, &i, amatch); 
     }
 
   return matched;
@@ -186,7 +186,7 @@ int match_function_interface(bool eqconnection,
 }
 
 int match_interface_component(bool eqconnection,
-			      struct endp i, struct endp c, endp amatch)
+                              struct endp i, struct endp c, endp amatch)
 {
   const char *ifname;
   void *ifentry;
@@ -204,17 +204,17 @@ int match_interface_component(bool eqconnection,
       data_declaration idecl = ifentry;
 
       if (idecl->kind == decl_interface_ref)
-	{
-	  c.interface = idecl;
-	  if (c.interface->required == want_required)
-	    matched += match_endpoints(&i, &c, amatch);
-	}
+        {
+          c.interface = idecl;
+          if (c.interface->required == want_required)
+            matched += match_endpoints(&i, &c, amatch);
+        }
     }
   return matched;
 }
 
 int match_function_component(bool eqconnection,
-			     struct endp f, struct endp c, endp amatch)
+                             struct endp f, struct endp c, endp amatch)
 {
   const char *ifname;
   void *ifentry;
@@ -233,17 +233,17 @@ int match_function_component(bool eqconnection,
 
       c.function = c.interface = NULL;
       if (idecl->kind == decl_interface_ref)
-	{
-	  c.interface = idecl;
-	  matched += match_function_interface(want_defined ^ idecl->required,
-					      f, c, amatch);
-	}
+        {
+          c.interface = idecl;
+          matched += match_function_interface(want_defined ^ idecl->required,
+                                              f, c, amatch);
+        }
       else
-	{
-	  c.function = idecl;
-	  if (c.function->defined == want_defined)
-	    matched += match_endpoints(&f, &c, amatch);
-	}
+        {
+          c.function = idecl;
+          if (c.function->defined == want_defined)
+            matched += match_endpoints(&f, &c, amatch);
+        }
     }
   return matched;
 }
@@ -261,28 +261,28 @@ void check_generic_arguments(expression args, typelist gparms)
       type gparm_type = typelist_next(&scan_gparms);
 
       if (!gparm_type)
-	{
-	  error_with_location(l, "too many arguments");
-	  return;
-	}
+        {
+          error_with_location(l, "too many arguments");
+          return;
+        }
 
       if (arg->type == error_type || !check_constant_once(arg, cst_numerical))
-	continue;
+        continue;
 
       if (!arg->cst || !constant_integral(arg->cst))
-	error_with_location(l, "constant expression expected");
+        error_with_location(l, "constant expression expected");
       else
-	{
-	  if (!cval_inrange(arg->cst->cval, gparm_type))
-	    error_with_location(l, "constant out of range for argument type");
-	}
+        {
+          if (!cval_inrange(arg->cst->cval, gparm_type))
+            error_with_location(l, "constant out of range for argument type");
+        }
     }
   if (typelist_next(&scan_gparms))
     error_with_location(args->location, "too few arguments");
 }
 
 static bool lookup_endpoint(environment configuration_env, endpoint ep,
-			    endp lep)
+                            endp lep)
 {
   parameterised_identifier pid;
   environment lookup_env = configuration_env;
@@ -296,64 +296,64 @@ static bool lookup_endpoint(environment configuration_env, endpoint ep,
       location l = pid->location;
 
       if (!lookup_env)
-	error_with_location(l, "unexpected identifier `%s'", idname);
+        error_with_location(l, "unexpected identifier `%s'", idname);
       else
-	{
-	  expression args = pid->args;
-	  data_declaration d = env_lookup(lookup_env->id_env, idname, TRUE);
+        {
+          expression args = pid->args;
+          data_declaration d = env_lookup(lookup_env->id_env, idname, TRUE);
 
-	  if (!d)
-	    {
-	      /* This is a bit hacky: lookup in parent env, but not if
-		 it's the global env. We want to check a configuration's
-		 env, and it's parent component's env, but not the global
-		 env. */
-	      if (lookup_env->parent && lookup_env->parent != global_env)
-		d = env_lookup(lookup_env->parent->id_env, idname, TRUE);
-	      if (!d)
-		{
-		  error_with_location(l, "cannot find `%s'", idname);
-		  return FALSE; /* prevent cascading error messages */
-		}
-	    }
+          if (!d)
+            {
+              /* This is a bit hacky: lookup in parent env, but not if
+                 it's the global env. We want to check a configuration's
+                 env, and it's parent component's env, but not the global
+                 env. */
+              if (lookup_env->parent && lookup_env->parent != global_env)
+                d = env_lookup(lookup_env->parent->id_env, idname, TRUE);
+              if (!d)
+                {
+                  error_with_location(l, "cannot find `%s'", idname);
+                  return FALSE; /* prevent cascading error messages */
+                }
+            }
 
-	  if (args)
-	    {
-	      if (pid->next)
-		error_with_location(l, "arguments must be specified last");
-	      lep->args_node = pid->args;
-	    }
+          if (args)
+            {
+              if (pid->next)
+                error_with_location(l, "arguments must be specified last");
+              lep->args_node = pid->args;
+            }
 
-	  switch (d->kind)
-	    {
-	    default:
-	      error_with_location(l, "cannot find `%s'", idname);
-	      return FALSE; /* prevent cascading error messages */
+          switch (d->kind)
+            {
+            default:
+              error_with_location(l, "cannot find `%s'", idname);
+              return FALSE; /* prevent cascading error messages */
 
-	    case decl_component_ref:
-	      assert(!lep->component);
-	      lep->component = d;
-	      lookup_env = d->ctype->env;
-	      break;
-	    case decl_interface_ref:
-	      assert(!lep->interface);
-	      lep->interface = d;
+            case decl_component_ref:
+              assert(!lep->component);
+              lep->component = d;
+              lookup_env = d->ctype->env;
+              break;
+            case decl_interface_ref:
+              assert(!lep->interface);
+              lep->interface = d;
 
 #ifdef NO_FUNCTION_INTERFACE_MATCHING
-	      /* Can't lookup a function inside an interface (no partial interface
-		 connections) */
-	      lookup_env = NULL;
+              /* Can't lookup a function inside an interface (no partial interface
+                 connections) */
+              lookup_env = NULL;
 #else
-	      /* Get next environment */
-	      lookup_env = d->itype->decls;
+              /* Get next environment */
+              lookup_env = d->itype->decls;
 #endif
-	      break;
-	    case decl_function:
-	      lep->function = d;
-	      lookup_env = NULL;
-	      break;
-	    }
-	}
+              break;
+            case decl_function:
+              lep->function = d;
+              lookup_env = NULL;
+              break;
+            }
+        }
     }
 
   /* Check generic arguments */
@@ -362,9 +362,9 @@ static bool lookup_endpoint(environment configuration_env, endpoint ep,
       typelist gparms = endpoint_args(lep);
 
       if (gparms)
-	check_generic_arguments(lep->args_node, gparms);
+        check_generic_arguments(lep->args_node, gparms);
       else
-	error_with_location(ep->location, "endpoint is not a parameterised interface");
+        error_with_location(ep->location, "endpoint is not a parameterised interface");
     }
 
   return TRUE;
@@ -372,49 +372,49 @@ static bool lookup_endpoint(environment configuration_env, endpoint ep,
 
 
 static void process_interface_connection(cgraph cg, cgraph userg, connection conn,
-					 struct endp p1, struct endp p2)
+                                         struct endp p1, struct endp p2)
 {
   location l = conn->location;
 
   if (is_eq_connection(conn)) /* p1 = p2 */
     {
       if (!p1.component && !p2.component)
-	{
-	  if (p1.interface->required == p2.interface->required)
-	    error_with_location(l, "external to external connections must be between provided and used interfaces");
-	  else
-	    connect_interface(l, cg, userg, p1, p2, TRUE);
-	}
+        {
+          if (p1.interface->required == p2.interface->required)
+            error_with_location(l, "external to external connections must be between provided and used interfaces");
+          else
+            connect_interface(l, cg, userg, p1, p2, TRUE);
+        }
       else
-	{
-	  if (p1.interface->required != p2.interface->required)
-	    error_with_location(l, "external to internal connections must be both provided or both used");
-	  else if (!p1.component)
-	    connect_interface(l, cg, userg, p1, p2, FALSE);
-	  else
-	    connect_interface(l, cg, userg, p2, p1, FALSE);
-	  /* Note: connect_interface takes care of choosing the right edge
-	     direction. There are two cases:
-	     - the interface is provided: then we want edges from outside in,
-	     so from = the outside interface
-	     - the interface is required: then we want edges from inside out,
-	     but connect_interface will reverse them because the interface
-	     is required. So we also pick from = the outside interface.
-	  */
-	}
+        {
+          if (p1.interface->required != p2.interface->required)
+            error_with_location(l, "external to internal connections must be both provided or both used");
+          else if (!p1.component)
+            connect_interface(l, cg, userg, p1, p2, FALSE);
+          else
+            connect_interface(l, cg, userg, p2, p1, FALSE);
+          /* Note: connect_interface takes care of choosing the right edge
+             direction. There are two cases:
+             - the interface is provided: then we want edges from outside in,
+             so from = the outside interface
+             - the interface is required: then we want edges from inside out,
+             but connect_interface will reverse them because the interface
+             is required. So we also pick from = the outside interface.
+          */
+        }
     }
   else /* p1 <- p2 */
     {
       if (p1.interface->required)
-	error_with_location(l, "target of '<-' interface must be provided");
+        error_with_location(l, "target of '<-' interface must be provided");
       else if (!p2.interface->required)
-	error_with_location(l, "source of '<-' interface must be required");
+        error_with_location(l, "source of '<-' interface must be required");
       else connect_interface(l, cg, userg, p2, p1, FALSE);
     }
 }
 
 static void process_function_connection(cgraph cg, cgraph userg, connection conn,
-					struct endp p1, struct endp p2)
+                                        struct endp p1, struct endp p2)
 {
   location l = conn->location;
   bool p1def = (p1.interface && !p1.interface->required) ^ p1.function->defined;
@@ -423,48 +423,48 @@ static void process_function_connection(cgraph cg, cgraph userg, connection conn
   if (is_eq_connection(conn)) /* p1 = p2 */
     {
       if (!p1.component && !p2.component)
-	{
-	  if (p1def == p2def)
-	    error_with_location(l, "external to external connections must be between provided and used functions");
-	  else if (p1def)
-	    connect_function(l, cg, userg, p1, p2); /* from provided to used */
-	  else
-	    connect_function(l, cg, userg, p2, p1);
-	}
+        {
+          if (p1def == p2def)
+            error_with_location(l, "external to external connections must be between provided and used functions");
+          else if (p1def)
+            connect_function(l, cg, userg, p1, p2); /* from provided to used */
+          else
+            connect_function(l, cg, userg, p2, p1);
+        }
       else 
-	{
-	  if (p1def != p2def)
-	    error_with_location(l, "external to internal connections must be both provided or both used");
-	  else if ((!p1.component && !p1def) || (p1.component && p1def))
-	    connect_function(l, cg, userg, p2, p1);
-	  else
-	    connect_function(l, cg, userg, p1, p2);
-	}
+        {
+          if (p1def != p2def)
+            error_with_location(l, "external to internal connections must be both provided or both used");
+          else if ((!p1.component && !p1def) || (p1.component && p1def))
+            connect_function(l, cg, userg, p2, p1);
+          else
+            connect_function(l, cg, userg, p1, p2);
+        }
     }
   else /* p1 <- p2 */
     {
       if (!p1def)
-	error_with_location(l, "target of '<-' function must be defined");
+        error_with_location(l, "target of '<-' function must be defined");
       else if (p2def)
-	error_with_location(l, "source of '<-' function must be used");
+        error_with_location(l, "source of '<-' function must be used");
       else connect_function(l, cg, userg, p2, p1);
     }
 }
 
 static void process_actual_connection(cgraph cg, cgraph userg, connection conn,
-				      struct endp p1, struct endp p2)
+                                      struct endp p1, struct endp p2)
 {
   location l = conn->location;
 
   if (is_eq_connection(conn)) /* p1 = p2 */
     {
       if (p1.component && p2.component)
-	error_with_location(l, "there must be at least one external interface in an '=' connection");
+        error_with_location(l, "there must be at least one external interface in an '=' connection");
     }
   else /* p1 <- p2 */
     {
       if (!p1.component || !p2.component)
-	error_with_location(l, "external interfaces cannot be connected with `<-' or `->'");
+        error_with_location(l, "external interfaces cannot be connected with `<-' or `->'");
     }
 
   if (p1.function)
@@ -474,7 +474,7 @@ static void process_actual_connection(cgraph cg, cgraph userg, connection conn,
 }
 
 static void process_connection(cgraph cg, cgraph userg, connection conn,
-			       struct endp p1, struct endp p2)
+                               struct endp p1, struct endp p2)
 {
   int matches;
   bool eqconnection = is_eq_connection(conn);
@@ -482,27 +482,27 @@ static void process_connection(cgraph cg, cgraph userg, connection conn,
   if (p1.function) /* f X ... */
     {
       if (p2.function) /* f X f */
-	matches = match_endpoints(&p1, &p2, NULL);
+        matches = match_endpoints(&p1, &p2, NULL);
       else if (p2.interface) /* f X i */
-	matches = match_function_interface(eqconnection, p1, p2, &p2);
+        matches = match_function_interface(eqconnection, p1, p2, &p2);
       else /* f X c */
-	matches = match_function_component(eqconnection, p1, p2, &p2);
+        matches = match_function_component(eqconnection, p1, p2, &p2);
     }
   else if (p1.interface) /* i X ... */
     {
       if (p2.function) /* i X f */
-	matches = match_function_interface(eqconnection, p2, p1, &p1);
+        matches = match_function_interface(eqconnection, p2, p1, &p1);
       else if (p2.interface) /* i X i */
-	matches = match_endpoints(&p1, &p2, NULL);
+        matches = match_endpoints(&p1, &p2, NULL);
       else /* i X c */
-	matches = match_interface_component(eqconnection, p1, p2, &p2);
+        matches = match_interface_component(eqconnection, p1, p2, &p2);
     }
   else /* c X ... */
     {
       if (p2.function) /* c X f */
-	matches = match_function_component(eqconnection, p2, p1, &p1);
+        matches = match_function_component(eqconnection, p2, p1, &p1);
       else /* c X i */
-	matches = match_interface_component(eqconnection, p2, p1, &p1);
+        matches = match_interface_component(eqconnection, p2, p1, &p1);
     }
 
   if (matches == 0)
@@ -514,7 +514,7 @@ static void process_connection(cgraph cg, cgraph userg, connection conn,
 }
 
 static void process_component_connection(cgraph cg, cgraph userg, connection conn,
-					 struct endp p1, struct endp p2)
+                                         struct endp p1, struct endp p2)
 {
 #ifndef NO_COMPONENT_MATCHING
   /* c X c, the only list case */
@@ -532,24 +532,24 @@ static void process_component_connection(cgraph cg, cgraph userg, connection con
 
       p1.interface = p1.function = p2.interface = p2.function = NULL;
       if (idecl->kind == decl_interface_ref)
-	{
-	  p1.interface = idecl;
-	  matches = match_interface_component(eqconnection, p1, p2, &p2);
-	}
+        {
+          p1.interface = idecl;
+          matches = match_interface_component(eqconnection, p1, p2, &p2);
+        }
       else
-	{
-	  p1.function = idecl;
-	  matches = match_function_component(eqconnection, p1, p2, &p2);
-	}
+        {
+          p1.function = idecl;
+          matches = match_function_component(eqconnection, p1, p2, &p2);
+        }
 
       total_matches += matches;
       if (matches > 1)
-	{
-	  error_with_location(conn->location, "ambiguous match");
-	  break;
-	}
+        {
+          error_with_location(conn->location, "ambiguous match");
+          break;
+        }
       else if (matches == 1)
-	process_actual_connection(cg, userg, conn, p1, p2);
+        process_actual_connection(cg, userg, conn, p1, p2);
     }
   if (total_matches == 0)
 #endif
@@ -566,24 +566,24 @@ static void process_connections(configuration c)
   scan_declaration (decl, c->decls)
     if (is_connection(decl))
       {
-	connection conn = CAST(connection, decl);
+        connection conn = CAST(connection, decl);
 
-	if (lookup_endpoint(c->ienv, conn->ep1, &p1) &&
-	    lookup_endpoint(c->ienv, conn->ep2, &p2))
-	  {
-	    /* There are a lot of kinds of connections here.
-	       lookup_endpoint has already resolved pseudo-interfaces to functions
-	       (c is component, i is interface, f is function, X is = or <-)
-	       c X c, c X i, i X c, c X f, f X c, i X i, i X f, f X i, f X f
+        if (lookup_endpoint(c->ienv, conn->ep1, &p1) &&
+            lookup_endpoint(c->ienv, conn->ep2, &p2))
+          {
+            /* There are a lot of kinds of connections here.
+               lookup_endpoint has already resolved pseudo-interfaces to functions
+               (c is component, i is interface, f is function, X is = or <-)
+               c X c, c X i, i X c, c X f, f X c, i X i, i X f, f X i, f X f
 
-	       We first resolve the c X c case, which can lead to multiple
-	       connections, then handle all remaining cases in process_connection
-	    */
-	    if (!p1.interface && !p2.interface && !p1.function && !p2.function)
-	      process_component_connection(cg, userg, conn, p1, p2);
-	    else
-	      process_connection(cg, userg, conn, p1, p2);
-	  }
+               We first resolve the c X c case, which can lead to multiple
+               connections, then handle all remaining cases in process_connection
+            */
+            if (!p1.interface && !p2.interface && !p1.function && !p2.function)
+              process_component_connection(cg, userg, conn, p1, p2);
+            else
+              process_connection(cg, userg, conn, p1, p2);
+          }
       }
 }
 
@@ -599,7 +599,7 @@ component_ref require_component(component_ref comp, word as)
   comp->cdecl = require(l_component, comp->location, cname);
 
   init_data_declaration(&tempdecl, CAST(declaration, comp), asname,
-			void_type);
+                        void_type);
   tempdecl.kind = decl_component_ref;
 
   /* Avoid duplicates in implementation *or* specification env */
@@ -620,28 +620,28 @@ component_ref require_component(component_ref comp, word as)
       generic_used = TRUE;
 
       comp->cdecl = specification_copy(parse_region, comp,
-				       current.container->abstract);
+                                       current.container->abstract);
       /* give copy a nice instance name if it is inside a generic
-	 configuration */
+         configuration */
       if (current.container->abstract)
-	{
-	  size_t inamelen = strlen(current.container->name) +
-	    strlen(comp->cdecl->instance_name) + 2;
-	  char *iname = rstralloc(parse_region, inamelen);
+        {
+          size_t inamelen = strlen(current.container->name) +
+            strlen(comp->cdecl->instance_name) + 2;
+          char *iname = rstralloc(parse_region, inamelen);
 
-	  sprintf(iname, "%s.%s", current.container->name, comp->cdecl->instance_name);
-	  comp->cdecl->instance_name = iname;
-	}
+          sprintf(iname, "%s.%s", current.container->name, comp->cdecl->instance_name);
+          comp->cdecl->instance_name = iname;
+        }
 
       if (!comp->abstract)
-	error_with_location(comp->location, "generic component `%s' requires instantiation arguments", cname);
+        error_with_location(comp->location, "generic component `%s' requires instantiation arguments", cname);
       else
-	check_abstract_arguments("component", ddecl, comp->cdecl->parameters, comp->args);
+        check_abstract_arguments("component", ddecl, comp->cdecl->parameters, comp->args);
     }
   else
     {
       if (comp->abstract)
-	error_with_location(comp->location, "component `%s' is not generic", cname);
+        error_with_location(comp->location, "component `%s' is not generic", cname);
     }
 
   ddecl->type = make_component_type(ddecl);
@@ -703,13 +703,13 @@ static void check_function_connected(data_declaration fndecl, void *data)
 
       if (idecl)
 #ifdef NO_FUNCTION_INTERFACE_MATCHING
-	error_with_location(d->loc, "`%s' not connected", idecl->name);
+        error_with_location(d->loc, "`%s' not connected", idecl->name);
 #else
-	error_with_location(d->loc, "`%s.%s' not connected",
-			    idecl->name, fndecl->name);
+        error_with_location(d->loc, "`%s.%s' not connected",
+                            idecl->name, fndecl->name);
 #endif
       else
-	error_with_location(d->loc, "`%s' not connected", fndecl->name);
+        error_with_location(d->loc, "`%s' not connected", fndecl->name);
     }
 }
 

--- a/src/nesc-configuration.h
+++ b/src/nesc-configuration.h
@@ -30,7 +30,7 @@ typelist endpoint_args(struct endp *p);
 void component_scan(data_declaration cref, env_scanner *scan);
 
 void connect_interface(location l, cgraph cg, cgraph userg,
-		       struct endp from, struct endp to,
-		       bool reverse);
+                       struct endp from, struct endp to,
+                       bool reverse);
 
 #endif

--- a/src/nesc-constants.c
+++ b/src/nesc-constants.c
@@ -35,7 +35,7 @@ struct folder_data {
 };
 
 static AST_walker_result folder_expression(AST_walker spec, void *data,
-					   expression *n)
+                                           expression *n)
 {
   struct folder_data *d = data;
   expression e = *n;
@@ -51,11 +51,11 @@ static AST_walker_result folder_expression(AST_walker spec, void *data,
     case kind_lexical_cst: case kind_string: case kind_extension_expr:
       /* We preserve the constants in lexical_cst's and strings */
       /* XXX: should we allow string arguments to components to 
-	 be merged into strings (e.g. "aa" foo "bb", where foo
-	 is a `char *' component arg)? 
-	 (If so: the ddecl for the args should be classified as
+         be merged into strings (e.g. "aa" foo "bb", where foo
+         is a `char *' component arg)? 
+         (If so: the ddecl for the args should be classified as
          a decl_magic_string, and make_string and this function must be
-	 modified accordingly) */
+         modified accordingly) */
       c = e->cst;
       sa = e->static_address;
       break;
@@ -103,9 +103,9 @@ static AST_walker_result folder_expression(AST_walker spec, void *data,
 
       /* Find the array type */
       if (type_integer(aref->arg1->type))
-	atype = aref->arg2->type;
+        atype = aref->arg2->type;
       else
-	atype = aref->arg1->type;
+        atype = aref->arg1->type;
 
       sa = fold_binary(type_default_conversion(atype), e);
       break;
@@ -114,14 +114,14 @@ static AST_walker_result folder_expression(AST_walker spec, void *data,
       expression sub;;
 
       scan_expression (sub, CAST(comma, e)->arg1)
-	if (!sub->cst)
-	  break;
-	else if (!sub->next)
-	  {
-	    /* (e1, ..., en) is a constant expression if all ei are constant
-	       expressions. Weird? (see cst10.c) */
-	    c = sub->cst;
-	  }
+        if (!sub->cst)
+          break;
+        else if (!sub->next)
+          {
+            /* (e1, ..., en) is a constant expression if all ei are constant
+               expressions. Weird? (see cst10.c) */
+            c = sub->cst;
+          }
       break;
     }
     case kind_component_deref:
@@ -129,9 +129,9 @@ static AST_walker_result folder_expression(AST_walker spec, void *data,
       break;
     default:
       if (is_binary(e))
-	c = fold_binary(e->type, e);
+        c = fold_binary(e->type, e);
       else if (is_unary(e))
-	c = fold_unary(e);
+        c = fold_unary(e);
       break;
     }
   e->cst = c;
@@ -170,7 +170,7 @@ bool fold_constants_list(node n, int pass)
 }
 
 static AST_walker_result folder_array_declarator(AST_walker spec, void *data,
-						 array_declarator *n)
+                                                 array_declarator *n)
 {
   expression size = (*n)->arg1;
 
@@ -183,7 +183,7 @@ static AST_walker_result folder_array_declarator(AST_walker spec, void *data,
 }
 
 static AST_walker_result folder_enum_ref(AST_walker spec, void *data,
-					 enum_ref *n)
+                                         enum_ref *n)
 {
   if (!(*n)->defined)
     return aw_walk;
@@ -196,7 +196,7 @@ static AST_walker_result folder_enum_ref(AST_walker spec, void *data,
 }
 
 static AST_walker_result folder_enumerator(AST_walker spec, void *data,
-					   enumerator *n)
+                                           enumerator *n)
 {
   enumerator e = *n;
 
@@ -207,7 +207,7 @@ static AST_walker_result folder_enumerator(AST_walker spec, void *data,
 }
 
 static AST_walker_result folder_tag_ref(AST_walker spec, void *data,
-					tag_ref *n)
+                                        tag_ref *n)
 {
   if (!(*n)->defined)
     return aw_walk;
@@ -219,7 +219,7 @@ static AST_walker_result folder_tag_ref(AST_walker spec, void *data,
 }
 
 static AST_walker_result folder_case_label(AST_walker spec, void *data,
-					   case_label *n)
+                                           case_label *n)
 {
   case_label label = *n;
 
@@ -232,7 +232,7 @@ static AST_walker_result folder_case_label(AST_walker spec, void *data,
 }
 
 static AST_walker_result folder_function_decl(AST_walker spec, void *data,
-					      function_decl *n)
+                                              function_decl *n)
 {
   function_decl fd = *n, old = current.function_decl;
 

--- a/src/nesc-cpp.c
+++ b/src/nesc-cpp.c
@@ -54,7 +54,7 @@ static void account_for_newlines (const unsigned char *, size_t);
 static void print_line (source_location, const char *);
 static void maybe_print_line (source_location);
 static void save_pp_define(cpp_reader *pfile, source_location line,
-			    cpp_hashnode *node);
+                            cpp_hashnode *node);
 static void save_pp_undef(source_location line, cpp_hashnode *node);
 
 void save_cpp_option(const char *option, const char *arg)
@@ -127,21 +127,21 @@ void preprocess_init(void)
 
   /* Process saved options */
   cpp_cbacks->file_change(reader, linemap_add(current.lex.line_map, LC_RENAME, 0,
-					      "<command-line>", 0));
+                                              "<command-line>", 0));
 
   for (opt = saved_options; opt; opt = opt->next)
     {
       if (opt->opt[0] == 'D')
-	cpp_define(reader, opt->arg);
+        cpp_define(reader, opt->arg);
       else if (opt->opt[0] == 'U')
-	cpp_undef(reader, opt->arg);
+        cpp_undef(reader, opt->arg);
       else if (opt->opt[0] == 'A')
-	{
-	  if (opt->arg[0] == '-')
-	    cpp_unassert(reader, opt->arg + 1);
-	  else
-	    cpp_assert(reader, opt->arg);
-	}
+        {
+          if (opt->arg[0] == '-')
+            cpp_unassert(reader, opt->arg + 1);
+          else
+            cpp_assert(reader, opt->arg);
+        }
     }
   if (use_nido)
     {
@@ -156,7 +156,7 @@ void preprocess_init(void)
 }
 
 static void cb_define(cpp_reader *reader, source_location loc, 
-		      cpp_hashnode *macro)
+                      cpp_hashnode *macro)
 {
   char *def = rstrdup(permanent, (char *)cpp_macro_definition(reader, macro));
   char *firstspace = strchr(def, ' ');
@@ -169,7 +169,7 @@ static void cb_define(cpp_reader *reader, source_location loc,
 }
 
 static void cb_undef(cpp_reader *reader, source_location loc,
-		     cpp_hashnode *macro)
+                     cpp_hashnode *macro)
 {
   macro_set(NODE_NAME(macro), NULL);
   save_pp_undef(loc, macro);
@@ -232,7 +232,7 @@ void save_pp_file_start(const char *path)
 
   const char *fname = lbasename(path);
   char *pp_path = rstralloc(current.fileregion,
-			    strlen(cpp_save_dir) + strlen(fname) + 2);
+                            strlen(cpp_save_dir) + strlen(fname) + 2);
 
   sprintf(pp_path, "%s/%s", cpp_save_dir, fname);
   current.lex.pp.outf = fopen(pp_path, "w");
@@ -241,7 +241,7 @@ void save_pp_file_start(const char *path)
       static int first = 1;
 
       if (first)
-	warning("cannot create preprocessed output file `%s'", pp_path);
+        warning("cannot create preprocessed output file `%s'", pp_path);
       first = FALSE;
       return;
     }
@@ -280,9 +280,9 @@ void save_pp_token(const cpp_token *token)
     {
       current.lex.pp.avoid_paste = true;
       if (current.lex.pp.source == NULL
-	  || (!(current.lex.pp.source->flags & PREV_WHITE)
-	      && token->val.source == NULL))
-	current.lex.pp.source = token->val.source;
+          || (!(current.lex.pp.source->flags & PREV_WHITE)
+              && token->val.source == NULL))
+        current.lex.pp.source = token->val.source;
       return;
     }
 
@@ -293,12 +293,12 @@ void save_pp_token(const cpp_token *token)
   if (current.lex.pp.avoid_paste)
     {
       if (current.lex.pp.source == NULL)
-	current.lex.pp.source = token;
+        current.lex.pp.source = token;
       if (current.lex.pp.source->flags & PREV_WHITE
-	  || (current.lex.pp.prev
-	      && cpp_avoid_paste(pfile, current.lex.pp.prev, token))
-	  || (current.lex.pp.prev == NULL && token->type == CPP_HASH))
-	putc(' ', current.lex.pp.outf);
+          || (current.lex.pp.prev
+              && cpp_avoid_paste(pfile, current.lex.pp.prev, token))
+          || (current.lex.pp.prev == NULL && token->type == CPP_HASH))
+        putc(' ', current.lex.pp.outf);
     }
   else if (token->flags & PREV_WHITE)
     putc(' ', current.lex.pp.outf);
@@ -338,10 +338,10 @@ static void maybe_print_line(source_location src_loc)
   if (src_line >= current.lex.pp.src_line && src_line < current.lex.pp.src_line + 8)
     {
       while (src_line > current.lex.pp.src_line)
-	{
-	  putc('\n', current.lex.pp.outf);
-	  current.lex.pp.src_line++;
-	}
+        {
+          putc('\n', current.lex.pp.outf);
+          current.lex.pp.src_line++;
+        }
     }
   else
     print_line(src_loc, "");
@@ -368,18 +368,18 @@ static void print_line(source_location src_loc, const char *special_flags)
       current.lex.pp.src_line = SOURCE_LINE(map, src_loc);
 
       /* cpp_quote_string does not nul-terminate, so we have to do it
-	 ourselves.  */
+         ourselves.  */
       p = cpp_quote_string(to_file_quoted,
-			    (unsigned char *) map->to_file, to_file_len);
+                            (unsigned char *) map->to_file, to_file_len);
       *p = '\0';
       fprintf(current.lex.pp.outf, "# %u \"%s\"%s",
-	       current.lex.pp.src_line == 0 ? 1 : current.lex.pp.src_line,
-	       to_file_quoted, special_flags);
+               current.lex.pp.src_line == 0 ? 1 : current.lex.pp.src_line,
+               to_file_quoted, special_flags);
 
       if (map->sysp == 2)
-	fputs(" 3 4", current.lex.pp.outf);
+        fputs(" 3 4", current.lex.pp.outf);
       else if (map->sysp == 1)
-	fputs(" 3", current.lex.pp.outf);
+        fputs(" 3", current.lex.pp.outf);
 
       putc('\n', current.lex.pp.outf);
     }
@@ -410,12 +410,12 @@ void save_pp_line_change(cpp_reader *pfile, const cpp_token *token)
       current.lex.pp.printed = 1;
 
       while (-- spaces >= 0)
-	putc(' ', current.lex.pp.outf);
+        putc(' ', current.lex.pp.outf);
     }
 }
 
 static void save_pp_define(cpp_reader *pfile, source_location line,
-			   cpp_hashnode *node)
+                           cpp_hashnode *node)
 {
   if (!current.lex.pp.outf)
     return;
@@ -423,7 +423,7 @@ static void save_pp_define(cpp_reader *pfile, source_location line,
   maybe_print_line (line);
 
   fprintf(current.lex.pp.outf, "#define %s\n",
-	  (const char *)cpp_macro_definition(pfile, node));
+          (const char *)cpp_macro_definition(pfile, node));
 
   if (linemap_lookup(current.lex.line_map, line)->to_line != 0)
     current.lex.pp.src_line++;

--- a/src/nesc-decls.h
+++ b/src/nesc-decls.h
@@ -35,35 +35,35 @@ typedef struct nesc_declaration {
   struct environment *env;
   struct docstring doc;
 
-  bool abstract;		/* true for abstract components and
-				   generic interfaces */
-  bool dumped;			/* true if already added to dump list */
-  bool printed;			/* true if declarations already printed */
-  declaration parameters;	/* Parameters for generic components and
-				   interfaces */
-  expression arguments;		/* Arguments for instantiations of generic 
-				   components and interfaces */
+  bool abstract;                /* true for abstract components and
+                                   generic interfaces */
+  bool dumped;                        /* true if already added to dump list */
+  bool printed;                        /* true if declarations already printed */
+  declaration parameters;        /* Parameters for generic components and
+                                   interfaces */
+  expression arguments;                /* Arguments for instantiations of generic 
+                                   components and interfaces */
   struct environment *parameter_env;
   struct nesc_declaration *original; /* For instances: the "original" component
-					or interface */
+                                        or interface */
   /* All '@'-style attributes attached to this declaration */
   dd_list/*nesc_attribute*/ attributes;
 
   /* for components */
   /* Binary components are mostly treated like modules. */
 
-  bool configuration;		/* TRUE for configurations, FALSE for modules
-				   (needed before impl is set) and binary
-				   components. */
-  bool safe;			/* TRUE if safety checks should be performed in here */
+  bool configuration;                /* TRUE for configurations, FALSE for modules
+                                   (needed before impl is set) and binary
+                                   components. */
+  bool safe;                        /* TRUE if safety checks should be performed in here */
   implementation impl;
   struct cgraph *connections;
   struct cgraph *user_connections; /* interfaces are not expanded */
-  dd_list local_statics;	/* Local static variables (for nido) */
-  size_t instance_count;	/* For abstract components, the
-				   instance count (used to give each
-				   instance a unique name) */
-  int folded;			/* number of last constant folding pass */
+  dd_list local_statics;        /* Local static variables (for nido) */
+  size_t instance_count;        /* For abstract components, the
+                                   instance count (used to give each
+                                   instance a unique name) */
+  int folded;                        /* number of last constant folding pass */
 } *nesc_declaration;
 
 #endif

--- a/src/nesc-deputy.c
+++ b/src/nesc-deputy.c
@@ -37,7 +37,7 @@ static void dwalk(struct deputy_data *dd, void *p)
 }
 
 static AST_walker_result deputy_identifier(AST_walker unused, void *data,
-					   identifier *p)
+                                           identifier *p)
 {
   identifier id = *p;
   struct deputy_data *dd = data;
@@ -50,21 +50,21 @@ static AST_walker_result deputy_identifier(AST_walker unused, void *data,
       /* not doing make_identifier's error message suppression */
 
       if (dd->in_struct &&
-	  env_lookup(dd->in_struct->fields, name, TRUE))
-	realdecl = bad_decl; /* prevent renaming of field refs */
+          env_lookup(dd->in_struct->fields, name, TRUE))
+        realdecl = bad_decl; /* prevent renaming of field refs */
       if (!realdecl)
-	realdecl = env_lookup(dd->env->id_env, name, FALSE);
+        realdecl = env_lookup(dd->env->id_env, name, FALSE);
 
       if (realdecl)
-	id->ddecl = realdecl;
+        id->ddecl = realdecl;
       else
-	error_with_location(id->location, "`%s' undeclared", name);
+        error_with_location(id->location, "`%s' undeclared", name);
     }
   return aw_done;
 }
 
 static AST_walker_result deputy_nesc_attribute(AST_walker unused, void *data,
-					       nesc_attribute *p)
+                                               nesc_attribute *p)
 {
   nesc_attribute na = *p;
   struct deputy_data ndd = *(struct deputy_data *)data;
@@ -76,7 +76,7 @@ static AST_walker_result deputy_nesc_attribute(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_tag_ref(AST_walker unused, void *data,
-					tag_ref *p)
+                                        tag_ref *p)
 {
   tag_ref tref = *p;
   struct deputy_data ndd = *(struct deputy_data *)data;
@@ -89,7 +89,7 @@ static AST_walker_result deputy_tag_ref(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_fdeclarator(AST_walker unused, void *data,
-					    function_declarator *p)
+                                            function_declarator *p)
 {
   function_declarator fd = *p;
   struct deputy_data ndd = *(struct deputy_data *)data;
@@ -107,7 +107,7 @@ static AST_walker_result deputy_fdeclarator(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_function_decl(AST_walker unused, void *data,
-					      function_decl *p)
+                                              function_decl *p)
 {
   function_decl fdecl = *p;
   function_declarator fd = get_fdeclarator(fdecl->declarator);
@@ -126,7 +126,7 @@ static AST_walker_result deputy_function_decl(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_data_decl(AST_walker unused, void *data,
-					  data_decl *p)
+                                          data_decl *p)
 {
   data_decl dd = *p;
   declaration first;
@@ -157,7 +157,7 @@ static AST_walker_result deputy_data_decl(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_compound_stmt(AST_walker unused, void *data,
-					      compound_stmt *p)
+                                              compound_stmt *p)
 {
   compound_stmt cs = *p;
   struct deputy_data ndd;
@@ -171,7 +171,7 @@ static AST_walker_result deputy_compound_stmt(AST_walker unused, void *data,
 }
 
 static AST_walker_result deputy_implementation(AST_walker unused, void *data,
-					       implementation *p)
+                                               implementation *p)
 {
   implementation impl = *p;
   struct deputy_data ndd;
@@ -232,11 +232,11 @@ static void attr_decl_unsafe(nesc_attribute attr, data_declaration ddecl)
 void init_deputy(void)
 {
   define_internal_attribute("deputy_scope", NULL, NULL, attr_dscope_tdecl, NULL,
-			    NULL, NULL);
+                            NULL, NULL);
   define_internal_attribute("safe", attr_ndecl_safe, attr_decl_safe, NULL,
-			    NULL, NULL, NULL);
+                            NULL, NULL, NULL);
   define_internal_attribute("unsafe", attr_ndecl_unsafe, attr_decl_unsafe, NULL,
-			    NULL, NULL, NULL);
+                            NULL, NULL, NULL);
 
   deputy_walker = new_AST_walker(permanent);
   AST_walker_handle(deputy_walker, kind_identifier, deputy_identifier);

--- a/src/nesc-dfilter.c
+++ b/src/nesc-dfilter.c
@@ -39,7 +39,7 @@ Boston, MA 02111-1307, USA.  */
          component (i.e., shows up in the generated C code)"
        abstract() && instance(): "a partially instantiated generic component,
          i.e., a generic component instantiated within a 
-	 generic configuration"
+         generic configuration"
 
   Filters can be combined with and, or, not.
 */
@@ -79,12 +79,12 @@ static bool filter_attribute(ndf_op filter, dd_list/*nesc_attribute*/ attrs)
       const char *reqname = nd_tokenval(reqattr);
 
       dd_scan (actualattr, attrs)
-	{
-	  nesc_attribute a = DD_GET(nesc_attribute, actualattr);
+        {
+          nesc_attribute a = DD_GET(nesc_attribute, actualattr);
 
-	  if (!strcmp(a->word1->cstring.data, reqname))
-	    return TRUE;
-	}
+          if (!strcmp(a->word1->cstring.data, reqname))
+            return TRUE;
+        }
     }
   return FALSE;
 }
@@ -274,33 +274,33 @@ nd_filter make_ndf_op(region r, const char *name, nd_arg args)
   for (i = 0; i < sizeof ops / sizeof *ops; i++)
     if (!strcmp(name, ops[i].name))
       {
-	const char *argspec = ops[i].args;
-	nd_arg arg;
-	int old_ec = errorcount;
+        const char *argspec = ops[i].args;
+        nd_arg arg;
+        int old_ec = errorcount;
 
-	op->filter_index = i;
+        op->filter_index = i;
 
-	/* Check arguments */
-	if (argspec[0] == '*')
-	  scan_nd_arg (arg, args)
-	    check_arg(arg, argspec[1]);
-	else
-	  {
-	    scan_nd_arg (arg, args)
-	      {
-		if (!*argspec)
-		  nderror("too many arguments");
-		else
-		  check_arg(arg, *argspec++);
-	      }
-	    if (*argspec)
-	      nderror("not enough arguments");
-	  }
+        /* Check arguments */
+        if (argspec[0] == '*')
+          scan_nd_arg (arg, args)
+            check_arg(arg, argspec[1]);
+        else
+          {
+            scan_nd_arg (arg, args)
+              {
+                if (!*argspec)
+                  nderror("too many arguments");
+                else
+                  check_arg(arg, *argspec++);
+              }
+            if (*argspec)
+              nderror("not enough arguments");
+          }
 
-	if (errorcount == old_ec && ops[i].compile)
-	  ops[i].compile(op);
+        if (errorcount == old_ec && ops[i].compile)
+          ops[i].compile(op);
 
-	return CAST(nd_filter, op);
+        return CAST(nd_filter, op);
       }
   nderror("unknown filter operator");
 
@@ -333,12 +333,12 @@ static bool dofilter(int op, nd_filter f, void *decl)
       struct filter_op *fop = &ops[f1->filter_index];
 
       switch (op)
-	{
-	case filter_ddecl: return fop->execute_ddecl(f1, decl);
-	case filter_ndecl: return fop->execute_ndecl(f1, decl);
-	case filter_tdecl: return fop->execute_tdecl(f1, decl);
-	default: assert(0); return FALSE;
-	}
+        {
+        case filter_ddecl: return fop->execute_ddecl(f1, decl);
+        case filter_ndecl: return fop->execute_ndecl(f1, decl);
+        case filter_tdecl: return fop->execute_tdecl(f1, decl);
+        default: assert(0); return FALSE;
+        }
     }
     default: 
       assert(0); return FALSE;
@@ -372,16 +372,16 @@ void dump_set_filter(nd_option opt)
       optargs = &(*optargs)->next;
     else
       {
-	nd_filter f = CAST(nd_filter, *optargs);
-	*optargs = (*optargs)->next;
+        nd_filter f = CAST(nd_filter, *optargs);
+        *optargs = (*optargs)->next;
 
-	if (extracted)
-	  {
-	    ndf_and x = new_ndf_and(dump_region, extracted, f);
-	    extracted = CAST(nd_filter, x);
-	  }
-	else
-	  extracted = f;
+        if (extracted)
+          {
+            ndf_and x = new_ndf_and(dump_region, extracted, f);
+            extracted = CAST(nd_filter, x);
+          }
+        else
+          extracted = f;
       }
 
   current_filter = extracted;

--- a/src/nesc-doc.c
+++ b/src/nesc-doc.c
@@ -732,28 +732,28 @@ static void ic_scan_rplist(nesc_declaration cdecl, char *name)
       rp_interface rp = CAST(rp_interface, dlist);
 
       scan_declaration(decl, rp->decls) {
-	if( is_interface_ref(decl) ) {
-	  iref = CAST(interface_ref,decl);
-	  ifname = ic_make_iface_key(iref->word1->cstring.data);
-	} else {
-	  continue;
-	}
+        if( is_interface_ref(decl) ) {
+          iref = CAST(interface_ref,decl);
+          ifname = ic_make_iface_key(iref->word1->cstring.data);
+        } else {
+          continue;
+        }
 
-	entry = ic_get_entry( ifname );
-	if(entry == NULL) {
-	  entry = ralloc(doc_region, ic_entry);
-	  memset(entry, 0, sizeof(ic_entry));
-	  env_add(ic_env, ifname, entry);
-	}
+        entry = ic_get_entry( ifname );
+        if(entry == NULL) {
+          entry = ralloc(doc_region, ic_entry);
+          memset(entry, 0, sizeof(ic_entry));
+          env_add(ic_env, ifname, entry);
+        }
         
-	// pick the list
-	if( rp->required )
-	  list = &(entry->r_list);
-	else 
-	  list = &(entry->p_list);
+        // pick the list
+        if( rp->required )
+          list = &(entry->r_list);
+        else 
+          list = &(entry->p_list);
       
-	// add to the list
-	ilist_add(list, name);
+        // add to the list
+        ilist_add(list, name);
       }
     }
   }
@@ -1482,20 +1482,20 @@ static bool connection_already_printed(dhash_table table,
 
   // sort out which is the "requires" side, and which is the "provides" side
   // For interfaces: ep1 is req, ep2 is prov if connecting a command,
-  // 		     the other way round if connecting an event
+  //                      the other way round if connecting an event
   // For functions: the direction in the graph is always the one we want
   if (ep1->interface)
     {
       if (ep1->function->ftype == function_command)
-	{
-	  *req = ep1;
-	  *prov = ep2;
-	}
+        {
+          *req = ep1;
+          *prov = ep2;
+        }
       else
-	{
-	  *req = ep2;
-	  *prov = ep1;
-	}
+        {
+          *req = ep2;
+          *prov = ep1;
+        }
     }
   else
     {
@@ -1921,7 +1921,7 @@ static void generate_component_html(nesc_declaration cdecl)
     // requires
     scan_declaration(dlist, comp->decls) {
       if(is_rp_interface(dlist) &&
-	 (rp = CAST(rp_interface, dlist))->required ) {
+         (rp = CAST(rp_interface, dlist))->required ) {
 
         scan_declaration(decl,rp->decls) {
           // commands / events
@@ -1958,7 +1958,7 @@ static void generate_component_html(nesc_declaration cdecl)
     header_printed = FALSE;
     scan_declaration(dlist, comp->decls) {
       if(is_rp_interface(dlist) &&
-	 !(rp = CAST(rp_interface, dlist))->required ) {
+         !(rp = CAST(rp_interface, dlist))->required ) {
         scan_declaration(decl,rp->decls) {
           // commands / events
           if( is_data_decl(decl) ) {
@@ -2064,8 +2064,8 @@ static void generate_component_html(nesc_declaration cdecl)
 
 
 static void generate_intf_function_list(const char *heading,
-					nesc_declaration idecl,
-					int kind, int flags)
+                                        nesc_declaration idecl,
+                                        int kind, int flags)
 {
   declaration funcs = CAST(interface, idecl->ast)->decls;
   declaration f;
@@ -2168,15 +2168,15 @@ static void generate_interface_html(nesc_declaration idecl)
   
   // summary
   generate_intf_function_list("<h3>Commands</h3>",
-			      idecl, function_command, short_desc);
+                              idecl, function_command, short_desc);
   generate_intf_function_list("<h3>Events</h3>",
-			      idecl, function_event, short_desc);
+                              idecl, function_event, short_desc);
 
   // detailed descriptions
   generate_intf_function_list("<h3>Commands - Details</h3>",
-			      idecl, function_command, long_desc);
+                              idecl, function_command, long_desc);
   generate_intf_function_list("<h3>Events - Details</h3>",
-			      idecl, function_event, long_desc);
+                              idecl, function_event, long_desc);
 
   close_outfile(outfile);
 }
@@ -2738,7 +2738,7 @@ void generate_docs(const char *ofilename, cgraph cg)
         *pos = '\0';
 
 #ifndef ENOMEDIUM
-	/* Ignore ENOMEDIUM on systems that don't have it */
+        /* Ignore ENOMEDIUM on systems that don't have it */
 #define ENOMEDIUM EEXIST
 #endif
 
@@ -2792,8 +2792,8 @@ void generate_docs(const char *ofilename, cgraph cg)
     env_scan(get_nesc_env(), &scanner);
     while( env_next(&scanner, &name, (void **)&cdecl) ) 
       if (cdecl->kind == l_component) {
-	if (flag_verbose) printf("        %s\n", cdecl->name);
-	generate_component_html(cdecl);
+        if (flag_verbose) printf("        %s\n", cdecl->name);
+        generate_component_html(cdecl);
       }
   }
 
@@ -2807,8 +2807,8 @@ void generate_docs(const char *ofilename, cgraph cg)
     env_scan(get_nesc_env(), &scanner);
     while( env_next(&scanner, &name, (void **)&idecl) )
       if (idecl->kind == l_interface) {
-	if (flag_verbose) printf("        %s\n", idecl->name);
-	generate_interface_html(idecl);
+        if (flag_verbose) printf("        %s\n", idecl->name);
+        generate_interface_html(idecl);
       }
   }
 

--- a/src/nesc-dump.c
+++ b/src/nesc-dump.c
@@ -178,23 +178,23 @@ void dump_ddecl(data_declaration ddecl)
     case decl_constant:
       indentedtag_start("constant");
       if (ddecl->value) /* generic components args are constants, but have
-			   no value */
-	xml_attr_cval("cst", ddecl->value->cval);
+                           no value */
+        xml_attr_cval("cst", ddecl->value->cval);
       break;
     case decl_function:
       indentedtag_start("function");
       switch (ddecl->ftype)
-	{
-	case function_event:
-	  xml_attr_noval("event");
-	  xml_attr_int("provided", ddecl->defined);
-	  break;
-	case function_command:
-	  xml_attr_noval("command");
-	  xml_attr_int("provided", ddecl->defined);
-	  break;
-	default: break;
-	}
+        {
+        case function_event:
+          xml_attr_noval("event");
+          xml_attr_int("provided", ddecl->defined);
+          break;
+        case function_command:
+          xml_attr_noval("command");
+          xml_attr_int("provided", ddecl->defined);
+          break;
+        default: break;
+        }
       xml_attr_bool("safe", ddecl->safe);
       break;
     case decl_typedef: indentedtag_start("typedef"); break;
@@ -228,39 +228,39 @@ void dump_ddecl(data_declaration ddecl)
     {
     case decl_interface_ref: 
       {
-	env_scanner fns;
-	const char *fnname;
-	void *fnentry;
-	
-	nxml_instance(ddecl->itype);
-	if (ddecl->gparms)
-	  nxml_typelist("interface-parameters", ddecl->gparms);
+        env_scanner fns;
+        const char *fnname;
+        void *fnentry;
+        
+        nxml_instance(ddecl->itype);
+        if (ddecl->gparms)
+          nxml_typelist("interface-parameters", ddecl->gparms);
 
-	indentedtag("interface-functions");
-	interface_scan(ddecl, &fns);
-	while (env_next(&fns, &fnname, &fnentry))
-	  {
-	    xstartline();
-	    nxml_ddecl_ref(fnentry);
-	  }
-	indentedtag_pop();
-	break;
+        indentedtag("interface-functions");
+        interface_scan(ddecl, &fns);
+        while (env_next(&fns, &fnname, &fnentry))
+          {
+            xstartline();
+            nxml_ddecl_ref(fnentry);
+          }
+        indentedtag_pop();
+        break;
       }
     case decl_function:
       {
-	if (ddecl->interface)
-	  nxml_ddecl_ref(ddecl->interface);
-	/* Builtin functions have no real AST */
-	if (!is_error_decl(ddecl->ast))
-	  {
-	    function_declarator fdecl = ddecl_get_fdeclarator(ddecl);
+        if (ddecl->interface)
+          nxml_ddecl_ref(ddecl->interface);
+        /* Builtin functions have no real AST */
+        if (!is_error_decl(ddecl->ast))
+          {
+            function_declarator fdecl = ddecl_get_fdeclarator(ddecl);
 
-	    if (fdecl->parms) /* absent in old-style functions */
-	      dump_parameters("parameters", fdecl->parms);
-	    if (fdecl->gparms)
-	      dump_parameters("instance-parameters", fdecl->gparms);
-	  }
-	break;
+            if (fdecl->parms) /* absent in old-style functions */
+              dump_parameters("parameters", fdecl->parms);
+            if (fdecl->gparms)
+              dump_parameters("instance-parameters", fdecl->gparms);
+          }
+        break;
       }
     default: break;
     }
@@ -338,7 +338,7 @@ static void dump_wiring(cgraph cg)
   graph_scan_nodes (from, cgraph_graph(cg))
     {
       graph_scan_out (wire, from)
-	dump_wire(EDGE_GET(location, wire), from, graph_edge_to(wire));
+        dump_wire(EDGE_GET(location, wire), from, graph_edge_to(wire));
     }
   indentedtag_pop();
 }
@@ -419,7 +419,7 @@ static void dump_interfacedef(void *entry)
       data_declaration fndecl = fnentry;
 
       if (fndecl->kind != decl_magic_string)
-	dump_ddecl(fnentry);
+        dump_ddecl(fnentry);
     }
 
   indentedtag_pop();
@@ -430,12 +430,12 @@ static void dump_field(field_declaration field)
   indentedtag_start("field");
   xml_attr("name", field->name);
   xml_attr_ptr("ref", field); /* collapsing structs into their parent can 
-				 cause duplicate names */
+                                 cause duplicate names */
   xml_attr_bool("packed", field->packed);
   xml_attr_cval("bit-offset", field->offset);
   if (cval_istop(field->bitwidth))
     xml_attr_cval("size", type_size_cc(field->type) ?
-		  type_size(field->type) : cval_top);
+                  type_size(field->type) : cval_top);
   else
     xml_attr_cval("bit-size", field->bitwidth);
   xml_tag_end();
@@ -483,15 +483,15 @@ static void dump_tag(void *entry)
       field_declaration fields;
 
       for (fields = tdecl->fieldlist; fields; fields = fields->next)
-	if (fields->name) /* skip unnamed fields */
-	  dump_field(fields);
+        if (fields->name) /* skip unnamed fields */
+          dump_field(fields);
     }
 
   indentedtag_pop();
 }
 
 static void dump_list(const char *name, xml_list l,
-		      void (*dump)(void *entry))
+                      void (*dump)(void *entry))
 {
   dd_list latest = xml_list_latest(l);
   dd_list_pos elem;
@@ -517,7 +517,7 @@ static void source_ndecl_iterate(int kind, int processkind, xml_list l, void (*p
       nesc_declaration ndecl = val;
 
       if (ndecl->kind == kind)
-	process(processkind, l, ndecl);
+        process(processkind, l, ndecl);
     }
 }
 
@@ -533,7 +533,7 @@ static void add_ddecls_from_env(int kind, xml_list l, struct environment *env)
       data_declaration ddecl = decl;
 
       if (ddecl->kind == kind && dump_filter_ddecl(ddecl))
-	xml_list_add(l, ddecl);
+        xml_list_add(l, ddecl);
     }
 }
 
@@ -574,12 +574,12 @@ static void select_components(xml_list l, nd_option opt, dd_list comps)
   scan_nd_arg (arg, opt->args)
     if (is_nd_token(arg))
       {
-	const char *req = nd_tokenval(arg);
+        const char *req = nd_tokenval(arg);
 
-	if (!strcmp(req, "wiring"))
-	  configuration_wiring = TRUE;
-	else
-	  error("unknown components option `%s'", req);
+        if (!strcmp(req, "wiring"))
+          configuration_wiring = TRUE;
+        else
+          error("unknown components option `%s'", req);
       }
     else
       error("bad components option");
@@ -639,7 +639,7 @@ static void add_tags_from_env(xml_list l, struct environment *env)
       tag_declaration tdecl = decl;
 
       if (dump_filter_tdecl(tdecl))
-	xml_list_add(l, tdecl);
+        xml_list_add(l, tdecl);
     }
 }
 
@@ -676,12 +676,12 @@ static void select_wiring(nd_option opt, dd_list comps)
   scan_nd_arg (arg, opt->args)
     if (is_nd_token(arg))
       {
-	const char *req = nd_tokenval(arg);
+        const char *req = nd_tokenval(arg);
 
-	if (!strcmp(req, "functions"))
-	  wiring = wiring_functions;
-	else
-	  error("unknown wiring request for `%s'", req);
+        if (!strcmp(req, "functions"))
+          wiring = wiring_functions;
+        else
+          error("unknown wiring request for `%s'", req);
       }
     else
       error("bad argument to wiring");
@@ -694,17 +694,17 @@ static void select_referenced(nd_option opt)
   scan_nd_arg (arg, opt->args)
     if (is_nd_token(arg))
       {
-	const char *req = nd_tokenval(arg);
-	int i;
+        const char *req = nd_tokenval(arg);
+        int i;
 
-	for (i = 0; i < NLISTS; i++)
-	  if (!strcmp(req, lists[i].name))
-	    {
-	      *lists[i].referenced = lists[i].l;
-	      break;
-	    }
-	if (i == NLISTS)
-	  error("unknown referenced request for `%s'", req);
+        for (i = 0; i < NLISTS; i++)
+          if (!strcmp(req, lists[i].name))
+            {
+              *lists[i].referenced = lists[i].l;
+              break;
+            }
+        if (i == NLISTS)
+          error("unknown referenced request for `%s'", req);
       }
     else
       error("bad argument to referenced");
@@ -727,16 +727,16 @@ void select_dump(char *what)
 
       fprintf(stderr, "opt %s, %d args\n", opt->name, opt->count);
       scan_nd_arg (arg, opt->args)
-	if (is_nd_int(arg))
-	  fprintf(stderr, "  arg %d int %ld\n", ++i,
-		  (long)ND_CAST(nd_int, arg)->val);
-	else
-	  fprintf(stderr, "  arg %d token %s\n", ++i,
-		  ND_CAST(nd_token, arg)->str);
+        if (is_nd_int(arg))
+          fprintf(stderr, "  arg %d int %ld\n", ++i,
+                  (long)ND_CAST(nd_int, arg)->val);
+        else
+          fprintf(stderr, "  arg %d token %s\n", ++i,
+                  ND_CAST(nd_token, arg)->str);
 #endif
 
       if (!opts)
-	opts = dd_new_list(dump_region);
+        opts = dd_new_list(dump_region);
       dd_add_last(dump_region, opts, opt);
     }
 }
@@ -760,7 +760,7 @@ static void do_lists(void)
 }
 
 void dump_info(nesc_declaration program, cgraph cg, cgraph userg,
-	       dd_list modules, dd_list comps)
+               dd_list modules, dd_list comps)
 {
   dd_list_pos scan_opts;
   bool list_change = FALSE;
@@ -779,20 +779,20 @@ void dump_info(nesc_declaration program, cgraph cg, cgraph userg,
       dump_set_filter(opt);
 
       for (i = 0; i < NLISTS; i++)
-	if (!strcmp(opt->name, lists[i].name))
-	  {
-	    lists[i].select(lists[i].l, opt, comps);
-	    break;
-	  }
+        if (!strcmp(opt->name, lists[i].name))
+          {
+            lists[i].select(lists[i].l, opt, comps);
+            break;
+          }
 
       if (i < NLISTS)
-	;
+        ;
       else if (!strcmp(opt->name, "wiring"))
-	select_wiring(opt, comps);
+        select_wiring(opt, comps);
       else if (!strcmp(opt->name, "referenced"))
-	select_referenced(opt);
+        select_referenced(opt);
       else
-	error("unknown dump request `%s'", opt->name);
+        error("unknown dump request `%s'", opt->name);
     }
 
   /* Repeatedly dump selected information (w/o performing any actual I/O).
@@ -805,7 +805,7 @@ void dump_info(nesc_declaration program, cgraph cg, cgraph userg,
     {
       do_lists();
       if (!list_change)
-	break;
+        break;
       list_change = FALSE;
     }
 
@@ -820,10 +820,10 @@ void dump_info(nesc_declaration program, cgraph cg, cgraph userg,
     {
       dumpf = fopen(dumpfile, "w");
       if (!dumpf)
-	{
-	  perror("couldn't create dump file");
-	  return;
-	}
+        {
+          perror("couldn't create dump file");
+          return;
+        }
       xml_start(dumpf);
     }
   indentedtag_start("nesc");

--- a/src/nesc-dump.h
+++ b/src/nesc-dump.h
@@ -43,7 +43,7 @@ bool dump_selected(void);
  */
 
 void dump_info(nesc_declaration program, cgraph cg, cgraph userg,
-	       dd_list modules, dd_list components);
+               dd_list modules, dd_list components);
 /* Effects: Dump selected information.
  */
 

--- a/src/nesc-env.c
+++ b/src/nesc-env.c
@@ -46,7 +46,7 @@ void init_nesc_env(region r)
 }
 
 nesc_declaration new_nesc_declaration(region r, source_language kind,
-				      const char *name)
+                                      const char *name)
 {
   nesc_declaration new = ralloc(r, struct nesc_declaration);
 
@@ -76,7 +76,7 @@ void preload(source_language sl, location l, const char *name)
   if (!nesc_lookup(name))
     load(sl, l, name, FALSE);
 }
-				    
+                                    
 nesc_declaration require(source_language sl, location l, const char *name)
 {
   nesc_declaration d = nesc_lookup(name);
@@ -93,13 +93,13 @@ nesc_declaration require(source_language sl, location l, const char *name)
       nd = dummy_nesc_decl(l, d);
 
       error_with_location(l, "expected %s `%s', but got %s %s",
-			  language_name(sl), name,
-			  d->kind == l_interface ? "an" : "a",
-			  language_name(d->kind));
+                          language_name(sl), name,
+                          d->kind == l_interface ? "an" : "a",
+                          language_name(d->kind));
     }
   return d;
 }
-				    
+                                    
 void require_c(location l, const char *name)
 {
   static int dummy;

--- a/src/nesc-env.h
+++ b/src/nesc-env.h
@@ -22,7 +22,7 @@ Boston, MA 02111-1307, USA.  */
    components, loads them on demand */
 
 nesc_declaration new_nesc_declaration(region r, source_language kind,
-				      const char *name);
+                                      const char *name);
 
 void init_nesc_env(region r);
 env get_nesc_env(void);

--- a/src/nesc-gcc.c
+++ b/src/nesc-gcc.c
@@ -62,11 +62,11 @@ static char *mktempfile(region r, const char *name)
       char *tmpenv = getenv("TMP");
 
       if (!tmpenv)
-	{
-	  fprintf(stderr, "You must define the TMP environment variable to point to a directory\n");
-	  fprintf(stderr, "for temporary files.\n");
-	  exit(2);
-	}
+        {
+          fprintf(stderr, "You must define the TMP environment variable to point to a directory\n");
+          fprintf(stderr, "for temporary files.\n");
+          exit(2);
+        }
       newname = rstralloc(r, strlen(tmpenv) + strlen(name));
       sprintf(newname, "%s/%s", tmpenv, name + 5);
     }
@@ -121,8 +121,8 @@ static void dup_restore(int to, int save)
 
 static bool 
 exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
-	 char *gcc_error_template, bool mketmp, char **gcc_error_file, 
-	 int nargs, void (*setargs)(void *data, const char **argv), void *data)
+         char *gcc_error_template, bool mketmp, char **gcc_error_file, 
+         int nargs, void (*setargs)(void *data, const char **argv), void *data)
 {
   int gcc_stat, res, outputfd, errorfd;
   const char **argv;
@@ -139,7 +139,7 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
       int i;
 
       for (i = 0; argv[i]; i++)
-	fprintf(stderr, "%s ", argv[i]);
+        fprintf(stderr, "%s ", argv[i]);
       fprintf(stderr, "\n");
     }
 
@@ -149,10 +149,10 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
       tmpfd2 = open(DEVNULL, O_RDONLY);
 
       if (tmpfd1 < 0 || tmpfd2 < 0)
-	{
-	  fprintf(stderr, "Internal error (can't open " DEVNULL "!?)\n");
-	  exit(2);
-	}
+        {
+          fprintf(stderr, "Internal error (can't open " DEVNULL "!?)\n");
+          exit(2);
+        }
     }
 
   if (mkotmp)
@@ -173,9 +173,9 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
   if (outputfd < 0 || errorfd < 0)
     {
       if (outputfd >= 0)
-	close(outputfd);
+        close(outputfd);
       if (errorfd >= 0)
-	close(errorfd);
+        close(errorfd);
 
       return FALSE;
     }
@@ -214,8 +214,8 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
 
 static bool 
 exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
-	 char *gcc_error_template, bool mketmp, char **gcc_error_file, 
-	 int nargs, void (*setargs)(void *data, const char **argv), void *data)
+         char *gcc_error_template, bool mketmp, char **gcc_error_file, 
+         int nargs, void (*setargs)(void *data, const char **argv), void *data)
 {
   int gcc_pid, gcc_stat, res;
   char *outputf, *errorf;
@@ -244,17 +244,17 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
 
       /* It's really spammy with this on */
       if (flag_verbose >= 2)
-	{
-	  int i;
+        {
+          int i;
 
-	  for (i = 0; argv[i]; i++)
-	    fprintf(stderr, "%s ", argv[i]);
-	  fprintf(stderr, "\n");
-	}
+          for (i = 0; argv[i]; i++)
+            fprintf(stderr, "%s ", argv[i]);
+          fprintf(stderr, "\n");
+        }
 
       if (outputfd < 0 || dup2(outputfd, 1) < 0 ||
-	  errorfd < 0 || dup2(errorfd, 2) < 0)
-	exit(2);
+          errorfd < 0 || dup2(errorfd, 2) < 0)
+        exit(2);
 
       close(outputfd);
       close(errorfd);
@@ -269,24 +269,24 @@ exec_gcc(char *gcc_output_template, bool mkotmp, char **gcc_output_file,
       int pid = wait(&gcc_stat);
 
       if (pid == -1)
-	{
-	  if (errno == EINTR)
-	    continue;
-	  else
-	    {
-	      res = 2;
-	      break;
-	    }
-	}
+        {
+          if (errno == EINTR)
+            continue;
+          else
+            {
+              res = 2;
+              break;
+            }
+        }
 
       if (pid == gcc_pid)
-	{
-	  if (WIFEXITED(gcc_stat))
-	    res = WEXITSTATUS(gcc_stat);
-	  else
-	    res = 2;
-	  break;
-	}
+        {
+          if (WIFEXITED(gcc_stat))
+            res = WEXITSTATUS(gcc_stat);
+          else
+            res = 2;
+          break;
+        }
     }
 
   return res == 0;
@@ -385,11 +385,11 @@ const char *gcc_global_cpp_init(void)
 
   /* Execute gcc to get builtin macros and include search path */
   if (!exec_gcc(tbuiltins, TRUE, &gcc_builtin_macros_file,
-		tincludes, TRUE, &includes, 
-		7 + extra_options_count, gcc_preprocess_init_setargs, NULL))
+                tincludes, TRUE, &includes, 
+                7 + extra_options_count, gcc_preprocess_init_setargs, NULL))
     {
       error("invocation of %s to find builtin macros failed (error message output follows)", 
-	    target_compiler);
+            target_compiler);
       print_error_file(stderr, includes);
 
       return NULL;
@@ -406,15 +406,15 @@ const char *gcc_global_cpp_init(void)
   while (fgets(line, LINELEN - 1, incf))
     {
       if (!strncmp(line, "#include \"...\"", 14))
-	quote_includes = TRUE;
+        quote_includes = TRUE;
       else if (!strncmp(line, "#include <...>", 14))
-	bracket_includes = TRUE;
+        bracket_includes = TRUE;
       else if (!strncmp(line, "End of search list.", 19))
-	break;
+        break;
       else if (bracket_includes)
-	add_nesc_dir(sanitize_path(permanent, line), CHAIN_SYSTEM);
+        add_nesc_dir(sanitize_path(permanent, line), CHAIN_SYSTEM);
       else if (quote_includes)
-	add_nesc_dir(sanitize_path(permanent, line), CHAIN_QUOTE);
+        add_nesc_dir(sanitize_path(permanent, line), CHAIN_QUOTE);
     }
   fclose(incf);
   unlink(includes);

--- a/src/nesc-generate.c
+++ b/src/nesc-generate.c
@@ -34,7 +34,7 @@ Boston, MA 02111-1307, USA.  */
 #include "nesc-cpp.h"
 
 static void prt_nesc_function_hdr(data_declaration fn_decl,
-				  psd_options options)
+                                  psd_options options)
 /* Effects: prints the C function declaration for fn_decl
 */
 {
@@ -67,13 +67,13 @@ static void prt_nesc_function_hdr(data_declaration fn_decl,
       prt_attribute_elements(fn_dd->modifiers);
       prt_type_elements(ret->qualifiers, opts);
       prt_declarator(ret->declarator, NULL, ifn_vd->attributes, fn_decl,
-		     options | psd_print_ddecl_fdeclarator);
+                     options | psd_print_ddecl_fdeclarator);
     }
   else
     {
       prt_type_elements(fn_dd->modifiers, opts);
       prt_declarator(ifn_vd->declarator, NULL, ifn_vd->attributes, fn_decl, 
-		     options);
+                     options);
     }
 }
 
@@ -125,7 +125,7 @@ struct connections
 };
 
 static full_connection new_full_connection(region r, endp ep, expression cond,
-				 expression args)
+                                 expression args)
 {
   full_connection c = ralloc(r, struct full_connection);
 
@@ -179,28 +179,28 @@ static bool prt_arguments(declaration parms, bool first, bool rename)
       /* Not supporting ... here for now. Fix requires different approach */
       data_decl dd = CAST(data_decl, parm);
       variable_decl vd = CAST(variable_decl, dd->decls);
-	  
+          
       if (!vd->ddecl) /* empty (void) parameter list */
-	break;
+        break;
 
       if (!first)
-	output(", ");
+        output(", ");
       first = FALSE;
 
       if (rename || !vd->ddecl->name)
-	output("arg_%p", vd->ddecl);
+        output("arg_%p", vd->ddecl);
       else
-	output((char *)vd->ddecl->name);
+        output((char *)vd->ddecl->name);
     }
   return first;
 }
 
 void prt_ncf_direct_call(struct connections *c,
-			 full_connection ccall,
-			 bool first_call,
-			 psd_options options,
-			 type return_type,
-			 function_declarator called_fd)
+                         full_connection ccall,
+                         bool first_call,
+                         psd_options options,
+                         type return_type,
+                         function_declarator called_fd)
 /* Effects: prints call to 'calls' in a connection function.
      Assigns result if last_call is TRUE.
 */
@@ -215,10 +215,10 @@ void prt_ncf_direct_call(struct connections *c,
 
       /* Combine w/ the combiner on subsequent calls */
       if (!first_call && combiner)
-	{
-	  output("%s(__nesc_result, ", combiner->name);
-	  calling_combiner = TRUE;
-	}
+        {
+          output("%s(__nesc_result, ", combiner->name);
+          calling_combiner = TRUE;
+        }
     }
 
   prt_ddecl_full_name(ccall->ep->function, options);
@@ -226,16 +226,16 @@ void prt_ncf_direct_call(struct connections *c,
   if (ccall->ep->function->gparms)
     {
       if (ccall->args)
-	{
-	  /* Non-generic calling generic, add arguments */
-	  prt_expressions(ccall->args, first_arg);
-	  first_arg = FALSE;
-	}
+        {
+          /* Non-generic calling generic, add arguments */
+          prt_expressions(ccall->args, first_arg);
+          first_arg = FALSE;
+        }
       else
-	{
-	  /* Generic calling generic, pass arguments through */
-	  first_arg = prt_arguments(ddecl_get_gparms(c->called), first_arg, TRUE);
-	}
+        {
+          /* Generic calling generic, pass arguments through */
+          first_arg = prt_arguments(ddecl_get_gparms(c->called), first_arg, TRUE);
+        }
     }
   else
     assert(!ccall->args);
@@ -249,8 +249,8 @@ void prt_ncf_direct_call(struct connections *c,
 }
 
 void prt_ncf_default_call(struct connections *c,
-			  type return_type,
-			  function_declarator called_fd)
+                          type return_type,
+                          function_declarator called_fd)
 {
   struct full_connection default_target;
   struct endp default_ep;
@@ -260,12 +260,12 @@ void prt_ncf_default_call(struct connections *c,
   default_ep.function = c->called;
 
   prt_ncf_direct_call(c, &default_target, TRUE, psd_print_default,
-		      return_type, called_fd);
+                      return_type, called_fd);
 }
 
 bool prt_ncf_direct_calls(struct connections *c,
-			  dd_list/*<full_connection>*/ calls,
-			  type return_type)
+                          dd_list/*<full_connection>*/ calls,
+                          type return_type)
 /* Effects: prints calls to 'calls' in a connection function.
 */
 {
@@ -297,9 +297,9 @@ static int constant_expression_list_compare(expression arg1, expression arg2)
 
       /* Can't use - as might overflow and mod down to 0 */
       if (uval1 < uval2)
-	return -1;
+        return -1;
       else if (uval1 > uval2)
-	return 1;
+        return 1;
 
       arg1 = CAST(expression, arg1->next);
       arg2 = CAST(expression, arg2->next);
@@ -325,11 +325,11 @@ static void prt_ncf_condition(struct connections *c, expression cond)
     {
       data_decl dd = CAST(data_decl, gparm);
       variable_decl vd = CAST(variable_decl, dd->decls);
-	  
+          
       if (first)
-	output("if (");
+        output("if (");
       else
-	output(" && ");
+        output(" && ");
       first = FALSE;
 
       output("arg_%p == ", vd->ddecl);
@@ -378,59 +378,59 @@ static void prt_ncf_conditional_calls(struct connections *c, bool first_call, ty
 
       /* output latest condition */
       if (one_arg)
-	{
-	  output("case ");
-	  prt_expression(cond, P_ASSIGN);
-	  outputln(":");
-	}
+        {
+          output("case ");
+          prt_expression(cond, P_ASSIGN);
+          outputln(":");
+        }
       else
-	{
-	  if (i != 0)
-	    output("else ");
-	  prt_ncf_condition(c, cond);
-	  outputln("{");
-	}
+        {
+          if (i != 0)
+            output("else ");
+          prt_ncf_condition(c, cond);
+          outputln("{");
+        }
       indent();
 
       /* find last target with same condition */
       j = i;
       while (++j < ncalls && condition_compare(&cond_eps[i], &cond_eps[j]) == 0)
-	;
+        ;
 
       /* print them, setting result for the last one */
       while (i < j)
-	{
-	  prt_ncf_direct_call(c, cond_eps[i], first_cond_call, 0,
-			      return_type, called_fd);
-	  first_cond_call = FALSE;
-	  i++;
-	}
-	
+        {
+          prt_ncf_direct_call(c, cond_eps[i], first_cond_call, 0,
+                              return_type, called_fd);
+          first_cond_call = FALSE;
+          i++;
+        }
+        
       if (one_arg)
-	outputln("break;");
+        outputln("break;");
       unindent();
       if (!one_arg)
-	outputln("}");
+        outputln("}");
     }
   /* output call to default if there are no non-conditional calls */
   if (first_call)
     {
       if (ncalls > 0)
-	{
-	  if (one_arg)
-	    outputln("default:");
-	  else
-	    outputln("else");
-	}
+        {
+          if (one_arg)
+            outputln("default:");
+          else
+            outputln("else");
+        }
       indent();
       prt_ncf_default_call(c, return_type, called_fd);
       unindent();
       if (ncalls > 0 && one_arg)
-	{
-	  outputln("  break;");
-	  outputln("}");
-	  unindent();
-	}
+        {
+          outputln("  break;");
+          outputln("}");
+          unindent();
+        }
     }
   else if (one_arg)
     {
@@ -460,10 +460,10 @@ static void prt_nesc_connection_function(struct connections *c)
   else
     {
       if (dd_is_empty(c->normal_calls))
-	prt_ncf_default_call(c, return_type,
-			     ddecl_get_fdeclarator(c->called));
+        prt_ncf_default_call(c, return_type,
+                             ddecl_get_fdeclarator(c->called));
       else
-	prt_ncf_direct_calls(c, c->normal_calls, return_type);
+        prt_ncf_direct_calls(c, c->normal_calls, return_type);
     }
 
   prt_ncf_trailer(return_type);
@@ -483,10 +483,10 @@ void prt_nesc_called_function_hdr(data_declaration fndecl, void *data)
   if (!fndecl->defined && fndecl->uncallable &&
       is_binary_component(fndecl->container->impl))
     error("binary entry point %s%s%s.%s is not fully wired",
-	  fndecl->container->instance_name, 
-	  fndecl->interface ? "." : "",
-	  fndecl->interface ? fndecl->interface->name : "",
-	  fndecl->name);
+          fndecl->container->instance_name, 
+          fndecl->interface ? "." : "",
+          fndecl->interface ? fndecl->interface->name : "",
+          fndecl->name);
 }
 
 void prt_nesc_called_function_headers(cgraph cg, nesc_declaration mod)
@@ -520,28 +520,28 @@ void prt_nesc_module(cgraph cg, nesc_declaration mod)
       dd_list_pos scan;
 
       dd_scan (scan, mod->local_statics)
-	{
-	  data_declaration localsvar = DD_GET(data_declaration, scan);
-	  variable_decl localsvd;
-	  data_decl localsdd;
+        {
+          data_declaration localsvar = DD_GET(data_declaration, scan);
+          variable_decl localsvd;
+          data_decl localsdd;
 
-	  if (!localsvar->isused)
-	    continue;
+          if (!localsvar->isused)
+            continue;
 
-	  localsvd = CAST(variable_decl, localsvar->ast);
-	  localsdd = CAST(data_decl, localsvd->parent);
-	  /* Note: we don't print the elements with pte_duplicate as we
-	     don't (easily) know here if the elements will be printed
-	     several times. If the type elements define a new type we most
-	     likely have a problem anyway (see discussion above) */
-	  prt_variable_decl(localsdd->modifiers, localsvd, 0);
-	  outputln(";");
-	}
+          localsvd = CAST(variable_decl, localsvar->ast);
+          localsdd = CAST(data_decl, localsvd->parent);
+          /* Note: we don't print the elements with pte_duplicate as we
+             don't (easily) know here if the elements will be printed
+             several times. If the type elements define a new type we most
+             likely have a problem anyway (see discussion above) */
+          prt_variable_decl(localsdd->modifiers, localsvd, 0);
+          outputln(";");
+        }
     }
 }
 
 static bool find_reachable_functions(struct connections *c, gnode n,
-				     expression gcond, expression gargs)
+                                     expression gcond, expression gargs)
 {
   endp ep = NODE_GET(endp, n);
 
@@ -549,36 +549,36 @@ static bool find_reachable_functions(struct connections *c, gnode n,
     {
       /* First set of arguments is a condition if 'called' is generic */
       if (c->called->gparms && !gcond)
-	gcond = ep->args_node;
+        gcond = ep->args_node;
       else if (gargs)
-	{
-	  /* We already have some arguments, so this is a condition again.
-	     If the condition doesn't match gargs, then the call is
-	     filtered out. If they do match, we set gargs to null (we're
-	     back to a non-parameterised call) */
-	  if (constant_expression_list_compare(gargs, ep->args_node) != 0)
-	    return FALSE;
-	  gargs = NULL;
-	}
+        {
+          /* We already have some arguments, so this is a condition again.
+             If the condition doesn't match gargs, then the call is
+             filtered out. If they do match, we set gargs to null (we're
+             back to a non-parameterised call) */
+          if (constant_expression_list_compare(gargs, ep->args_node) != 0)
+            return FALSE;
+          gargs = NULL;
+        }
       else
-	{
-	  assert(!gargs);
-	  gargs = ep->args_node;
-	}
+        {
+          assert(!gargs);
+          gargs = ep->args_node;
+        }
     }
   if (graph_node_markedp(n))
     return TRUE;
   else if (!ep->args_node && ep->function->defined &&
-	   !ep->function->container->configuration)
+           !ep->function->container->configuration)
     {
       full_connection target = new_full_connection(c->r, ep, gcond, gargs);
 
       assert(!graph_first_edge_out(n));
 
       dd_add_last(c->r, 
-		  c->called->gparms && !gcond ?
-		    c->generic_calls : c->normal_calls, 
-		  target);
+                  c->called->gparms && !gcond ?
+                    c->generic_calls : c->normal_calls, 
+                  target);
     }
   else
     {
@@ -586,8 +586,8 @@ static bool find_reachable_functions(struct connections *c, gnode n,
 
       graph_mark_node(n);
       graph_scan_out (out, n)
-	if (find_reachable_functions(c, graph_edge_to(out), gcond, gargs))
-	  return TRUE;
+        if (find_reachable_functions(c, graph_edge_to(out), gcond, gargs))
+          return TRUE;
       graph_unmark_node(n);
     }
   return FALSE;
@@ -602,11 +602,11 @@ static void find_connected_functions(struct connections *c)
   assert(!graph_first_edge_in(called_fn_node));
   if (find_reachable_functions(c, called_fn_node, NULL, NULL))
     error_with_location(c->called->ast->location,
-			"cycle in configuration (for %s%s%s.%s)",
-			c->called->container->name,
-			c->called->interface ? "." : "",
-			c->called->interface ? c->called->interface->name : "",
-			c->called->name);
+                        "cycle in configuration (for %s%s%s.%s)",
+                        c->called->container->name,
+                        c->called->interface ? "." : "",
+                        c->called->interface ? c->called->interface->name : "",
+                        c->called->name);
 }
 
 static void combine_warning(struct connections *c)
@@ -615,13 +615,13 @@ static void combine_warning(struct connections *c)
     {
       /* Warnings to be enabled when result_t gets defined correctly */
       if (c->called->interface)
-	nesc_warning("calls to %s.%s in %s fan out, but there is no combine function specified for the return type",
-		     c->called->interface->name,
-		     c->called->name,
-		     c->called->container->name);
+        nesc_warning("calls to %s.%s in %s fan out, but there is no combine function specified for the return type",
+                     c->called->interface->name,
+                     c->called->name,
+                     c->called->container->name);
       else
-	nesc_warning("calls to %s in %s fan out, but there is no combine function specified for the return type" ,
-		     c->called->name, c->called->container->name);
+        nesc_warning("calls to %s in %s fan out, but there is no combine function specified for the return type" ,
+                     c->called->name, c->called->container->name);
     }
 }
 
@@ -660,10 +660,10 @@ static void cicn_conditional_calls(struct connections *c, bool first_call)
       /* find last target with same condition */
       j = i;
       while (++j < ncalls && condition_compare(&cond_eps[i], &cond_eps[j]) == 0)
-	;
+        ;
 
       if (i + first_call < j)
-	combiner_used = TRUE;
+        combiner_used = TRUE;
       i = j;
     }
 }
@@ -694,7 +694,7 @@ static void check_if_combiner_needed(struct connections *c)
     {
       c->combiner = type_combiner(return_type);
       if (!c->combiner)
-	combine_warning(c);
+        combine_warning(c);
     }
 }
 
@@ -718,17 +718,17 @@ void find_function_connections(data_declaration fndecl, void *data)
       find_connected_functions(connections);
 
       /* a function is uncallable if it has no default definition and
-	   non-generic: no connections
-	   generic: no generic connections
+           non-generic: no connections
+           generic: no generic connections
       */
       if (!(fndecl->definition ||
-	    !dd_is_empty(connections->generic_calls) ||
-	    (!fndecl->gparms && !dd_is_empty(connections->normal_calls))))
-	fndecl->uncallable = TRUE;
+            !dd_is_empty(connections->generic_calls) ||
+            (!fndecl->gparms && !dd_is_empty(connections->normal_calls))))
+        fndecl->uncallable = TRUE;
       else
-	fndecl->suppress_definition =
-	  !dd_is_empty(fndecl->gparms ? connections->generic_calls :
-		       connections->normal_calls);
+        fndecl->suppress_definition =
+          !dd_is_empty(fndecl->gparms ? connections->generic_calls :
+                       connections->normal_calls);
 
       check_if_combiner_needed(connections);
     }
@@ -740,13 +740,13 @@ void find_connections(cgraph cg, nesc_declaration mod)
 }
 
 static void mark_reachable_function(cgraph cg,
-				    data_declaration caller,
-				    data_declaration ddecl,
-				    use caller_use);
+                                    data_declaration caller,
+                                    data_declaration ddecl,
+                                    use caller_use);
 
 static void mark_connected_function_list(cgraph cg,
-					 data_declaration caller,
-					 dd_list/*full_connection*/ calls)
+                                         data_declaration caller,
+                                         dd_list/*full_connection*/ calls)
 {
   dd_list_pos connected;
 
@@ -755,14 +755,14 @@ static void mark_connected_function_list(cgraph cg,
       full_connection conn = DD_GET(full_connection, connected);
 
       mark_reachable_function(cg, caller, conn->ep->function,
-			      new_use(dummy_location, caller, c_executable | c_fncall));
+                              new_use(dummy_location, caller, c_executable | c_fncall));
     }
 }
 
 static void mark_reachable_function(cgraph cg,
-				    data_declaration caller,
-				    data_declaration ddecl,
-				    use caller_use)
+                                    data_declaration caller,
+                                    data_declaration ddecl,
+                                    use caller_use)
 {
   dd_list_pos use;
 
@@ -780,7 +780,7 @@ static void mark_reachable_function(cgraph cg,
   if (ddecl->kind != decl_function ||
       (ddecl->container && 
        !(ddecl->container->kind == l_component &&
-	 !ddecl->container->configuration)))
+         !ddecl->container->configuration)))
     return;
 
   if ((ddecl->ftype == function_command || ddecl->ftype == function_event) &&
@@ -789,16 +789,16 @@ static void mark_reachable_function(cgraph cg,
       struct connections *conn = ddecl->connections;
 
       /* Call to a command or event not defined in this module.
-	 Mark all connected functions */
+         Mark all connected functions */
       mark_connected_function_list(cg, ddecl, conn->generic_calls);
       mark_connected_function_list(cg, ddecl, conn->normal_calls);
       if (conn->combiner)
-	mark_reachable_function(cg, ddecl, conn->combiner,
-				new_use(dummy_location, caller, c_executable | c_fncall));
+        mark_reachable_function(cg, ddecl, conn->combiner,
+                                new_use(dummy_location, caller, c_executable | c_fncall));
 
       /* Don't process body of suppressed default defs */
       if (ddecl->suppress_definition)
-	return;
+        return;
     }
 
   /* Make sure ddecl gets a node in the graph even if it doesn't call
@@ -808,9 +808,9 @@ static void mark_reachable_function(cgraph cg,
   if (ddecl->fn_uses)
     dd_scan (use, ddecl->fn_uses)
       {
-	iduse i = DD_GET(iduse, use);
+        iduse i = DD_GET(iduse, use);
 
-	mark_reachable_function(cg, ddecl, i->id, i->u);
+        mark_reachable_function(cg, ddecl, i->id, i->u);
       }
 }
 
@@ -819,7 +819,7 @@ static declaration dummy_function(data_declaration ddecl)
   empty_stmt body = new_empty_stmt(parse_region, dummy_location);
   function_decl fd = 
     new_function_decl(parse_region, dummy_location, NULL, NULL, NULL, NULL,
-		      CAST(statement, body), NULL, NULL);
+                      CAST(statement, body), NULL, NULL);
 
   fd->ddecl = ddecl;
 
@@ -855,7 +855,7 @@ static cgraph mark_reachable_code(dd_list modules)
       nesc_declaration m = DD_GET(nesc_declaration, mod);
 
       if (is_binary_component(m->impl))
-	component_functions_iterate(m, mark_binary_reachable, cg);
+        component_functions_iterate(m, mark_binary_reachable, cg);
     }
 
   return cg;
@@ -889,12 +889,12 @@ static void topological_prt(gnode gep, bool force)
   if (isinlined(fn) || force)
     {
       if (graph_node_markedp(gep))
-	return;
+        return;
 
       graph_mark_node(gep);
 
       graph_scan_out (out, gep)
-	topological_prt(graph_edge_to(out), FALSE);
+        topological_prt(graph_edge_to(out), FALSE);
 
       prt_nesc_function(fn);
     }
@@ -908,25 +908,25 @@ static void prt_inline_functions(cgraph callgraph)
     {
       data_declaration fn = NODE_GET(endp, fns)->function;
       if (isinlined(fn))
-	{
-	  gedge callers;
-	  bool inlinecallers = FALSE;
+        {
+          gedge callers;
+          bool inlinecallers = FALSE;
 
-	  graph_scan_in (callers, fns)
-	    {
-	      data_declaration caller =
-		NODE_GET(endp, graph_edge_from(callers))->function;
+          graph_scan_in (callers, fns)
+            {
+              data_declaration caller =
+                NODE_GET(endp, graph_edge_from(callers))->function;
 
-	      if (isinlined(caller))
-		{
-		  inlinecallers = TRUE;
-		  break;
-		}
-	    }
+              if (isinlined(caller))
+                {
+                  inlinecallers = TRUE;
+                  break;
+                }
+            }
 
-	  if (!inlinecallers)
-	    topological_prt(fns, FALSE);
-	}
+          if (!inlinecallers)
+            topological_prt(fns, FALSE);
+        }
     }
 }
 
@@ -938,17 +938,17 @@ static void prt_noninline_functions(cgraph callgraph)
       data_declaration fn = NODE_GET(endp, fns)->function;
 
       if (!isinlined(fn))
-	{
-	  /* There may be some inlined functions which were not printed
-	     earlier, because they were:
-	     a) recursive (possibly indirectly), with explicit inline
-	        keywords
-	     b) not called from another inline function
-	     So we use topological_prt here to ensure they are printed
-	     before any calls to them from non-inlined functions
-	  */
-	  topological_prt(fns, TRUE);
-	}
+        {
+          /* There may be some inlined functions which were not printed
+             earlier, because they were:
+             a) recursive (possibly indirectly), with explicit inline
+                keywords
+             b) not called from another inline function
+             So we use topological_prt here to ensure they are printed
+             before any calls to them from non-inlined functions
+          */
+          topological_prt(fns, TRUE);
+        }
     }
 }
 
@@ -974,7 +974,7 @@ static void prt_ddecl_for_init(region r, data_declaration ddecl)
       output("*(");
       nonconst = make_qualified_type(ddecl->type, dquals & ~const_qualifier);
       type2ast(r, dummy_location, make_pointer_type(nonconst), NULL,
-	       &nc_decl, &nc_mods);
+               &nc_decl, &nc_mods);
       nc_type = new_asttype(r, dummy_location, nc_decl, nc_mods);
       prt_asttype(nc_type);
       output(")&");
@@ -1011,7 +1011,7 @@ static void prt_nido_initializer(region r, variable_decl vd)
 
       output(", (void *)&");
       type2ast(parse_region, dummy_location, ddecl->type, NULL,
-	       &vtype, &vmods);
+               &vtype, &vmods);
       output("(");
       prt_declarator(vtype, vmods, NULL, NULL, 0);
       output(")");
@@ -1052,10 +1052,10 @@ static void prt_nido_initializations(nesc_declaration mod)
       variable_decl vd;
 
       if (reald->kind != kind_data_decl)
-	continue;
+        continue;
 
       scan_variable_decl (vd, CAST(variable_decl, CAST(data_decl, d)->decls))
-	prt_nido_initializer(r, vd);
+        prt_nido_initializer(r, vd);
     }
 
   /* Local static variables */
@@ -1093,13 +1093,13 @@ static void prt_typedefs(nesc_declaration comp)
   scan_declaration (parm, comp->parameters)
     if (is_type_parm_decl(parm))
       {
-	type_parm_decl td = CAST(type_parm_decl, parm);
-	asttype arg = CAST(type_argument, td->ddecl->initialiser)->asttype;
+        type_parm_decl td = CAST(type_parm_decl, parm);
+        asttype arg = CAST(type_argument, td->ddecl->initialiser)->asttype;
 
-	output("typedef ");
-	prt_declarator(arg->declarator, arg->qualifiers, NULL, td->ddecl,
-		       psd_print_ddecl);
-	outputln(";");
+        output("typedef ");
+        prt_declarator(arg->declarator, arg->qualifiers, NULL, td->ddecl,
+                       psd_print_ddecl);
+        outputln(";");
       }
 }
 
@@ -1115,7 +1115,7 @@ void prt_nesc_interface_typedefs(nesc_declaration comp)
       data_declaration idecl = ifentry;
 
       if (idecl->kind == decl_interface_ref)
-	prt_typedefs(idecl->itype);
+        prt_typedefs(idecl->itype);
     }
 }
 
@@ -1199,10 +1199,10 @@ static void prt_nido_resolvers(nesc_declaration mod)
       variable_decl vd;
 
       if (reald->kind != kind_data_decl)
-	continue;
+        continue;
       
       scan_variable_decl (vd, CAST(variable_decl, CAST(data_decl, d)->decls))
-	prt_nido_resolver(r, vd);
+        prt_nido_resolver(r, vd);
     }
   deleteregion(r);
 
@@ -1246,14 +1246,14 @@ static void include_support_functions(void)
       data_declaration fndecl = lookup_global_id(fns[i]);
 
       /* Adding the function to spontaneous_calls w/o setting the
-	 spontaneous field makes the function stay static */
+         spontaneous field makes the function stay static */
       if (fndecl && fndecl->kind == decl_function && !fndecl->spontaneous)
-	dd_add_last(parse_region, spontaneous_calls, fndecl);
+        dd_add_last(parse_region, spontaneous_calls, fndecl);
     }
 }
 
 void generate_c_code(const char *target_name, nesc_declaration program,
-		     cgraph cg, dd_list modules, dd_list components)
+                     cgraph cg, dd_list modules, dd_list components)
 {
   dd_list_pos mod;
   cgraph callgraph;
@@ -1263,10 +1263,10 @@ void generate_c_code(const char *target_name, nesc_declaration program,
     {
       output = fopen(target_name, "w");
       if (!output)
-	{
-	  perror("couldn't create output file");
-	  exit(2);
-	}
+        {
+          perror("couldn't create output file");
+          exit(2);
+        }
     }
 
   if (diff_output)
@@ -1274,20 +1274,20 @@ void generate_c_code(const char *target_name, nesc_declaration program,
       char *diffname = rstralloc(permanent, strlen(diff_output) + 9);
 
       if (use_nido)
-	{
-	  /* There's no use for nido+diffs, and it would complicate
-	     things somewhat (nido changes rules for symbols, etc) */
-	  error("diff output is not supported with simulation");
-	  exit(1);
-	}
+        {
+          /* There's no use for nido+diffs, and it would complicate
+             things somewhat (nido changes rules for symbols, etc) */
+          error("diff output is not supported with simulation");
+          exit(1);
+        }
       sprintf(diffname, "%s/symbols", diff_output);
       diff_file = fopen(diffname, "w");
       if (!diff_file)
-	{
-	  fprintf(stderr, "couldn't create diff output file %s: ", diffname);
-	  perror(NULL);
-	  exit(2);
-	}
+        {
+          fprintf(stderr, "couldn't create diff output file %s: ", diffname);
+          perror(NULL);
+          exit(2);
+        }
     }
 
   include_support_functions();
@@ -1320,12 +1320,12 @@ void generate_c_code(const char *target_name, nesc_declaration program,
       nesc_declaration m = DD_GET(nesc_declaration, mod);
 
       if (is_module(m->impl))
-	{
-	  declaration body = CAST(module, m->impl)->decls;
+        {
+          declaration body = CAST(module, m->impl)->decls;
 
-	  collect_uses(body);
-	  handle_network_types(body);
-	}
+          collect_uses(body);
+          handle_network_types(body);
+        }
       
       find_connections(cg, m);
     }

--- a/src/nesc-generate.h
+++ b/src/nesc-generate.h
@@ -21,6 +21,6 @@ Boston, MA 02111-1307, USA.  */
 #include "nesc-cg.h"
 
 void generate_c_code(const char *target_name, nesc_declaration program,
-		     cgraph cg, dd_list modules, dd_list components);
+                     cgraph cg, dd_list modules, dd_list components);
 
 #endif

--- a/src/nesc-inline.c
+++ b/src/nesc-inline.c
@@ -107,18 +107,18 @@ static size_t expression_size(expression expr, bool inatomic)
       conditional ce = CAST(conditional, expr);
 
       if (ce->condition->cst)
-	{
-	  if (definite_zero(ce->condition))
-	    sum += expression_size(ce->arg2, inatomic);
-	  else
-	    sum += expression_size(ce->arg1, inatomic);
-	}
+        {
+          if (definite_zero(ce->condition))
+            sum += expression_size(ce->arg2, inatomic);
+          else
+            sum += expression_size(ce->arg1, inatomic);
+        }
       else
-	{
-	  sum += 2 + expression_size(ce->condition, inatomic);
-	  sum += expression_size(ce->arg1, inatomic);
-	  sum += expression_size(ce->arg2, inatomic);
-	}
+        {
+          sum += 2 + expression_size(ce->condition, inatomic);
+          sum += expression_size(ce->arg1, inatomic);
+          sum += expression_size(ce->arg2, inatomic);
+        }
       break;
     }
     case kind_compound_expr:
@@ -145,16 +145,16 @@ static size_t expression_size(expression expr, bool inatomic)
 
     default:
       if (is_unary(expr))
-	sum += 1 + expression_size(CAST(unary, expr)->arg1, inatomic);
+        sum += 1 + expression_size(CAST(unary, expr)->arg1, inatomic);
       else if (is_binary(expr))
-	{
-	  binary be = CAST(binary, expr);
+        {
+          binary be = CAST(binary, expr);
 
-	  sum += 1 + expression_size(be->arg1, inatomic);
-	  sum += expression_size(be->arg2, inatomic);
-	}
+          sum += 1 + expression_size(be->arg1, inatomic);
+          sum += expression_size(be->arg2, inatomic);
+        }
       else 
-	assert(0);
+        assert(0);
       break;
     }
 
@@ -180,38 +180,38 @@ static size_t statement_size(statement stmt, bool inatomic)
       declaration d;
 
       scan_declaration (d, cs->decls)
-	if (is_data_decl(d))
-	  {
-	    variable_decl vd;
+        if (is_data_decl(d))
+          {
+            variable_decl vd;
 
-	    /* Include size of initialisers of non-static variables */
-	    scan_variable_decl (vd, CAST(variable_decl,
-					 CAST(data_decl, d)->decls))
-	      if (vd->ddecl->kind == decl_variable &&
-		  vd->ddecl->vtype != variable_static)
-		sum += 1 + expression_size(vd->arg1, inatomic);
-	  }
+            /* Include size of initialisers of non-static variables */
+            scan_variable_decl (vd, CAST(variable_decl,
+                                         CAST(data_decl, d)->decls))
+              if (vd->ddecl->kind == decl_variable &&
+                  vd->ddecl->vtype != variable_static)
+                sum += 1 + expression_size(vd->arg1, inatomic);
+          }
 
       scan_statement (s, cs->stmts)
-	sum += statement_size(s, inatomic);
+        sum += statement_size(s, inatomic);
       break;
     }
     case kind_if_stmt: {
       if_stmt is = CAST(if_stmt, stmt);
 
       if (is->condition->cst)
-	{
-	  if (definite_zero(is->condition))
-	    sum += statement_size(is->stmt2, inatomic);
-	  else
-	    sum += statement_size(is->stmt1, inatomic);
-	}
+        {
+          if (definite_zero(is->condition))
+            sum += statement_size(is->stmt2, inatomic);
+          else
+            sum += statement_size(is->stmt1, inatomic);
+        }
       else
-	{
-	  sum += 2 + expression_size(is->condition, inatomic);
-	  sum += statement_size(is->stmt1, inatomic);
-	  sum += statement_size(is->stmt2, inatomic);
-	}
+        {
+          sum += 2 + expression_size(is->condition, inatomic);
+          sum += statement_size(is->stmt1, inatomic);
+          sum += statement_size(is->stmt2, inatomic);
+        }
       break;
     }
     case kind_labeled_stmt: {
@@ -225,7 +225,7 @@ static size_t statement_size(statement stmt, bool inatomic)
 
       sum += statement_size(ls->stmt, inatomic);
       if (!inatomic)
-	sum += 6;
+        sum += 6;
       break;
     }
     case kind_expression_stmt: {
@@ -238,14 +238,14 @@ static size_t statement_size(statement stmt, bool inatomic)
       conditional_stmt cs = CAST(conditional_stmt, stmt);
 
       if (cs->condition->cst && stmt->kind != kind_switch_stmt &&
-	  definite_zero(cs->condition))
-	{
-	  /* do s while (0): just include size of s
-	     while (0) s: size is 0 */
-	  if (stmt->kind == kind_dowhile_stmt)
-	    sum += statement_size(cs->stmt, inatomic);
-	  break;
-	}
+          definite_zero(cs->condition))
+        {
+          /* do s while (0): just include size of s
+             while (0) s: size is 0 */
+          if (stmt->kind == kind_dowhile_stmt)
+            sum += statement_size(cs->stmt, inatomic);
+          break;
+        }
       sum += 2 + expression_size(cs->condition, inatomic);
       sum += statement_size(cs->stmt, inatomic);
       break;
@@ -327,22 +327,22 @@ static ggraph make_ig(region r, cgraph callgraph)
       size_t fnsize = 1;
 
       if (fn->definition)
-	fnsize = function_size(CAST(function_decl, fn->definition));
+        fnsize = function_size(CAST(function_decl, fn->definition));
 
       if (fn->interface && !fn->defined)
-	{
-	  /* stub function. size is based on number of outgoing edges and
-	     number of parameters (first outgoing edge counted as "free") */
-	  gedge e;
-	  int edgecount = 0;
+        {
+          /* stub function. size is based on number of outgoing edges and
+             number of parameters (first outgoing edge counted as "free") */
+          gedge e;
+          int edgecount = 0;
 
-	  graph_scan_out (e, n)
-	    edgecount++;
-	  /* use size of default definition (already computed above) if no
-	     outgoing edges */
-	  if (edgecount > 0)
-	    fnsize = (edgecount - 1) * (2 + function_argcount(fn)) + 1;
-	}
+          graph_scan_out (e, n)
+            edgecount++;
+          /* use size of default definition (already computed above) if no
+             outgoing edges */
+          if (edgecount > 0)
+            fnsize = (edgecount - 1) * (2 + function_argcount(fn)) + 1;
+        }
 
       ig_add_fn(r, ig, fn, fnsize);
     }
@@ -352,7 +352,7 @@ static ggraph make_ig(region r, cgraph callgraph)
       gedge e;
 
       graph_scan_out (e, n)
-	ig_add_edge(fn, NODE_GET(endp, graph_edge_to(e))->function);
+        ig_add_edge(fn, NODE_GET(endp, graph_edge_to(e))->function);
     }
   return ig;
 }
@@ -375,12 +375,12 @@ static void inline_function(gnode n, struct inline_node *in)
       caller_in->size += in->size - 1;
 
       graph_scan_out (called_edge, n)
-	{
-	  gnode called = graph_edge_to(called_edge);
+        {
+          gnode called = graph_edge_to(called_edge);
 
-	  ig_add_edge(caller_in->fn,
-		      NODE_GET(struct inline_node *, called)->fn);
-	}
+          ig_add_edge(caller_in->fn,
+                      NODE_GET(struct inline_node *, called)->fn);
+        }
     }
 
   /* Remove edges leaving inlined function 
@@ -416,17 +416,17 @@ void inline_functions(cgraph callgraph)
       struct inline_node *in = NODE_GET(struct inline_node *, n);
       
       if (!in->fn->isinline && !in->fn->makeinline)
-	{
-	  gedge e;
-	  size_t edgecount = 0;
+        {
+          gedge e;
+          size_t edgecount = 0;
 
-	  graph_scan_in (e, n)
-	    edgecount++;
+          graph_scan_in (e, n)
+            edgecount++;
       
-	  if (edgecount == 1 ||
-	      (bis >=0 && in->size <= bis + function_argcount(in->fn) * ipa))
-	    inline_function(n, in);
-	}
+          if (edgecount == 1 ||
+              (bis >=0 && in->size <= bis + function_argcount(in->fn) * ipa))
+            inline_function(n, in);
+        }
     }
   deleteregion(igr);
 }

--- a/src/nesc-magic.c
+++ b/src/nesc-magic.c
@@ -12,7 +12,7 @@ data_declaration magic_unique, magic_uniqueN, magic_uniqueCount;
 
 static data_declaration 
 declare_magic(const char *name, type return_type, typelist argument_types,
-	      known_cst (*magic_fold)(function_call fcall, int pass))
+              known_cst (*magic_fold)(function_call fcall, int pass))
 {
   struct data_declaration tempdecl;
   type ftype = make_function_type(return_type, argument_types, FALSE, FALSE);
@@ -35,7 +35,7 @@ data_declaration get_magic(function_call fcall)
       identifier called = CAST(identifier, fcall->arg1);
 
       if (called->ddecl->kind == decl_magic_function)
-	return called->ddecl;
+        return called->ddecl;
     }
   return NULL;
 }
@@ -48,28 +48,28 @@ known_cst fold_magic(function_call fcall, int pass)
   if (called)
     {
       /* we can assume arguments are of valid type and number,
-	 check that they are constants in the parse phase */
+         check that they are constants in the parse phase */
 
       if (pass == 0)
-	{
-	  bool all_constant = TRUE;
-	  expression arg;
-	  int argn = 1;
+        {
+          bool all_constant = TRUE;
+          expression arg;
+          int argn = 1;
 
-	  scan_expression (arg, fcall->args)
-	    {
-	      if (!arg->cst)
-		{
-		  error("argument %d to magic function `%s' is not constant",
-			argn, called->name);
-		  all_constant = FALSE;
-		}
-	      argn++;
-	    }
-	  
-	  if (!all_constant)
-	    return NULL;
-	}
+          scan_expression (arg, fcall->args)
+            {
+              if (!arg->cst)
+                {
+                  error("argument %d to magic function `%s' is not constant",
+                        argn, called->name);
+                  all_constant = FALSE;
+                }
+              argn++;
+            }
+          
+          if (!all_constant)
+            return NULL;
+        }
 
       return called->magic_fold(fcall, pass);
     }
@@ -191,14 +191,14 @@ static void unique_init(void)
   string_args = new_typelist(parse_region);
   typelist_append(string_args, make_pointer_type(char_type));
   magic_unique = declare_magic("unique", unsigned_int_type, string_args,
-			       unique_fold);
+                               unique_fold);
   string_int_args = new_typelist(parse_region);
   typelist_append(string_int_args, make_pointer_type(char_type));
   typelist_append(string_int_args, unsigned_int_type);
   magic_uniqueN = declare_magic("uniqueN", unsigned_int_type, string_int_args,
-				uniqueN_fold);
+                                uniqueN_fold);
   magic_uniqueCount = declare_magic("uniqueCount", unsigned_int_type,
-				    string_args, uniqueCount_fold);
+                                    string_args, uniqueCount_fold);
   unique_region = newregion();
   unique_env = new_env(unique_region, NULL);
 }

--- a/src/nesc-main.c
+++ b/src/nesc-main.c
@@ -91,30 +91,30 @@ static void connect_graph(cgraph master, cgraph component)
       gnode mfrom = endpoint_lookup(master, from);
 
       graph_scan_out (connection, n)
-	{
-	  endp to = NODE_GET(endp, graph_edge_to(connection));
-	  gnode mto = endpoint_lookup(master, to);
+        {
+          endp to = NODE_GET(endp, graph_edge_to(connection));
+          gnode mto = endpoint_lookup(master, to);
 
-	  graph_add_edge(mfrom, mto, EDGE_GET(location, connection));
-	}
+          graph_add_edge(mfrom, mto, EDGE_GET(location, connection));
+        }
     }
 }
 
 static void connect(location loc, nesc_declaration cdecl, cgraph cg,
-		    cgraph userg, dd_list modules, dd_list components)
+                    cgraph userg, dd_list modules, dd_list components)
 {
   nesc_declaration loop;
 
   if ((loop = abstract_recursion()))
     {
       /* We can help the programmer find the loop by showing the 
-	 instantiation path that causes it. loop's instance name is a prefix
-	 of cdecl's, the looping path is loop's abstract component name
-	 followed by the difference between loop's and cdecl's instance name.
+         instantiation path that causes it. loop's instance name is a prefix
+         of cdecl's, the looping path is loop's abstract component name
+         followed by the difference between loop's and cdecl's instance name.
       */
       error_with_location(loc, "component instantiation loop `%s%s'",
-			  original_component(loop)->name,
-			  cdecl->instance_name + strlen(loop->instance_name));
+                          original_component(loop)->name,
+                          cdecl->instance_name + strlen(loop->instance_name));
     }
   else if (!dd_find(components, cdecl))
     {
@@ -123,29 +123,29 @@ static void connect(location loc, nesc_declaration cdecl, cgraph cg,
       connect_graph(userg, cdecl->user_connections);
 
       if (!cdecl->configuration)
-	dd_add_last(regionof(modules), modules, cdecl);
+        dd_add_last(regionof(modules), modules, cdecl);
       else
-	{
-	  configuration c = CAST(configuration, cdecl->impl);
-	  declaration d;
+        {
+          configuration c = CAST(configuration, cdecl->impl);
+          declaration d;
 
-	  scan_declaration (d, c->decls)
-	    if (is_component_ref(d))
-	      {
-		component_ref comp = CAST(component_ref, d);
+          scan_declaration (d, c->decls)
+            if (is_component_ref(d))
+              {
+                component_ref comp = CAST(component_ref, d);
 
-		push_instance(comp->cdecl);
-		if (comp->cdecl->original)
-		  instantiate(comp->cdecl, comp->args);
-		connect(comp->location, comp->cdecl, cg, userg, modules, components);
-		pop_instance();
-	      }
-	}
+                push_instance(comp->cdecl);
+                if (comp->cdecl->original)
+                  instantiate(comp->cdecl, comp->args);
+                connect(comp->location, comp->cdecl, cg, userg, modules, components);
+                pop_instance();
+              }
+        }
     }
 }
 
 static void connect_graphs(region r, nesc_declaration program, nesc_declaration scheduler,
-			   cgraph *cg, cgraph *userg, dd_list *modules, dd_list *components)
+                           cgraph *cg, cgraph *userg, dd_list *modules, dd_list *components)
 {
   *cg = new_cgraph(r);
   *userg = new_cgraph(r);
@@ -299,14 +299,14 @@ int nesc_option(char *p)
 
       /* <inputdir>,<outputdir> or <outputdir> only for original */
       if (comma)
-	{
-	  diff_input = rstralloc(permanent, comma - dirs + 1);
-	  strncpy(diff_input, dirs, comma - dirs);
-	  diff_input[comma - dirs] = '\0';
-	  diff_output = comma + 1;
-	}
+        {
+          diff_input = rstralloc(permanent, comma - dirs + 1);
+          strncpy(diff_input, dirs, comma - dirs);
+          diff_input[comma - dirs] = '\0';
+          diff_output = comma + 1;
+        }
       else
-	diff_output = dirs;
+        diff_output = dirs;
     }
   else if (!strncmp(p, "fnesc-separator=", strlen("fnesc-separator=")))
     set_function_separator(p + 16);
@@ -323,16 +323,16 @@ static void destroy_target(const char *name)
   if (name)
     {
       /* unlink would be nicer, but would have nasty consequences for
-	 -o /dev/null when run by root... */
+         -o /dev/null when run by root... */
       int fd = creat(name, 0666);
 
       if (fd < 0)
-	{
-	  fprintf(stderr, "%s: ", name);
-	  perror("failed to truncate target");
-	}
+        {
+          fprintf(stderr, "%s: ", name);
+          perror("failed to truncate target");
+        }
       else
-	close(fd);
+        close(fd);
     }
 
 }
@@ -396,7 +396,7 @@ void nesc_compile(const char *filename, const char *target_name)
     {
       connect_graphs(parse_region, program, scheduler, &cg, &userg, &modules, &components);
       if (errorcount)
-	return;
+        return;
       current.container = NULL;
       fold_program(program, scheduler);
       gencode = TRUE;
@@ -415,11 +415,11 @@ void nesc_compile(const char *filename, const char *target_name)
   if (docs_requested())
     {
       if (generic_used)
-	error("documentation system does not yet support generic components and interfaces");
+        error("documentation system does not yet support generic components and interfaces");
       else if (program)
-	generate_docs(filename, cg);
+        generate_docs(filename, cg);
       else
-	error("documentation requested on a C file ");
+        error("documentation requested on a C file ");
       gencode = FALSE;
     }
   if (layout_requested())
@@ -433,6 +433,6 @@ void nesc_compile(const char *filename, const char *target_name)
     generate_c_code(target_name, program, cg, modules, components);
   else if (flag_c)
     generate_c_code(target_name, NULL,
-		    new_cgraph(permanent), dd_new_list(permanent),
-		    dd_new_list(permanent));
+                    new_cgraph(permanent), dd_new_list(permanent),
+                    dd_new_list(permanent));
 }

--- a/src/nesc-module.c
+++ b/src/nesc-module.c
@@ -46,9 +46,9 @@ declarator make_interface_ref_declarator(location l, cstring w1, cstring w2)
     new_identifier_declarator(parse_region, l, w2);
 
   return CAST(declarator,
-	      new_interface_ref_declarator(parse_region, l,
-					   CAST(declarator, id),
-					   make_word(l, w1)));
+              new_interface_ref_declarator(parse_region, l,
+                                           CAST(declarator, id),
+                                           make_word(l, w1)));
 }
 
 expression make_interface_deref(location loc, expression object, cstring field)
@@ -82,10 +82,10 @@ static void check_function_implemented(data_declaration fndecl, void *data)
   if (fndecl->defined && !fndecl->definition)
     {
       if (idecl)
-	error_with_location(*loc, "`%s.%s' not implemented",
-			    idecl->name, fndecl->name);
+        error_with_location(*loc, "`%s.%s' not implemented",
+                            idecl->name, fndecl->name);
       else
-	error_with_location(*loc, "`%s' not implemented", fndecl->name);
+        error_with_location(*loc, "`%s' not implemented", fndecl->name);
     }
 }
 
@@ -93,7 +93,7 @@ static void check_function_implemented(data_declaration fndecl, void *data)
 static void check_complete_implementation(module m)
 {
   component_functions_iterate(m->cdecl, check_function_implemented,
-			      &m->location);
+                              &m->location);
 }
 
 void process_module(module m)

--- a/src/nesc-msg.c
+++ b/src/nesc-msg.c
@@ -80,37 +80,37 @@ static void dump_fields(region r, const char *prefix, field_declaration fields)
   while (fields)
     {
       if (fields->name) /* skip anon fields */
-	{
-	  type t = fields->type;
+        {
+          type t = fields->type;
 
-	  printf("  %s%s ", prefix, fields->name);
-	  while (type_array(t))
-	    {
-	      type base = type_array_of(t);
-	      expression size = type_array_size(t);
+          printf("  %s%s ", prefix, fields->name);
+          while (type_array(t))
+            {
+              type base = type_array_of(t);
+              expression size = type_array_size(t);
 
-	      printf("[%lu]", (unsigned long)constant_uint_value(size->cst));
-	      t = base;
-	    }
-	  dump_type(t);
+              printf("[%lu]", (unsigned long)constant_uint_value(size->cst));
+              t = base;
+            }
+          dump_type(t);
 
-	  assert(cval_isinteger(fields->offset));
-	  printf(" %lu %lu\n", (unsigned long)cval_uint_value(fields->offset),
-		 (unsigned long)
-		 (!cval_istop(fields->bitwidth) ?
-		  cval_uint_value(fields->bitwidth) :
-		  BITSPERBYTE * cval_uint_value(type_size(t))));
+          assert(cval_isinteger(fields->offset));
+          printf(" %lu %lu\n", (unsigned long)cval_uint_value(fields->offset),
+                 (unsigned long)
+                 (!cval_istop(fields->bitwidth) ?
+                  cval_uint_value(fields->bitwidth) :
+                  BITSPERBYTE * cval_uint_value(type_size(t))));
 
-	  if (type_aggregate(t))
-	    {
-	      tag_declaration tdecl = type_tag(t);
-	      char *newprefix = rarrayalloc(r, strlen(prefix) + strlen(fields->name) + 2, char);
+          if (type_aggregate(t))
+            {
+              tag_declaration tdecl = type_tag(t);
+              char *newprefix = rarrayalloc(r, strlen(prefix) + strlen(fields->name) + 2, char);
 
-	      sprintf(newprefix, "%s%s.", prefix, fields->name);
-	      dump_fields(r, newprefix, tdecl->fieldlist);
-	      printf("  %s%s AX\n", prefix, fields->name);
-	    }
-	}
+              sprintf(newprefix, "%s%s.", prefix, fields->name);
+              dump_fields(r, newprefix, tdecl->fieldlist);
+              printf("  %s%s AX\n", prefix, fields->name);
+            }
+        }
       fields = fields->next;
     }
 }
@@ -154,9 +154,9 @@ static void dump_layout(tag_declaration tdecl)
   
 
   printf("%s %s %lu %d\n", tagkind_name(tdecl->kind),
-	 tdecl->name,
-	 (unsigned long)cval_uint_value(tdecl->size),
-	 am_type(r, tdecl));
+         tdecl->name,
+         (unsigned long)cval_uint_value(tdecl->size),
+         am_type(r, tdecl));
 
   dump_fields(r, "", tdecl->fieldlist);
 
@@ -182,27 +182,27 @@ void dump_msg_layout(void)
       tdecl = env_lookup(global_env->tag_env, selected_type, FALSE);
 
       if (!tdecl)
-	{
-	  fprintf(stderr, "error: tag %s not found\n", selected_type);
-	  exit(1);
-	}
+        {
+          fprintf(stderr, "error: tag %s not found\n", selected_type);
+          exit(1);
+        }
 
       if (tdecl->kind == kind_enum_ref)
-	{
-	  fprintf(stderr, "error: %s is an enum\n", selected_type);
-	  exit(1);
-	}
+        {
+          fprintf(stderr, "error: %s is an enum\n", selected_type);
+          exit(1);
+        }
 
       if (cval_istop(tdecl->size))
-	{
-	  fprintf(stderr, "error: %s is variable size\n", selected_type);
-	  exit(1);
-	}
+        {
+          fprintf(stderr, "error: %s is variable size\n", selected_type);
+          exit(1);
+        }
 
       if (type_contains_pointers(make_tagged_type(tdecl)))
-	{
-	  fprintf(stderr, "warning: %s contains pointers\n", selected_type);
-	}
+        {
+          fprintf(stderr, "warning: %s contains pointers\n", selected_type);
+        }
 
       dump_layout(tdecl);
 
@@ -216,24 +216,24 @@ void dump_msg_layout(void)
 
       env_scan(global_env->id_env, &scan_global);
       while (env_next(&scan_global, &name, &vdecl))
-	{
-	  data_declaration ddecl = vdecl;
+        {
+          data_declaration ddecl = vdecl;
 
-	  if (ddecl->kind == decl_constant)
-	    {
-	      known_cst val = ddecl->value;
+          if (ddecl->kind == decl_constant)
+            {
+              known_cst val = ddecl->value;
 
-	      printf("%s \"%s\" ", name, ddecl->definition->location->filename);
-	      dump_type(val->type);
-	      putchar(' ');
+              printf("%s \"%s\" ", name, ddecl->definition->location->filename);
+              dump_type(val->type);
+              putchar(' ');
 
-	      if (cval_knownvalue(val->cval))
-		cval_print(stdout, val->cval);
-	      else
-		puts(" UNKNOWN");
-	      putchar('\n');
-	    }
-	}
+              if (cval_knownvalue(val->cval))
+                cval_print(stdout, val->cval);
+              else
+                puts(" UNKNOWN");
+              putchar('\n');
+            }
+        }
     }
 }
 

--- a/src/nesc-ndoc.c
+++ b/src/nesc-ndoc.c
@@ -18,9 +18,9 @@ static char *rmakestr(region r, char *s, char *e)
 }
 
 static void save_doctag(location loc, region entries_r, dd_list *entries,
-			char *tag_s, char *tag_e,
-			char *arg_s, char *arg_e,
-			int lineno)
+                        char *tag_s, char *tag_e,
+                        char *arg_s, char *arg_e,
+                        int lineno)
 {
   if (entries)
     {
@@ -34,12 +34,12 @@ static void save_doctag(location loc, region entries_r, dd_list *entries,
   else
     {
       /* warn about ignored quoted arguments that normally have
-	 semantic significance */
+         semantic significance */
       struct location here = *loc;
 
       here.lineno += lineno;
       warning_with_location(&here, "@%s argument ignored",
-			    rmakestr(current.fileregion, tag_s, tag_e));
+                            rmakestr(current.fileregion, tag_s, tag_e));
     }
 }
 
@@ -81,118 +81,118 @@ bool get_latest_docstring(struct docstring *doc, region tags_r, dd_list *tags)
   while ((c = *r++))
     {
       if (state == s_linestart)
-	{
-	  if (isspace(c) || (cpp_comment && c == '/'))
-	    continue;
-	  state = s_normal;
-	  /* Skip one * in C-style comments (we've cleared line_start, so
-	     won't do this twice) */
-	  if (!cpp_comment && c == '*')
-	    continue;
-	}
+        {
+          if (isspace(c) || (cpp_comment && c == '/'))
+            continue;
+          state = s_normal;
+          /* Skip one * in C-style comments (we've cleared line_start, so
+             won't do this twice) */
+          if (!cpp_comment && c == '*')
+            continue;
+        }
 
       if (c == '\r' || c == '\n')
-	{
-	  if (state == s_docarg)
-	    {
-	      /* warn about broken quoted arguments, as they have semantic
-		 significance */
-	      struct location here = *loc;
+        {
+          if (state == s_docarg)
+            {
+              /* warn about broken quoted arguments, as they have semantic
+                 significance */
+              struct location here = *loc;
 
-	      here.lineno += lineno;
-	      warning_with_location(&here, "unterminated @%s argument ignored",
-				    rmakestr(current.fileregion, doctag, doctag_end));
-	    }
+              here.lineno += lineno;
+              warning_with_location(&here, "unterminated @%s argument ignored",
+                                    rmakestr(current.fileregion, doctag, doctag_end));
+            }
 
-	  *p++ = '\n';
-	  lineno++;
-	  state = s_linestart;
-	  continue;
-	}
+          *p++ = '\n';
+          lineno++;
+          state = s_linestart;
+          continue;
+        }
 
       /* Skip trailing / in C-style comments */
       if (!cpp_comment && c == '/' && !*r)
-	break;
+        break;
 
       *p++ = c;
 
       /* Space after . or space before @ indicates end of short doc string */
       if (!short_end)
-	{
-	  if (c == '.' && isspace(*r))
-	    short_end = p;
-	  else if (c == '@' && p - 2 >= parsed && isspace(p[-2]))
-	    short_end = p - 1;
+        {
+          if (c == '.' && isspace(*r))
+            short_end = p;
+          else if (c == '@' && p - 2 >= parsed && isspace(p[-2]))
+            short_end = p - 1;
 
-	  if (short_end)
-	    doc->short_s = rmakestr(parse_region, parsed, short_end);
-	}
+          if (short_end)
+            doc->short_s = rmakestr(parse_region, parsed, short_end);
+        }
 
       /* Extract tags with a fun state machine */
     redo:
       switch (state)
-	{
-	case s_normal:
-	  if (c == '@' && p - 2 >= parsed && isspace(p[-2]))
-	    {
-	      doctag = p;
-	      state = s_doctag;
-	    }
-	  break;
-	case s_doctag:
-	  if (!isalpha(c)) /* doctag keyword done, decide if we like it */
-	    {
-	      /* Currently we like all non-empty doctags and assume
-		 they might have up to one quoted argument - filtering
-		 is left to our caller. This might want to change if
-		 we get into fancier syntax for doctag arguments with
-		 semantic significance */
-	      if (p - 1 > doctag) /* not empty */
-		{
-		  doctag_end = p - 1;
-		  state = s_docarg_start;
-		}
-	      else
-		state = s_normal;
-	      goto redo;
-	    }
-	  break;
-	case s_docarg_start:
-	  if (isspace(c))
-	    ;
-	  else if (c == '\'')
-	    {
-	      docarg = p;
-	      state = s_docarg;
-	    }
-	  else
-	    {
-	      state = s_normal;
-	      goto redo;
-	    }
-	  break;
-	case s_docarg:
-	  if (c == '\'')
-	    {
-	      save_doctag(loc, tags_r, tags,
-			  doctag, doctag_end, docarg, p - 1, lineno);
-	      state = s_normal;
-	    }
-	  break;
-	default:
-	  assert(0);
-	  break;
-	}
+        {
+        case s_normal:
+          if (c == '@' && p - 2 >= parsed && isspace(p[-2]))
+            {
+              doctag = p;
+              state = s_doctag;
+            }
+          break;
+        case s_doctag:
+          if (!isalpha(c)) /* doctag keyword done, decide if we like it */
+            {
+              /* Currently we like all non-empty doctags and assume
+                 they might have up to one quoted argument - filtering
+                 is left to our caller. This might want to change if
+                 we get into fancier syntax for doctag arguments with
+                 semantic significance */
+              if (p - 1 > doctag) /* not empty */
+                {
+                  doctag_end = p - 1;
+                  state = s_docarg_start;
+                }
+              else
+                state = s_normal;
+              goto redo;
+            }
+          break;
+        case s_docarg_start:
+          if (isspace(c))
+            ;
+          else if (c == '\'')
+            {
+              docarg = p;
+              state = s_docarg;
+            }
+          else
+            {
+              state = s_normal;
+              goto redo;
+            }
+          break;
+        case s_docarg:
+          if (c == '\'')
+            {
+              save_doctag(loc, tags_r, tags,
+                          doctag, doctag_end, docarg, p - 1, lineno);
+              state = s_normal;
+            }
+          break;
+        default:
+          assert(0);
+          break;
+        }
     }
 
   if (short_end)
     {
       /* if there's only whitespace after short_end, then there's no long
-	 string */
+         string */
       while (*short_end && isspace(*short_end))
-	short_end++;
+        short_end++;
       if (*short_end)
-	doc->long_s = rmakestr(parse_region, parsed, p);
+        doc->long_s = rmakestr(parse_region, parsed, p);
     }
   else /* only a short string */
     doc->short_s = rmakestr(parse_region, parsed, p);
@@ -207,27 +207,27 @@ static void update_parameters(function_declarator fd)
   while (*parm)
     {
       if (is_data_decl(*parm)) /* skip errors */
-	{
-	  /* The ddecl points to the variable_decl of the new
-	     definition.  New variable_decls have a parent field
-	     pointing to their containing data_decl (from the call to
-	     AST_set_parents below). Use this to update the
-	     declaration list. */
-	  data_decl pd = CAST(data_decl, *parm);
-	  variable_decl vd = CAST(variable_decl, pd->decls);
+        {
+          /* The ddecl points to the variable_decl of the new
+             definition.  New variable_decls have a parent field
+             pointing to their containing data_decl (from the call to
+             AST_set_parents below). Use this to update the
+             declaration list. */
+          data_decl pd = CAST(data_decl, *parm);
+          variable_decl vd = CAST(variable_decl, pd->decls);
 
-	  if (vd->ddecl)
-	    {
-	      node newdecl = vd->ddecl->ast->parent;
+          if (vd->ddecl)
+            {
+              node newdecl = vd->ddecl->ast->parent;
 
-	      /* We also ignore forward parameter declarations (gcc ext) */
-	      if (!vd->forward && newdecl)
-		{
-		  newdecl->next = (*parm)->next;
-		  *parm = CAST(node, newdecl);
-		}
-	    }
-	}
+              /* We also ignore forward parameter declarations (gcc ext) */
+              if (!vd->forward && newdecl)
+                {
+                  newdecl->next = (*parm)->next;
+                  *parm = CAST(node, newdecl);
+                }
+            }
+        }
       parm = &(*parm)->next;
     }
 }
@@ -239,7 +239,7 @@ static void enforce_redeclaration(node newdecl)
       variable_decl vd = CAST(variable_decl, CAST(data_decl, newdecl)->decls);
 
       if (vd->ddecl->definition == vd->ddecl->ast)
-	error("%s is not a function parameter", vd->ddecl->name);
+        error("%s is not a function parameter", vd->ddecl->name);
     }
 }
 
@@ -260,7 +260,7 @@ void ignored_doctags(location docloc, dd_list tags)
 }
 
 void handle_ddecl_doc_tags(location docloc, data_declaration ddecl,
-			   dd_list tags)
+                           dd_list tags)
 {
   declarator d;
   declaration ast;
@@ -284,7 +284,7 @@ void handle_ddecl_doc_tags(location docloc, data_declaration ddecl,
 }
 
 void handle_fdecl_doc_tags(location docloc, data_declaration ddecl,
-			   function_declarator fd, dd_list tags)
+                           function_declarator fd, dd_list tags)
 {
   struct semantic_state old;
   struct location cloc;
@@ -306,40 +306,40 @@ void handle_fdecl_doc_tags(location docloc, data_declaration ddecl,
 
       tagloc.lineno += tag->lineno;
       if (!strcmp(tag->tag, "param"))
-	{
-	  int old_errorcount = errorcount;
+        {
+          int old_errorcount = errorcount;
 
-	  start_lex_string(l_parameter, tag->args[0]);
-	  set_lex_location(&tagloc);
-	  parsed = parse();
-	  AST_set_parents(parsed);
-	  /* Type errors in redeclaration confuse the redeclaration check,
-	     and we've already failed compilation anyway */
-	  if (errorcount == old_errorcount)
-	    enforce_redeclaration(parsed);
-	  end_lex();
-	}
+          start_lex_string(l_parameter, tag->args[0]);
+          set_lex_location(&tagloc);
+          parsed = parse();
+          AST_set_parents(parsed);
+          /* Type errors in redeclaration confuse the redeclaration check,
+             and we've already failed compilation anyway */
+          if (errorcount == old_errorcount)
+            enforce_redeclaration(parsed);
+          end_lex();
+        }
       else if (!strcmp(tag->tag, "return"))
-	{
-	  if (fd->return_type)
-	    warning_with_location(&tagloc, "duplicate @return tag ignored");
-	  else
-	    {
-	      start_lex_string(l_type, tag->args[0]);
-	      set_lex_location(&tagloc);
-	      parsed = parse();
-	      end_lex();
-	      if (parsed)
-		{
-		  fd->return_type = CAST(asttype, parsed);
-		  if (!type_equal(type_function_return_type(ddecl->type),
-				  fd->return_type->type))
-		    error("inconsistent return type in @return tag");
-		}
-	    }
-	}
+        {
+          if (fd->return_type)
+            warning_with_location(&tagloc, "duplicate @return tag ignored");
+          else
+            {
+              start_lex_string(l_type, tag->args[0]);
+              set_lex_location(&tagloc);
+              parsed = parse();
+              end_lex();
+              if (parsed)
+                {
+                  fd->return_type = CAST(asttype, parsed);
+                  if (!type_equal(type_function_return_type(ddecl->type),
+                                  fd->return_type->type))
+                    error("inconsistent return type in @return tag");
+                }
+            }
+        }
       else
-	ignored_doctag(docloc, tag);
+        ignored_doctag(docloc, tag);
     }
   update_parameters(fd);
 

--- a/src/nesc-ndoc.h
+++ b/src/nesc-ndoc.h
@@ -26,12 +26,12 @@ struct docstring
 
 struct doctag
 {
-  int lineno;			/* relative to start of string, first line=0 */
-  const char *tag;		/* @param, @result, etc */
-  const char *args[];		/* arguments to key:
-				   @param(1): parameter name or declaration
-				   @result(1): result type or empty string
-				*/
+  int lineno;                        /* relative to start of string, first line=0 */
+  const char *tag;                /* @param, @result, etc */
+  const char *args[];                /* arguments to key:
+                                   @param(1): parameter name or declaration
+                                   @result(1): result type or empty string
+                                */
 };
 
 bool get_latest_docstring(struct docstring *doc, region tags_r, dd_list *tags);
@@ -39,9 +39,9 @@ bool get_latest_docstring(struct docstring *doc, region tags_r, dd_list *tags);
 struct data_declaration;
 struct AST_function_declarator;
 void handle_ddecl_doc_tags(location docloc, struct data_declaration *ddecl,
-			   dd_list tags);
+                           dd_list tags);
 void handle_fdecl_doc_tags(location docloc, struct data_declaration *ddecl,
-			   struct AST_function_declarator *fd, dd_list tags);
+                           struct AST_function_declarator *fd, dd_list tags);
 
 void ignored_doctag(location docloc, struct doctag *tag);
 void ignored_doctags(location docloc, dd_list tags);

--- a/src/nesc-network.c
+++ b/src/nesc-network.c
@@ -75,7 +75,7 @@ static void validate_network_lvalue(expression e)
       (type_network_base_type(cond->arg1->type) ||
        type_network_base_type(cond->arg2->type)))
     error_with_location(e->location,
-			"Conditional assignment not supported for network types");
+                        "Conditional assignment not supported for network types");
 }
 
 /* Check if expression e is of network base type.  Parameters whose address
@@ -89,8 +89,8 @@ static bool really_network_base(expression e)
       data_declaration ddecl = id->ddecl;
 
       if (ddecl->kind == decl_variable && ddecl->isparameter &&
-	  !(ddecl->use_summary & c_addressed))
-	return FALSE;
+          !(ddecl->use_summary & c_addressed))
+        return FALSE;
     }
   return e->type && type_network_base_type(e->type);
 }
@@ -105,7 +105,7 @@ static data_declaration add_network_temporary(function_decl fn, type t)
 }
 
 static AST_walker_result network_expression(AST_walker spec, void *data,
-					    expression *n)
+                                            expression *n)
 {
   expression e = *n;
   function_decl fn = data;
@@ -118,7 +118,7 @@ static AST_walker_result network_expression(AST_walker spec, void *data,
 }
 
 static AST_walker_result network_assignment(AST_walker spec, void *data,
-					    assignment *n)
+                                            assignment *n)
 {
   assignment a = *n;
   function_decl fn = data;
@@ -126,13 +126,13 @@ static AST_walker_result network_assignment(AST_walker spec, void *data,
   if (really_network_base(a->arg1))
     {
       if (a->kind != kind_assign) /* op= reads too */
-	{
-	  ntoh_used(a->arg1, fn);
-	  /* See problem/ugly hack comment in network_increment */
-	  /* op= needs a temp */
-	  if (!a->temp1)
-	    a->temp1 = add_network_temporary(fn, uchar_ptr_type);
-	}
+        {
+          ntoh_used(a->arg1, fn);
+          /* See problem/ugly hack comment in network_increment */
+          /* op= needs a temp */
+          if (!a->temp1)
+            a->temp1 = add_network_temporary(fn, uchar_ptr_type);
+        }
       hton_used(a->arg1, fn);
     }
 
@@ -142,7 +142,7 @@ static AST_walker_result network_assignment(AST_walker spec, void *data,
 }
 
 static AST_walker_result network_increment(AST_walker spec, void *data,
-					   increment *n)
+                                           increment *n)
 {
   increment i = *n;
   function_decl fn = data;
@@ -153,18 +153,18 @@ static AST_walker_result network_increment(AST_walker spec, void *data,
       hton_used(i->arg1, fn);
 
       /* Problem: adding the declarations for the temporaries changes the
-	 AST as we're walking through it. If we add a temporary while
-	 walking through the first declaration, we'll revisit this
-	 declaration. Oops.  Ugly hack fix: don't create the temporaries if
-	 they've already been created. Note that this could lead to
-	 duplicate error messages from validate_network_lvalue, but that's
-	 for use of a deprecated gcc feature which is going away soon. */
+         AST as we're walking through it. If we add a temporary while
+         walking through the first declaration, we'll revisit this
+         declaration. Oops.  Ugly hack fix: don't create the temporaries if
+         they've already been created. Note that this could lead to
+         duplicate error messages from validate_network_lvalue, but that's
+         for use of a deprecated gcc feature which is going away soon. */
       if (!i->temp1)
-	{
-	  /* we use 2 temps */
-	  i->temp1 = add_network_temporary(fn, uchar_ptr_type);
-	  i->temp2 = add_network_temporary(fn, type_network_platform_type(i->type));
-	}
+        {
+          /* we use 2 temps */
+          i->temp1 = add_network_temporary(fn, uchar_ptr_type);
+          i->temp2 = add_network_temporary(fn, type_network_platform_type(i->type));
+        }
     }
 
   validate_network_lvalue(i->arg1);
@@ -173,7 +173,7 @@ static AST_walker_result network_increment(AST_walker spec, void *data,
 }
 
 static AST_walker_result network_fdecl(AST_walker spec, void *data,
-				       function_decl *fd)
+                                       function_decl *fd)
 {
   AST_walk_children(spec, *fd, CAST(node, *fd));
   return aw_done;
@@ -243,7 +243,7 @@ static bool prt_network_lvalue(expression e)
   if (isbf)
     {
       /* Network bitfields have no name in the generated code. Just
-	 print the structure. We'll add the offset and size later. */
+         print the structure. We'll add the offset and size later. */
       output("(unsigned char *)&");
       prt_expression(CAST(field_ref, e)->arg1, P_CALL);
     }
@@ -262,7 +262,7 @@ static void prt_network_bitfield_info(expression e)
   field_declaration fdecl = fref->fdecl;
 
   output(", %llu, %llu",
-	 cval_uint_value(fdecl->offset), cval_uint_value(fdecl->bitwidth));
+         cval_uint_value(fdecl->offset), cval_uint_value(fdecl->bitwidth));
 }
 
 static void prt_network_full_lvalue(expression e)
@@ -313,12 +313,12 @@ static bool prt_network_assignment(expression e)
       output_hton_expr(a->arg1);
       output("(%s", temp);
       if (bitfield)
-	prt_network_bitfield_info(a->arg1);
+        prt_network_bitfield_info(a->arg1);
       output(", ");
       output_ntoh_expr(a->arg1);
       output("(%s", temp);
       if (bitfield)
-	prt_network_bitfield_info(a->arg1);
+        prt_network_bitfield_info(a->arg1);
       output(") %s ", selfassign);
       prt_expression(a->arg2, P_TIMES);
       output("))");
@@ -379,7 +379,7 @@ static bool prt_network_increment(expression e)
 static bool prt_network_read(expression e)
 {
   if (!(really_network_base(e) &&
-	(e->context & c_read) && !(e->context & c_write)))
+        (e->context & c_read) && !(e->context & c_write)))
     return FALSE;
 
   output_ntoh_expr(e);
@@ -406,20 +406,20 @@ bool prt_network_typedef(data_decl d, variable_decl vd)
       type basetype = vd->ddecl->basetype;
 
       if (!type_size_cc(basetype) && cval_isinteger(type_size(basetype)))
-	error_with_location(vd->location, "network base type `%s' is of unknown size", vd->ddecl->name);
+        error_with_location(vd->location, "network base type `%s' is of unknown size", vd->ddecl->name);
       else
-	{
-	  set_location(vd->location);
-	  output("typedef struct { unsigned char nxdata[%d]; } __attribute__((packed)) %s;",
-		 (int)type_size_int(basetype), vd->ddecl->name);
-	}
+        {
+          set_location(vd->location);
+          output("typedef struct { unsigned char nxdata[%d]; } __attribute__((packed)) %s;",
+                 (int)type_size_int(basetype), vd->ddecl->name);
+        }
       return TRUE;
     }
   return FALSE;
 }
 
 static bool prt_network_parameter_copy(declaration parm, bool copies,
-				       bool init)
+                                       bool init)
 {
   if (is_data_decl(parm))
     {
@@ -428,26 +428,26 @@ static bool prt_network_parameter_copy(declaration parm, bool copies,
       data_declaration ddecl = vd->ddecl;
 
       if (ddecl && type_network_base_type(ddecl->type) &&
-	  (ddecl->use_summary & c_addressed))
-	{
-	  /* We need a real network type copy. */
-	  if (!init)
-	    {
-	      if (!copies)
-		{
-		  outputln("{");
-		  indent();
-		}
-	      prt_data_decl(dd);
-	    }
-	  else
-	    {
-	      output_hton(ddecl->type);
-	      outputln("(%s.nxdata, %s%s);", ddecl->name, NXBASE_PREFIX, ddecl->name);
-	    }
+          (ddecl->use_summary & c_addressed))
+        {
+          /* We need a real network type copy. */
+          if (!init)
+            {
+              if (!copies)
+                {
+                  outputln("{");
+                  indent();
+                }
+              prt_data_decl(dd);
+            }
+          else
+            {
+              output_hton(ddecl->type);
+              outputln("(%s.nxdata, %s%s);", ddecl->name, NXBASE_PREFIX, ddecl->name);
+            }
 
-	  return TRUE;
-	}
+          return TRUE;
+        }
     }
   return copies;
 }
@@ -486,7 +486,7 @@ static void network_align_to(largest_uint offset, struct network_state *ns)
 {
   if (ns->offset < offset) /* There's a gap. Fill it. */
     outputln("unsigned char __nesc_filler%lu[%llu];",
-	     filler_count++, offset - ns->offset);
+             filler_count++, offset - ns->offset);
 }
 
 void prt_network_field_data_decl(data_decl d, struct network_state *ns)
@@ -502,39 +502,39 @@ void prt_network_field_data_decl(data_decl d, struct network_state *ns)
 
       /* bitfields just show up as filler */
       if (cval_istop(fdecl->bitwidth))
-	{
-	  if (!cval_isinteger(fdecl->offset))
-	    error_with_location(fdd->location, "unsupported network type");
-	  else 
-	    {
-	      largest_uint offset = cval_uint_value(fdecl->offset) / BITSPERBYTE;
+        {
+          if (!cval_isinteger(fdecl->offset))
+            error_with_location(fdd->location, "unsupported network type");
+          else 
+            {
+              largest_uint offset = cval_uint_value(fdecl->offset) / BITSPERBYTE;
 
-	      network_align_to(offset, ns);
-	      if (type_size_cc(fdecl->type))
-		ns->offset = offset + type_size_int(fdecl->type);
-	    }
-	    
-	  if (ns->isextension)
-	    output("__extension__ ");
-	  prt_type_elements(d->modifiers, opts);
-	  opts |= psd_duplicate;
-	  prt_field_decl(fdd);
-	  outputln(";");
-	}
+              network_align_to(offset, ns);
+              if (type_size_cc(fdecl->type))
+                ns->offset = offset + type_size_int(fdecl->type);
+            }
+            
+          if (ns->isextension)
+            output("__extension__ ");
+          prt_type_elements(d->modifiers, opts);
+          opts |= psd_duplicate;
+          prt_field_decl(fdd);
+          outputln(";");
+        }
     }
   /* If there's an unnamed struct/union field, we need to print it and 
      account for its size in ns */
   if (!(opts & psd_duplicate))
     scan_type_element (interesting, d->modifiers)
       if (is_tag_ref(interesting))
-	{
-	  tag_ref tr = CAST(tag_ref, interesting);
+        {
+          tag_ref tr = CAST(tag_ref, interesting);
 
-	  prt_type_element(interesting, opts);
-	  outputln(";");
-	  if (cval_isinteger(tr->tdecl->size))
-	    ns->offset += cval_uint_value(tr->tdecl->size);	  
-	}
+          prt_type_element(interesting, opts);
+          outputln(";");
+          if (cval_isinteger(tr->tdecl->size))
+            ns->offset += cval_uint_value(tr->tdecl->size);          
+        }
 }
 
 void prt_network_field_declaration(declaration d, struct network_state *ns)

--- a/src/nesc-paths.c
+++ b/src/nesc-paths.c
@@ -84,7 +84,7 @@ static void add_dir(region r, const char *path, int len, int chain)
   np->name = canonicalise(r, path, len);;
   np->sysp = chain == CHAIN_SYSTEM || chain == CHAIN_AFTER;
   np->construct = 0;
-  np->user_supplied_p = 1;	/* appears unused */
+  np->user_supplied_p = 1;        /* appears unused */
 
   if (tails[chain])
     tails[chain]->next = np;
@@ -122,7 +122,7 @@ static const char *find_file(char *filename)
     {
       sprintf(fullname, "%s%s", p->name, filename);
       if (file_exists(fullname))
-	return p->name;
+        return p->name;
     }
   return NULL;
 }
@@ -134,11 +134,11 @@ static void build_search_path(region r, const char *pathlist, int chain)
       char *colon;
 
       while ((colon = strchr(pathlist, ':')))
-	{
-	  *colon = '\0';
-	  add_dir(r, pathlist, colon - pathlist, chain);
-	  pathlist = colon + 1;
-	}
+        {
+          *colon = '\0';
+          add_dir(r, pathlist, colon - pathlist, chain);
+          pathlist = colon + 1;
+        }
       add_dir(r, pathlist, strlen(pathlist), chain);
     }
 }
@@ -178,13 +178,13 @@ void init_nesc_paths_end(void)
 
       fprintf (stderr, "#include \"...\" and component search starts here:\n");
       for (p = heads[CHAIN_QUOTE];; p = p->next)
-	{
-	  if (p == heads[CHAIN_BRACKET])
-	    fprintf (stderr, "#include <...> search starts here:\n");
-	  if (!p)
-	    break;
-	  fprintf (stderr, " %s\n", p->name);
-	}
+        {
+          if (p == heads[CHAIN_BRACKET])
+            fprintf (stderr, "#include <...> search starts here:\n");
+          if (!p)
+            break;
+          fprintf (stderr, " %s\n", p->name);
+        }
       fprintf (stderr, "End of search list.\n");
     }
 }
@@ -194,7 +194,7 @@ void set_cpp_include_path(void)
   cpp_reader *reader = current.lex.finput;
 
   cpp_set_include_chains(reader, heads[CHAIN_QUOTE], heads[CHAIN_BRACKET],
-			 !include_current_dir);
+                         !include_current_dir);
 }
 
 #define MAX_EXT_LEN 2

--- a/src/nesc-semantics.c
+++ b/src/nesc-semantics.c
@@ -106,7 +106,7 @@ bool nesc_filename(const char *name)
   if (dot)
     {
       if (!strcmp(dot, ".nc"))
-	return TRUE;
+        return TRUE;
     }
   return FALSE; /* C by default */
 }
@@ -149,7 +149,7 @@ const char *language_name(source_language l)
 }
 
 node compile(location loc, nesc_declaration container,
-	     const char *name, bool name_is_path)
+             const char *name, bool name_is_path)
 {
   source_language l = container ? container->kind : l_c;
   const char *path =
@@ -163,7 +163,7 @@ node compile(location loc, nesc_declaration container,
   else
     {
       if (flag_verbose)
-	fprintf(stderr, "preprocessing %s\n", path);
+        fprintf(stderr, "preprocessing %s\n", path);
 
       current.file = container;
       current.fileregion = newregion();
@@ -171,9 +171,9 @@ node compile(location loc, nesc_declaration container,
       ok = start_lex(l, path);
       save_pp_file_start(path);
       if (!ok)
-	error_with_location(loc, "failed to preprocess %s", path);
+        error_with_location(loc, "failed to preprocess %s", path);
       else
-	parse_tree = parse();
+        parse_tree = parse();
       deleteregion_ptr(&current.fileregion);
       end_lex();
       save_pp_file_end();
@@ -194,14 +194,14 @@ nesc_decl dummy_nesc_decl(location loc, nesc_declaration d)
     case l_component: {
       environment env = new_environment(parse_region, global_env, TRUE, FALSE);
       implementation impl = CAST(implementation,
-	new_module(parse_region, loc, env, NULL));
+        new_module(parse_region, loc, env, NULL));
       nd = CAST(nesc_decl,
-		new_component(parse_region, dummy_location, wname, NULL, FALSE, NULL, NULL, impl));
+                new_component(parse_region, dummy_location, wname, NULL, FALSE, NULL, NULL, impl));
       break;
     }
     case l_interface:
       nd = CAST(nesc_decl,
-		new_interface(parse_region, loc, wname, NULL, NULL));
+                new_interface(parse_region, loc, wname, NULL, NULL));
       break;
     default:
       assert(0);
@@ -241,7 +241,7 @@ void build(nesc_decl ast)
 }
 
 nesc_declaration load(source_language sl, location l,
-		      const char *name, bool name_is_path)
+                      const char *name, bool name_is_path)
 {
   /* The l_any stuff is a bit of a hack. It's for use from nesc-main.c
      only, to allow loading something whose "kind" is not yet known.
@@ -269,15 +269,15 @@ nesc_declaration load(source_language sl, location l,
       actual_name = ast->word1->cstring.data;
       badkind = sl != l_any && ast->cdecl->kind != sl;
       if (badkind || strcmp(element, actual_name))
-	warning_or_error_with_location(!badkind, ast->location,
-	  "expected %s `%s', but got %s '%s'",
-	  language_name(sl), element,
-	  language_name(ast->cdecl->kind), actual_name);
+        warning_or_error_with_location(!badkind, ast->location,
+          "expected %s `%s', but got %s '%s'",
+          language_name(sl), element,
+          language_name(ast->cdecl->kind), actual_name);
 
       /* Force creation of dummy AST if we get wrong kind (this avoids
          a duplicate error message in require) */
       if (badkind)
-	ast = NULL;
+        ast = NULL;
     }
 
   if (!ast)
@@ -372,7 +372,7 @@ data_declaration get_function_ddecl(expression e)
       identifier id = CAST(identifier, e);
 
       if (id->ddecl->kind == decl_function)
-	return id->ddecl;
+        return id->ddecl;
     }
   else if (is_interface_deref(e))
     return CAST(interface_deref, e)->ddecl;
@@ -398,14 +398,14 @@ data_declaration declare_function(location loc, const char *name, type signature
   if (fdecl)
     {
       if (fdecl->kind != decl_function ||
-	  !(fdecl->ftype == function_normal || fdecl->ftype == function_static))
-	error_with_location(loc, "function `%s' is not a C function",
-			    name);
+          !(fdecl->ftype == function_normal || fdecl->ftype == function_static))
+        error_with_location(loc, "function `%s' is not a C function",
+                            name);
       else if (!type_compatible_unqualified(fdecl->type, signature))
-	error_with_location(loc, "function `%s' does not have the right signature",
-			    name);
+        error_with_location(loc, "function `%s' does not have the right signature",
+                            name);
       else
-	ok = TRUE;
+        ok = TRUE;
     }
   else
     {
@@ -429,14 +429,14 @@ void handle_combine_attribute(location loc, const char *combiner, type *t)
 {
   data_declaration cdecl = 
     declare_function(loc, combiner,
-		     build_function_type(parse_region, *t, *t, *t, NULL));
+                     build_function_type(parse_region, *t, *t, *t, NULL));
 
   if (cdecl)
     *t = make_combiner_type(*t, cdecl);
 }
 
 void handle_nxbase_attribute(location loc, bool be, bool allow_bf, const char *basename,
-			     data_declaration ddecl)
+                             data_declaration ddecl)
 {
   region r = parse_region;
   char *encoder_name, *decoder_name;
@@ -449,11 +449,11 @@ void handle_nxbase_attribute(location loc, bool be, bool allow_bf, const char *b
 
   ddecl->encoder = /* takes buffer and original value. returns original value */
     declare_function(loc, encoder_name,
-		     build_function_type(r, t, ptr_void_type, t, NULL));
+                     build_function_type(r, t, ptr_void_type, t, NULL));
 
   ddecl->decoder = /* takes buffer and returns decoded value */
     declare_function(loc, decoder_name,
-		     build_function_type(r, t, const_ptr_void_type, NULL));
+                     build_function_type(r, t, const_ptr_void_type, NULL));
 
   if (allow_bf)
     {
@@ -464,12 +464,12 @@ void handle_nxbase_attribute(location loc, bool be, bool allow_bf, const char *b
 
       /* bitfields take additional offset, length fields */
       ddecl->bf_encoder =
-	declare_function(loc, encoder_name,
-			 build_function_type(r, t, ptr_void_type, unsigned_int_type, unsigned_char_type, t, NULL));
+        declare_function(loc, encoder_name,
+                         build_function_type(r, t, ptr_void_type, unsigned_int_type, unsigned_char_type, t, NULL));
 
       ddecl->bf_decoder =
-	declare_function(loc, decoder_name,
-			 build_function_type(r, t, const_ptr_void_type, unsigned_int_type, unsigned_char_type, NULL));
+        declare_function(loc, decoder_name,
+                         build_function_type(r, t, const_ptr_void_type, unsigned_int_type, unsigned_char_type, NULL));
     }
   ddecl->isbe = be;
 
@@ -483,7 +483,7 @@ void handle_nxbase_attribute(location loc, bool be, bool allow_bf, const char *b
    Returns the declaration for the parameter.
 */
 declaration declare_template_parameter(declarator d, type_element elements,
-				       attribute attributes)
+                                       attribute attributes)
 {
   /* There must be at least a declarator or some form of type specification */
   location l = d ? d->location : elements->location;
@@ -501,8 +501,8 @@ declaration declare_template_parameter(declarator d, type_element elements,
   type parm_type;
 
   parse_declarator(elements, vd->declarator, FALSE, FALSE,
-		   &class, &scf, NULL, &name, &parm_type,
-		   &defaulted_int, NULL, &extra_attr);
+                   &class, &scf, NULL, &name, &parm_type,
+                   &defaulted_int, NULL, &extra_attr);
   vd->declared_type = parm_type;
 
   /* Storage class checks */
@@ -510,34 +510,34 @@ declaration declare_template_parameter(declarator d, type_element elements,
     {
       /* Detect "typedef t", to declare a type parameter */
       if (class == RID_TYPEDEF && defaulted_int &&
-	  is_identifier_declarator(d))
-	return declare_type_parameter(d->location,
-				      CAST(identifier_declarator, d)->cstring,
-				      attributes, extra_attr);
+          is_identifier_declarator(d))
+        return declare_type_parameter(d->location,
+                                      CAST(identifier_declarator, d)->cstring,
+                                      attributes, extra_attr);
       else if (class == RID_TYPEDEF && d == NULL) 
-	{
-	  /* Recognise "typedef TYPENAME", and declare TYPENAME as a 
-	     type parameter (i.e., we're shadowing a global typedef) */
-	  type_element elem;
-	  typename tname;
-	  bool ok = TRUE;
+        {
+          /* Recognise "typedef TYPENAME", and declare TYPENAME as a 
+             type parameter (i.e., we're shadowing a global typedef) */
+          type_element elem;
+          typename tname;
+          bool ok = TRUE;
 
-	  /* Check there's only a typedef and a typename */
-	  scan_type_element (elem, elements)
-	    if (is_typename(elem))
-	      tname = CAST(typename, elem);
-	    else if (!(is_attribute(elem) ||
-		       (is_rid(elem) && CAST(rid, elem)->id == RID_TYPEDEF)))
-	      ok = FALSE;
+          /* Check there's only a typedef and a typename */
+          scan_type_element (elem, elements)
+            if (is_typename(elem))
+              tname = CAST(typename, elem);
+            else if (!(is_attribute(elem) ||
+                       (is_rid(elem) && CAST(rid, elem)->id == RID_TYPEDEF)))
+              ok = FALSE;
 
-	  if (ok && tname)
-	    {
-	      cstring cname = make_cstring(parse_region, tname->ddecl->name,
-					   strlen(tname->ddecl->name));
-	      return
-		declare_type_parameter(l, cname, attributes, extra_attr);
-	    }
-	}
+          if (ok && tname)
+            {
+              cstring cname = make_cstring(parse_region, tname->ddecl->name,
+                                           strlen(tname->ddecl->name));
+              return
+                declare_type_parameter(l, cname, attributes, extra_attr);
+            }
+        }
     }
 
   if (!name)
@@ -576,7 +576,7 @@ declaration declare_template_parameter(declarator d, type_element elements,
 }
 
 declaration declare_type_parameter(location l, cstring id, attribute attribs,
-				   dd_list extra_attr)
+                                   dd_list extra_attr)
 {
   type_parm_decl d = new_type_parm_decl(parse_region, l, id, NULL);
   data_declaration ddecl;
@@ -588,7 +588,7 @@ declaration declare_type_parameter(location l, cstring id, attribute attribs,
       struct data_declaration tempdecl;
 
       init_data_declaration(&tempdecl, CAST(declaration, d), id.data,
-			    error_type);
+                            error_type);
       tempdecl.kind = decl_typedef;
       tempdecl.typevar_kind = typevar_normal;
       tempdecl.definition = tempdecl.ast;
@@ -673,7 +673,7 @@ static void attr_spontaneous_decl(nesc_attribute attr, data_declaration ddecl)
     {
       /* The test avoids overriding the effect of atomic_hwevent */
       if (!ddecl->spontaneous)
-	ddecl->spontaneous = c_call_nonatomic;
+        ddecl->spontaneous = c_call_nonatomic;
     }
 }
 
@@ -688,9 +688,9 @@ static void attr_combine_decl(nesc_attribute attr, data_declaration ddecl)
       (fn_name = ddecl2str(parse_region, fn_name_ddecl)))
     {
       if (ddecl->kind == decl_typedef)
-	handle_combine_attribute(attr->location, fn_name, &ddecl->type);
+        handle_combine_attribute(attr->location, fn_name, &ddecl->type);
       else
-	error_with_location(attr->location, "@combine(\"function-name\") can only be used with typedef");
+        error_with_location(attr->location, "@combine(\"function-name\") can only be used with typedef");
     }
   else
     error_with_location(attr->location, "usage is @combine(\"function-name\")");
@@ -709,8 +709,8 @@ static void attr_macro_tdecl(nesc_attribute attr, tag_declaration tdecl)
     }
 
   if (!(macro_name_init && macro_name_init->kind == iv_base &&
-	(macro_name_ddecl = string_ddecl(macro_name_init->u.base.expr)) &&
-	(macro_name = ddecl2str(parse_region, macro_name_ddecl))))
+        (macro_name_ddecl = string_ddecl(macro_name_init->u.base.expr)) &&
+        (macro_name = ddecl2str(parse_region, macro_name_ddecl))))
     goto bad;
 
   /* Check that the symbol name is a valid macro name (C symbol) */
@@ -731,18 +731,18 @@ static void attr_macro_tdecl(nesc_attribute attr, tag_declaration tdecl)
 void init_internal_nesc_attributes(void)
 {
   define_internal_attribute("C", NULL, attr_C_decl, attr_C_tdecl, NULL, NULL,
-			    NULL);
+                            NULL);
   define_internal_attribute("hwevent", NULL, attr_hwevent_decl, NULL, NULL,
-			    NULL, NULL);
+                            NULL, NULL);
   define_internal_attribute("atomic_hwevent", NULL, attr_atomic_hwevent_decl,
-			    NULL, NULL, NULL, NULL);
+                            NULL, NULL, NULL, NULL);
   define_internal_attribute("spontaneous", NULL, attr_spontaneous_decl, NULL,
-			    NULL, NULL, NULL);
+                            NULL, NULL, NULL);
   define_internal_attribute("combine", NULL, attr_combine_decl, NULL, NULL,
-			    NULL,
-			    "fn", make_pointer_type(char_type), NULL);
+                            NULL,
+                            "fn", make_pointer_type(char_type), NULL);
   define_internal_attribute("macro", NULL, NULL, attr_macro_tdecl, NULL, NULL,
-			    "macro_name", make_pointer_type(char_type), NULL);
+                            "macro_name", make_pointer_type(char_type), NULL);
 }
 
 void check_name(const char *name)
@@ -766,12 +766,12 @@ void check_name(const char *name)
       static int first = 1;
 
       warning("symbol `%s' contains the separator `%s' used in generated code",
-	      name, sep);
+              name, sep);
       if (first)
-	{
-	  warning("This can cause bugs or compile errors when the C code");
-	  warning("generated by nesC is passed to the underlying C compiler");
-	  first = FALSE;
-	}
+        {
+          warning("This can cause bugs or compile errors when the C code");
+          warning("generated by nesC is passed to the underlying C compiler");
+          first = FALSE;
+        }
     }
 }

--- a/src/nesc-semantics.h
+++ b/src/nesc-semantics.h
@@ -35,10 +35,10 @@ const char *element_name(region r, const char *path);
 */
 
 node compile(location loc, nesc_declaration container,
-	     const char *name, bool name_is_path);
+             const char *name, bool name_is_path);
 
 nesc_declaration load(source_language sl, location l,
-		      const char *name, bool name_is_path);
+                      const char *name, bool name_is_path);
 
 type get_actual_function_type(type t);
 /* Returns: The actual function type for a (possibly generic) type t
@@ -98,7 +98,7 @@ void handle_combine_attribute(location loc, const char *combiner, type *t);
  */
 
 void handle_nxbase_attribute(location loc, bool be, bool allow_bf,
-			     const char *fnbasename, data_declaration ddecl);
+                             const char *fnbasename, data_declaration ddecl);
 /* Effects: handle network type attribute specifying functions 
      ntoh_fnbasename and hton_fnbasename as the decoding and encoding
      functions respectively.
@@ -111,9 +111,9 @@ void handle_nxbase_attribute(location loc, bool be, bool allow_bf,
  */
 
 declaration declare_template_parameter(declarator d, type_element elements,
-				       attribute attributes);
+                                       attribute attributes);
 declaration declare_type_parameter(location l, cstring id, attribute attribs,
-				   dd_list extra_attr);
+                                   dd_list extra_attr);
 
 expression make_type_argument(asttype t);
 

--- a/src/nesc-task.c
+++ b/src/nesc-task.c
@@ -100,7 +100,7 @@ static void declare_scheduler_interface(data_declaration task_decl)
   /* This specific AST structure is assumed in wire_scheduler below */
   task_name = new_word(r, loc, str2cstring(r, task_decl->name));
   task_interface = new_interface_ref(r, loc, make_scheduler_interfacedef_name(loc),
-				     NULL, task_name, NULL, NULL, NULL);
+                                     NULL, task_name, NULL, NULL, NULL);
   osection = current.spec_section;
   current.spec_section = spec_uses;
   declare_interface_ref(task_interface, NULL, current.container->env, NULL);
@@ -119,10 +119,10 @@ static void replace_task_with_event(type_element modifiers)
   scan_type_element (modifier, modifiers)
     if (is_rid(modifier))
       {
-	rid keyword = CAST(rid, modifier);
+        rid keyword = CAST(rid, modifier);
 
-	if (keyword->id == RID_TASK)
-	  keyword->id = RID_EVENT;
+        if (keyword->id == RID_TASK)
+          keyword->id = RID_EVENT;
       }
 }
 
@@ -139,11 +139,11 @@ void handle_post(function_call fcall)
       static int oneerror;
 
       if (!oneerror)
-	{
-	  oneerror = TRUE;
-	  error("task interface `%s' has no command named `%s'",
-		scheduler_interface_name, scheduler_post_name);
-	}
+        {
+          oneerror = TRUE;
+          error("task interface `%s' has no command named `%s'",
+                scheduler_interface_name, scheduler_post_name);
+        }
       return;
     }
 
@@ -152,8 +152,8 @@ void handle_post(function_call fcall)
   task->ddecl = task->ddecl->interface;
   task->type = task->ddecl->type;
   scheduler_post = new_interface_deref(parse_region, task->location,
-				       CAST(expression, task),
-				       make_scheduler_post_name(), postdecl);
+                                       CAST(expression, task),
+                                       make_scheduler_post_name(), postdecl);
   scheduler_post->type = postdecl->type;
   fcall->arg1 = CAST(expression, scheduler_post);
 }
@@ -176,34 +176,34 @@ void handle_task_definition(function_decl fdecl)
       data_declaration rundecl;
       identifier_declarator oldd = CAST(identifier_declarator, fd->declarator);
       identifier_declarator rund =
-	new_identifier_declarator(parse_region, fd->location,
-				  make_scheduler_run_name());
+        new_identifier_declarator(parse_region, fd->location,
+                                  make_scheduler_run_name());
       interface_ref_declarator ird =
-	new_interface_ref_declarator(parse_region, fd->location,
-				     CAST(declarator, rund),
-				     new_word(parse_region, fd->location, oldd->cstring));
+        new_interface_ref_declarator(parse_region, fd->location,
+                                     CAST(declarator, rund),
+                                     new_word(parse_region, fd->location, oldd->cstring));
       fd->declarator = CAST(declarator, ird);
 
       /* Update task's declaration object */
       rundecl = interface_lookup(fdecl->ddecl->interface, scheduler_run_name);
       if (!rundecl || rundecl->ftype != function_event)
-	{
-	  static int oneerror;
+        {
+          static int oneerror;
 
-	  if (!oneerror)
-	    {
-	      oneerror = TRUE;
-	      error("task interface `%s' has no event named `%s'",
-		    scheduler_interface_name, scheduler_run_name);
-	    }
-	}
+          if (!oneerror)
+            {
+              oneerror = TRUE;
+              error("task interface `%s' has no event named `%s'",
+                    scheduler_interface_name, scheduler_run_name);
+            }
+        }
       else
-	{
-	  /* Don't lose safe flag */
-	  rundecl->safe = fdecl->ddecl->safe;
-	  fdecl->ddecl = rundecl;
-	  rundecl->definition = CAST(declaration, fdecl);
-	}
+        {
+          /* Don't lose safe flag */
+          rundecl->safe = fdecl->ddecl->safe;
+          fdecl->ddecl = rundecl;
+          rundecl->definition = CAST(declaration, fdecl);
+        }
     }
 }
 
@@ -220,25 +220,25 @@ void load_scheduler(void)
   if (scheduler_name)
     {
       data_declaration intf = env_lookup(scheduler->env->id_env,
-					 scheduler_interface_name, TRUE);
+                                         scheduler_interface_name, TRUE);
 
       /* Check interface for validity. It must be the provided, have a
-	 single parameter and be the right interface type.
-	 Also, no generic interfaces please. */
+         single parameter and be the right interface type.
+         Also, no generic interfaces please. */
       if (intf && intf->kind == decl_interface_ref && !intf->required &&
-	  intf->gparms && !intf->itype->abstract &&
-	  !strcmp(intf->itype->name, scheduler_interfacedef_name))
-	{
-	  typelist_scanner dummy;
+          intf->gparms && !intf->itype->abstract &&
+          !strcmp(intf->itype->name, scheduler_interfacedef_name))
+        {
+          typelist_scanner dummy;
 
-	  typelist_scan(intf->gparms, &dummy);
-	  if (typelist_next(&dummy) && !typelist_next(&dummy))
-	    scheduler_interface = intf;
-	}
+          typelist_scan(intf->gparms, &dummy);
+          if (typelist_next(&dummy) && !typelist_next(&dummy))
+            scheduler_interface = intf;
+        }
       if (!scheduler_interface)
-	error_with_location(toplevel_location,
-			    "Scheduler `%s' has no scheduling interface named `%s'",
-			    scheduler_name, scheduler_interface_name);
+        error_with_location(toplevel_location,
+                            "Scheduler `%s' has no scheduling interface named `%s'",
+                            scheduler_name, scheduler_interface_name);
     }
 }
 
@@ -248,7 +248,7 @@ static expression build_taskid(module m, data_declaration taskdecl)
      in module m.
      Method: we add enum { m$taskdecl = unique("task-unique-string") };
              to all_cdecls
-	     and return an identifier-expression referring to m$taskdecl
+             and return an identifier-expression referring to m$taskdecl
   */
 
   location loc = taskdecl->ast->location;
@@ -279,7 +279,7 @@ static expression build_taskid(module m, data_declaration taskdecl)
   idname = str2cstring(r, taskdecl->name);
   idast = new_enumerator(r, loc, idname, unique_id, NULL);
   init_data_declaration(&tempdecl, CAST(declaration, idast), idname.data,
-			int_type);
+                        int_type);
   tempdecl.kind = decl_constant;
   tempdecl.definition = tempdecl.ast;
   tempdecl.value = unique_id->cst;
@@ -307,22 +307,22 @@ static expression build_taskid(module m, data_declaration taskdecl)
   silly_id = new_identifier_declarator(r, loc, silly_name);
   silly_type = make_array_type(int_type, use_id);
   type2ast(r, loc, silly_type, CAST(declarator, silly_id), 
-	   &silly_d, &silly_modifiers);
+           &silly_d, &silly_modifiers);
 
   silly_typedef = new_rid(r, loc, RID_TYPEDEF);
 
   silly_vd = new_variable_decl(r, loc, silly_d, NULL, NULL, NULL,
-			       NULL/*ddecl*/);
+                               NULL/*ddecl*/);
   init_data_declaration(&tempdecl, CAST(declaration, silly_vd),
-			silly_name.data, silly_type);
+                        silly_name.data, silly_type);
   tempdecl.kind = decl_typedef;
   tempdecl.definition = tempdecl.ast;
   silly_vd->ddecl = declare(m->ienv, &tempdecl, FALSE);
   silly_vd->declared_type = silly_type;
   silly_decl =
     new_data_decl(r, loc, type_element_chain(CAST(type_element, silly_typedef),
-					     silly_modifiers),
-		  CAST(declaration, silly_vd));
+                                             silly_modifiers),
+                  CAST(declaration, silly_vd));
   m->decls = declaration_chain(CAST(declaration, silly_decl), m->decls);
 
   /* Build the declaration and add it to the module's decls */
@@ -345,20 +345,20 @@ void wire_scheduler(module m)
       static int use_module = 0;
 
       /* If all_tasks is non-null, we have a problem: a task that needs to
-	 be wired, but the scheduler is not yet available. Report as an error.
+         be wired, but the scheduler is not yet available. Report as an error.
       */
       scan_declaration (task, all_tasks)
-	{
-	  error_with_location(task->location, "scheduler depends on a task");
-	  if (!use_module)
-	    {
-	      use_module = 1;
-	      error_with_location(task->location,
-				  "The -fnesc_scheduler flag should specify a module");
-	      error_with_location(task->location,
-				  "(the module with the scheduling code, even if the scheduler is a configuration)");
-	    }
-	}
+        {
+          error_with_location(task->location, "scheduler depends on a task");
+          if (!use_module)
+            {
+              use_module = 1;
+              error_with_location(task->location,
+                                  "The -fnesc_scheduler flag should specify a module");
+              error_with_location(task->location,
+                                  "(the module with the scheduling code, even if the scheduler is a configuration)");
+            }
+        }
       return;
     }
 

--- a/src/nesc-uses.c
+++ b/src/nesc-uses.c
@@ -91,7 +91,7 @@ void ddecl_used(data_declaration id, use u)
   if (u->fn)
     {
       if (!u->fn->fn_uses)
-	u->fn->fn_uses = dd_new_list(rr);
+        u->fn->fn_uses = dd_new_list(rr);
       dd_add_last(rr, u->fn->fn_uses, i);
     }
   else
@@ -115,7 +115,7 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c);
 
 
 static void collect_uses_deref(expression expr, expression dereferenced,
-			       data_declaration fn, context c)
+                               data_declaration fn, context c)
 {
   c = use_context(c);
 
@@ -144,14 +144,14 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
   if (expr->type && type_array(expr->type))
     {
       /* A dereference of an array type means that the context operation
-	 is being applied to the array.
-	 If not in a dereference, a read of an array returns its address,
-	 so is an address-taking context 
+         is being applied to the array.
+         If not in a dereference, a read of an array returns its address,
+         so is an address-taking context 
       */
       if (c & c_deref)
-	c &= ~c_deref;
+        c &= ~c_deref;
       else if (c & c_read)
-	c = (c & ~c_read) | c_addressed;
+        c = (c & ~c_read) | c_addressed;
     }
   else if (expr->cst)
     c |= c_constant;
@@ -171,10 +171,10 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
       expression e;
 
       scan_expression (e, CAST(comma, expr)->arg1)
-	if (e->next)
-	  collect_uses_expr(e, fn, exe_c);
-	else
-	  collect_uses_expr(e, fn, c);
+        if (e->next)
+          collect_uses_expr(e, fn, exe_c);
+        else
+          collect_uses_expr(e, fn, c);
       break;
     }
     case kind_extension_expr:
@@ -186,12 +186,12 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
       context true_c = c, false_c = c;
 
       if (ce->condition->cst)
-	{
-	  if (definite_zero(ce->condition))
-	    true_c &= ~c_executable;
-	  else
-	    false_c &= ~c_executable;
-	}
+        {
+          if (definite_zero(ce->condition))
+            true_c &= ~c_executable;
+          else
+            false_c &= ~c_executable;
+        }
 
       collect_uses_expr(ce->condition, fn, exe_c | c_read);
       collect_uses_expr(ce->arg1, fn, true_c);
@@ -208,29 +208,29 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
 
       // tasks posts are a "read" of the task
       if (fce->call_kind == post_task)
-	collect_uses_expr(fce->arg1, fn, exe_c | c_read);
+        collect_uses_expr(fce->arg1, fn, exe_c | c_read);
       // C named fn calls, commands and events are c_fncall, 
       // otherwise its c_read (and a warning about fn ptr use)
       else if (!(is_interface_deref(fce->arg1) ||
-	    is_generic_call(fce->arg1) ||
-	    (is_identifier(fce->arg1) &&
-	     (CAST(identifier, fce->arg1)->ddecl->kind == decl_function ||
-	      CAST(identifier, fce->arg1)->ddecl->kind == decl_magic_function)) ||
-	    fce->va_arg_call))
-	{
-	  /* We allow a function pointer calls in C code on the assumption
-	     that this represents runtime implementation stuff (e.g., 
-	     the task scheduler, or tossim stuff) */
-	  if (warn_fnptr && 
-	      (!fn || fn->container))
-	    nesc_warning_with_location(fce->location, "call via function pointer");
-	  collect_uses_expr(fce->arg1, fn, exe_c | c_read);
-	}
+            is_generic_call(fce->arg1) ||
+            (is_identifier(fce->arg1) &&
+             (CAST(identifier, fce->arg1)->ddecl->kind == decl_function ||
+              CAST(identifier, fce->arg1)->ddecl->kind == decl_magic_function)) ||
+            fce->va_arg_call))
+        {
+          /* We allow a function pointer calls in C code on the assumption
+             that this represents runtime implementation stuff (e.g., 
+             the task scheduler, or tossim stuff) */
+          if (warn_fnptr && 
+              (!fn || fn->container))
+            nesc_warning_with_location(fce->location, "call via function pointer");
+          collect_uses_expr(fce->arg1, fn, exe_c | c_read);
+        }
       else
-	collect_uses_expr(fce->arg1, fn, exe_c | c_fncall);
+        collect_uses_expr(fce->arg1, fn, exe_c | c_fncall);
 
       scan_expression (e, fce->args)
-	collect_uses_expr(e, fn, exe_c | c_read);
+        collect_uses_expr(e, fn, exe_c | c_read);
       break;
     }
     case kind_generic_call: {
@@ -239,7 +239,7 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
 
       collect_uses_expr(fce->arg1, fn, exe_c | c_fncall);
       scan_expression (e, fce->args)
-	collect_uses_expr(e, fn, exe_c | c_read);
+        collect_uses_expr(e, fn, exe_c | c_read);
       break;
     }
 
@@ -248,11 +248,11 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
       expression arg1 = are->arg1, arg2 = are->arg2, arg;
 
       /* When presented with something like 1[a], switch args to ensure that
-	 arg1 is the pointer or array, arg2 the index */
+         arg1 is the pointer or array, arg2 the index */
       if (type_integer(arg1->type)) 
-	{
-	  arg = arg1; arg1 = arg2; arg2 = arg;
-	}
+        {
+          arg = arg1; arg1 = arg2; arg2 = arg;
+        }
 
       collect_uses_deref(expr, arg1, fn, c);
       collect_uses_expr(arg2, fn, exe_c | c_read);
@@ -268,9 +268,9 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
       expression arg = CAST(unary, expr)->arg1;
 
       if (c & c_deref) /* *&x is just x */
-	c &= ~c_deref;
+        c &= ~c_deref;
       else
-	c = exe_c | c_addressed;
+        c = exe_c | c_addressed;
 
       collect_uses_expr(arg, fn, c);
       break;
@@ -315,28 +315,28 @@ static void collect_uses_expr(expression expr, data_declaration fn, context c)
     }
     default:
       if (is_unary(expr))
-	collect_uses_expr(CAST(unary,expr)->arg1, fn, c);
+        collect_uses_expr(CAST(unary,expr)->arg1, fn, c);
       else if (is_binary(expr))
-	{
-	  binary be = CAST(binary, expr);
+        {
+          binary be = CAST(binary, expr);
 
-	  collect_uses_expr(be->arg1, fn, exe_c | c_read);
-	  collect_uses_expr(be->arg2, fn, exe_c | c_read);
-	}
+          collect_uses_expr(be->arg1, fn, exe_c | c_read);
+          collect_uses_expr(be->arg2, fn, exe_c | c_read);
+        }
       else
-	/* A default catch-all for
-	     sizeof_type, alignof_type, label_address, cast_list,
-	     init_list, init_index, init_field, lexical_cst,
-	     string_cst, string
-	   Embeddded expressions are compile-time constants or read-only,
-	   so the default collect_uses_ast_expr is valid. */
-	collect_uses_children(expr, fn, c);
+        /* A default catch-all for
+             sizeof_type, alignof_type, label_address, cast_list,
+             init_list, init_index, init_field, lexical_cst,
+             string_cst, string
+           Embeddded expressions are compile-time constants or read-only,
+           so the default collect_uses_ast_expr is valid. */
+        collect_uses_children(expr, fn, c);
       break;
     }
 }
 
 static void collect_uses_asm_operands(asm_operand operands,
-				      data_declaration fn, context exe_c)
+                                      data_declaration fn, context exe_c)
 {
   asm_operand aop;
 
@@ -347,9 +347,9 @@ static void collect_uses_asm_operands(asm_operand operands,
 
       /* = is write, + is r/w, everything else is read */
       if (mode == '=' || mode == '+')
-	c |= c_write;
+        c |= c_write;
       if (mode != '=')
-	c |= c_read;
+        c |= c_read;
 
       collect_uses_expr(aop->arg1, fn, c);
     }
@@ -386,12 +386,12 @@ static void collect_uses_stmt(statement stmt, data_declaration fn, context c)
       context true_c = exe_c, false_c = exe_c;
 
       if (is->condition->cst)
-	{
-	  if (definite_zero(is->condition))
-	    true_c &= ~c_executable;
-	  else
-	    false_c &= ~c_executable;
-	}
+        {
+          if (definite_zero(is->condition))
+            true_c &= ~c_executable;
+          else
+            false_c &= ~c_executable;
+        }
 
       collect_uses_expr(is->condition, fn, exe_c | c_read);
       collect_uses_stmt(is->stmt1, fn, true_c);
@@ -403,8 +403,8 @@ static void collect_uses_stmt(statement stmt, data_declaration fn, context c)
       context body_c = exe_c;
 
       if (cs->condition->cst && stmt->kind == kind_while_stmt &&
-	  definite_zero(cs->condition))
-	body_c &= ~c_executable;
+          definite_zero(cs->condition))
+        body_c &= ~c_executable;
       collect_uses_expr(cs->condition, fn, exe_c | c_read);
       collect_uses_stmt(cs->stmt, fn, body_c);
       break;
@@ -414,7 +414,7 @@ static void collect_uses_stmt(statement stmt, data_declaration fn, context c)
       context body_c = exe_c;
 
       if (fs->arg2 && fs->arg2->cst && definite_zero(fs->arg2))
-	body_c &= ~c_executable;
+        body_c &= ~c_executable;
       collect_uses_expr(fs->arg1, fn, exe_c | c_read);
       collect_uses_expr(fs->arg2, fn, exe_c | c_read);
       collect_uses_expr(fs->arg3, fn, body_c | c_read);
@@ -460,7 +460,7 @@ struct uses_data
 };
 
 static AST_walker_result collect_uses_ast_expr(AST_walker spec, void *data,
-					       expression *e)
+                                               expression *e)
 {
   struct uses_data *ud = data;
   collect_uses_expr(*e, ud->function, exe_context(ud->c) | c_read);
@@ -468,7 +468,7 @@ static AST_walker_result collect_uses_ast_expr(AST_walker spec, void *data,
 }
 
 static AST_walker_result collect_uses_ast_stmt(AST_walker spec, void *data,
-					       statement *s)
+                                               statement *s)
 {
   struct uses_data *ud = data;
   collect_uses_stmt(*s, ud->function, exe_context(ud->c));
@@ -476,7 +476,7 @@ static AST_walker_result collect_uses_ast_stmt(AST_walker spec, void *data,
 }
 
 static AST_walker_result collect_uses_ast_fdecl(AST_walker spec, void *data,
-						function_decl *fd)
+                                                function_decl *fd)
 {
   struct uses_data *ud = data;
   struct uses_data new_ud = *ud;
@@ -491,11 +491,11 @@ static void init_collect_uses_walker(void)
 {
   collect_uses_walker = new_AST_walker(rr);
   AST_walker_handle(collect_uses_walker, kind_expression,
-		    collect_uses_ast_expr);
+                    collect_uses_ast_expr);
   AST_walker_handle(collect_uses_walker, kind_statement,
-		    collect_uses_ast_stmt);
+                    collect_uses_ast_stmt);
   AST_walker_handle(collect_uses_walker, kind_function_decl,
-		    collect_uses_ast_fdecl);
+                    collect_uses_ast_fdecl);
 }
 
 static void collect_uses_ast(void *n, data_declaration fn, context c)

--- a/src/nesc-uses.h
+++ b/src/nesc-uses.h
@@ -32,7 +32,7 @@ typedef enum {
 typedef struct use
 {
   location l;
-  data_declaration fn;		/* function containing use */
+  data_declaration fn;                /* function containing use */
   context c;
 } *use;
 

--- a/src/nesc-xml.c
+++ b/src/nesc-xml.c
@@ -259,13 +259,13 @@ void xml_attr_cval(const char *name, cval val)
 
       /* XXX: We don't (yet) support strings with an offset */
       if (ddecl && ddecl->kind == decl_magic_string && cval_knownbool(val))
-	{
-	  /* Wide strings are printed as their byte-by-byte rep. FIXME */
-	  xputs("S:");
-	  xqputcs(ddecl->schars);
-	}
+        {
+          /* Wide strings are printed as their byte-by-byte rep. FIXME */
+          xputs("S:");
+          xqputcs(ddecl->schars);
+        }
       else
-	unknown = TRUE;
+        unknown = TRUE;
     }
   else if (cval_istop(val))
     xputs("V:");
@@ -406,9 +406,9 @@ void nxml_arguments(expression arguments)
   scan_expression (arg, arguments)
     {
       if (is_type_argument(arg))
-	nxml_type(CAST(type_argument, arg)->asttype->type);
+        nxml_type(CAST(type_argument, arg)->asttype->type);
       else 
-	nxml_simple_value(arg->type, arg->cst ? arg->cst->cval : cval_top);
+        nxml_simple_value(arg->type, arg->cst ? arg->cst->cval : cval_top);
     }
   indentedtag_pop();
 }

--- a/src/qualifiers.h
+++ b/src/qualifiers.h
@@ -1,3 +1,3 @@
-Q(const, 	TYPE_QUAL,	const_qualifier, 	2)
-Q(volatile, 	TYPE_QUAL,	volatile_qualifier, 	4)
-Q(__restrict,	TYPE_QUAL,	restrict_qualifier,	8)
+Q(const,         TYPE_QUAL,        const_qualifier,         2)
+Q(volatile,         TYPE_QUAL,        volatile_qualifier,         4)
+Q(__restrict,        TYPE_QUAL,        restrict_qualifier,        8)

--- a/src/semantics.c
+++ b/src/semantics.c
@@ -62,7 +62,7 @@ static known_cst onecst, zerocst;
 static expression oneexpr;
 
 environment new_environment(region r, environment parent,
-			    bool global_level, bool parm_level)
+                            bool global_level, bool parm_level)
 {
   environment env = ralloc(r, struct environment);
 
@@ -79,9 +79,9 @@ environment new_environment(region r, environment parent,
       env->id_env = new_env(r, parent->id_env);
       /* ANSI C is weird */
       if (parent->parm_level)
-	env->tag_env = parent->tag_env;
+        env->tag_env = parent->tag_env;
       else
-	env->tag_env = new_env(r, parent->tag_env);
+        env->tag_env = new_env(r, parent->tag_env);
     }
   else
     {
@@ -93,7 +93,7 @@ environment new_environment(region r, environment parent,
 }
 
 void init_data_declaration(data_declaration dd, declaration ast,
-			   const char *name, type t)
+                           const char *name, type t)
 {
   dd->kind = 0;
   dd->name = name;
@@ -169,7 +169,7 @@ data_declaration lookup_global_id(const char *s)
 }
 
 data_declaration declare(environment b, data_declaration from,
-			 bool ignore_shadow)
+                         bool ignore_shadow)
 {
   data_declaration dd = ralloc(parse_region, struct data_declaration);
 
@@ -180,62 +180,62 @@ data_declaration declare(environment b, data_declaration from,
       check_name(dd->name);
 
       /* In PCC-compatibility mode, extern decls of vars with no current decl
-	 take effect at top level no matter where they are.  */
+         take effect at top level no matter where they are.  */
       /* We don't do the GCC "type exists at global scope" check because
-	 it's mostly meaningless.
-	 XXX: review if I start freeing mem earlier */
+         it's mostly meaningless.
+         XXX: review if I start freeing mem earlier */
       if (!b->global_level)
-	{
-	  /* Here to install a non-global value.  */
-	  data_declaration shadowed = lookup_id(dd->name, FALSE);
-	  char *warnstring = 0;
+        {
+          /* Here to install a non-global value.  */
+          data_declaration shadowed = lookup_id(dd->name, FALSE);
+          char *warnstring = 0;
 
-	  /* Warn if shadowing an argument at the top level of the body.  */
-	  if (shadowed && shadowed->islocal
-	      /* This warning doesn't apply to the parms of a nested fcn.  */
-	      && !b->parm_level
-	      /* Check that this is one level down from the parms.  */
-	      && b->parent->parm_level
-	      /* Check that the decl exists in the parm level */
-	      && env_lookup(b->parent->id_env, dd->name, TRUE))
-	    {
-	      if (shadowed->isparameter)
-		warnstring = "declaration of `%s' shadows a parameter";
-	      else
-		warnstring = "declaration of `%s' shadows a symbol from the parameter list"; 
-	    }
-	  /* Maybe warn if shadowing something else.  */
-	  else if (warn_shadow && !ignore_shadow)
-	    {
+          /* Warn if shadowing an argument at the top level of the body.  */
+          if (shadowed && shadowed->islocal
+              /* This warning doesn't apply to the parms of a nested fcn.  */
+              && !b->parm_level
+              /* Check that this is one level down from the parms.  */
+              && b->parent->parm_level
+              /* Check that the decl exists in the parm level */
+              && env_lookup(b->parent->id_env, dd->name, TRUE))
+            {
+              if (shadowed->isparameter)
+                warnstring = "declaration of `%s' shadows a parameter";
+              else
+                warnstring = "declaration of `%s' shadows a symbol from the parameter list"; 
+            }
+          /* Maybe warn if shadowing something else.  */
+          else if (warn_shadow && !ignore_shadow)
+            {
 
-	      if (dd->isparameter
-		  && b->parent->parm_level)
-		/* Don't warn about the parm names in function declarator
-		   within a function declarator.
-		   It would be nice to avoid warning in any function
-		   declarator in a declaration, as opposed to a definition,
-		   but there is no way to tell it's not a definition.  */
-		;
-	      else if (shadowed && shadowed->isparameter)
-		warnstring = "declaration of `%s' shadows a parameter";
-	      else if (shadowed && shadowed->islocal)
-		warnstring = "declaration of `%s' shadows previous local";
-	      else if (shadowed)
-		warnstring = "declaration of `%s' shadows global declaration";
+              if (dd->isparameter
+                  && b->parent->parm_level)
+                /* Don't warn about the parm names in function declarator
+                   within a function declarator.
+                   It would be nice to avoid warning in any function
+                   declarator in a declaration, as opposed to a definition,
+                   but there is no way to tell it's not a definition.  */
+                ;
+              else if (shadowed && shadowed->isparameter)
+                warnstring = "declaration of `%s' shadows a parameter";
+              else if (shadowed && shadowed->islocal)
+                warnstring = "declaration of `%s' shadows previous local";
+              else if (shadowed)
+                warnstring = "declaration of `%s' shadows global declaration";
 
-	    }
-	  if (warnstring)
-	    {
-	      (error_shadow ? error : warning)(warnstring, dd->name);
-	      (error_shadow ? error_with_location : warning_with_location)(shadowed->ast->location, "location of shadowed declaration");
-	    }
-	}
+            }
+          if (warnstring)
+            {
+              (error_shadow ? error : warning)(warnstring, dd->name);
+              (error_shadow ? error_with_location : warning_with_location)(shadowed->ast->location, "location of shadowed declaration");
+            }
+        }
 
       /* Parameters are declared before the function_decl is created
-	 (and may be declared in several places). The id's of parameters
-	 are set in start_function */
+         (and may be declared in several places). The id's of parameters
+         are set in start_function */
       if (dd->kind == decl_variable && dd->islocal && !dd->isparameter)
-	dd->id = b->fdecl->nlocals++;
+        dd->id = b->fdecl->nlocals++;
 
    }
   assert(!dd->islimbo);
@@ -250,11 +250,11 @@ data_declaration declare(environment b, data_declaration from,
     {
       /* C names go all the way to the top... */
       if (dd->Cname)
-	env_add(global_env->id_env, dd->name, dd);
+        env_add(global_env->id_env, dd->name, dd);
       if (!dd->container_function && flag_c && !dd->spontaneous)
-	dd->spontaneous = c_call_nonatomic;
+        dd->spontaneous = c_call_nonatomic;
       if (dd->spontaneous || (getenv("ALLCODE") && dd->kind == decl_function))
-	dd_add_last(parse_region, spontaneous_calls, dd);
+        dd_add_last(parse_region, spontaneous_calls, dd);
     }
 
   return dd;
@@ -289,8 +289,8 @@ tag_declaration declare_tag_env(environment env, tag_ref t)
     {
       tdecl->shadowed = env_lookup(env->tag_env, name, FALSE);
       if (tdecl->shadowed && warn_shadow)
-	(error_shadow ? error : warning)
-	  ("tag %s shadows enclosing struct/union/enum", name);
+        (error_shadow ? error : warning)
+          ("tag %s shadows enclosing struct/union/enum", name);
     }
   else
     tdecl->shadowed = NULL;
@@ -356,39 +356,39 @@ void shadow_tag_warned(type_element elements, int warned)
   scan_type_element (elem, elements)
     {
       if (is_tag_ref(elem))
-	{
-	  tag_ref tag = CAST(tag_ref, elem);
-	  word name = tag->word1;
+        {
+          tag_ref tag = CAST(tag_ref, elem);
+          word name = tag->word1;
 
-	  found_tag++;
+          found_tag++;
 
-	  if (name == 0)
-	    {
-	      if (warned != 1 && !is_enum_ref(elem))
-		/* Empty unnamed enum OK */
-		{
-		  pedwarn ("unnamed struct/union that defines no instances");
-		  warned = 1;
-		}
-	    }
-	  else
-	    {
-	      void *tagdecl = lookup_tag(tag, TRUE);
+          if (name == 0)
+            {
+              if (warned != 1 && !is_enum_ref(elem))
+                /* Empty unnamed enum OK */
+                {
+                  pedwarn ("unnamed struct/union that defines no instances");
+                  warned = 1;
+                }
+            }
+          else
+            {
+              void *tagdecl = lookup_tag(tag, TRUE);
 
-	      if (tagdecl == 0)
-		declare_tag(tag);
-	      else
-		pending_xref_error();
-	    }
-	}
+              if (tagdecl == 0)
+                declare_tag(tag);
+              else
+                pending_xref_error();
+            }
+        }
       else
-	{
-	  if (!warned && ! current.lex.input->l.in_system_header)
-	    {
-	      warning("useless keyword or type name in empty declaration");
-	      warned = 2;
-	    }
-	}
+        {
+          if (!warned && ! current.lex.input->l.in_system_header)
+            {
+              warning("useless keyword or type name in empty declaration");
+              warned = 2;
+            }
+        }
     }
 
   if (found_tag > 1)
@@ -397,7 +397,7 @@ void shadow_tag_warned(type_element elements, int warned)
   if (warned != 1)
     {
       if (found_tag == 0)
-	pedwarn("empty declaration");
+        pedwarn("empty declaration");
     }
 }
 
@@ -411,8 +411,8 @@ void pending_xref_error(void)
   if (current.pending_invalid_xref != 0)
     {
       error_with_location(current.pending_invalid_xref->location,
-			  "`%s' defined as wrong kind of tag",
-			  current.pending_invalid_xref->word1->cstring.data);
+                          "`%s' defined as wrong kind of tag",
+                          current.pending_invalid_xref->word1->cstring.data);
       current.pending_invalid_xref = 0;
     }
 }
@@ -423,7 +423,7 @@ declaration make_void_parm(location loc)
   rid rvoid = new_rid(r, loc, RID_VOID);
   variable_decl vdvoid = new_variable_decl(r, loc, NULL, NULL, NULL, NULL, NULL);
   data_decl ddvoid = new_data_decl(r, loc, CAST(type_element, rvoid),
-				   CAST(declaration, vdvoid));
+                                   CAST(declaration, vdvoid));
 
   return CAST(declaration, ddvoid);
 }
@@ -445,22 +445,22 @@ static void parmlist_tags_warning(environment parm_env)
       const char *kindname = tagkind_name(kind);
 
       /* An anonymous union parm type is meaningful as a GNU extension.
-	 So don't warn for that.  */
+         So don't warn for that.  */
       if (kind == kind_union_ref && !tagname && !pedantic)
-	continue;
+        continue;
 
       if (tagname)
-	warning("`%s %s' declared inside parameter list", kindname,
-		tagname);
+        warning("`%s %s' declared inside parameter list", kindname,
+                tagname);
       else
-	warning("anonymous %s declared inside parameter list", kindname);
+        warning("anonymous %s declared inside parameter list", kindname);
 
       if (!already)
-	{
-	  warning("its scope is only this definition or declaration,");
-	  warning("which is probably not what you want.");
-	  already = TRUE;
-	}
+        {
+          warning("its scope is only this definition or declaration,");
+          warning("which is probably not what you want.");
+          already = TRUE;
+        }
     }
 }
 
@@ -473,27 +473,27 @@ typelist make_arg_types(bool definition, declaration parameters, bool *varargs)
   if (!is_void_parms(parameters))
     scan_declaration (parameter, parameters)
       if (is_ellipsis_decl(parameter))
-	*varargs = TRUE;
+        *varargs = TRUE;
       else if (is_error_decl(parameter))
-	{
-	  /* Make an "accept everything" signature for arg lists with
-	     error_decls */
-	  *varargs = TRUE;
-	  arg_types = new_typelist(parse_region);
-	  typelist_append(arg_types, error_type);
+        {
+          /* Make an "accept everything" signature for arg lists with
+             error_decls */
+          *varargs = TRUE;
+          arg_types = new_typelist(parse_region);
+          typelist_append(arg_types, error_type);
 
-	  return arg_types;
-	}
+          return arg_types;
+        }
       else
-	{
-	  data_decl dp = CAST(data_decl, parameter);
-	  variable_decl vp = CAST(variable_decl, dp->decls);
+        {
+          data_decl dp = CAST(data_decl, parameter);
+          variable_decl vp = CAST(variable_decl, dp->decls);
 
-	  assert(!vp->next);
-	  if (!vp->ddecl->name && definition)
-	    error_with_decl(dp->decls, "parameter name omitted");
-	  typelist_append(arg_types, vp->ddecl->type);
-	}
+          assert(!vp->next);
+          if (!vp->ddecl->name && definition)
+            error_with_decl(dp->decls, "parameter name omitted");
+          typelist_append(arg_types, vp->ddecl->type);
+        }
 
   return arg_types;
 }
@@ -540,7 +540,7 @@ static void check_legal_qualifiers(location l, type_quals quals)
 }
 
 static type parse_qualifiers(type t, location l, type_element qlist,
-			     dd_list *oattributes)
+                             dd_list *oattributes)
 {
   type_element q;
   type_quals tqs = no_qualifiers;
@@ -548,23 +548,23 @@ static type parse_qualifiers(type t, location l, type_element qlist,
   scan_type_element (q, qlist)
     if (is_qualifier(q))
       {
-	qualifier qq = CAST(qualifier, q);
+        qualifier qq = CAST(qualifier, q);
 
-	check_duplicate_qualifiers1(qq->location, qq->id, tqs);
-	tqs |= qq->id;
+        check_duplicate_qualifiers1(qq->location, qq->id, tqs);
+        tqs |= qq->id;
       }
     else if (is_attribute(q))
       {
-	/* Filter out type-only attributes */
-	if (!handle_type_attribute(CAST(attribute, q), &t))
-	  *oattributes = push_attribute(*oattributes, CAST(attribute, q));
+        /* Filter out type-only attributes */
+        if (!handle_type_attribute(CAST(attribute, q), &t))
+          *oattributes = push_attribute(*oattributes, CAST(attribute, q));
       }
   check_legal_qualifiers(l, tqs);
   return make_qualified_type(t, tqs);
 }
 
 static type make_nesc_function_type(int class, type returns, typelist argtypes,
-				    bool varargs)
+                                    bool varargs)
 {
   switch (class)
     {
@@ -592,7 +592,7 @@ scflags parse_scflags(int specbits)
 }
 
 void check_variable_scflags(scflags scf,
-			    location l, const char *kind, const char *name)
+                            location l, const char *kind, const char *name)
 {
   const char *badqual = NULL;
   void (*msg)(location l, const char *format, ...) = error_with_location;
@@ -618,40 +618,40 @@ void check_array_size(expression size, const char *printname)
   if (size->cst && constant_integral(size->cst))
     {
       if (pedantic)
-	{
-	  constant_overflow_warning(size->cst);
-	  if (definite_zero(size))
-	    pedwarn_with_location
-	      (size->location, "ANSI C forbids zero-size array `%s'", printname);
-	}
+        {
+          constant_overflow_warning(size->cst);
+          if (definite_zero(size))
+            pedwarn_with_location
+              (size->location, "ANSI C forbids zero-size array `%s'", printname);
+        }
 
       if (cval_intcompare(size->cst->cval, cval_zero) < 0)
-	error_with_location(size->location,
-			    "size of array `%s' is negative", printname);
+        error_with_location(size->location,
+                            "size of array `%s' is negative", printname);
     }
   else if (!(current.function_decl || current.env->parm_level))
     {
       if (size->cst)
-	error_with_location(size->location, "type size can't be explicitly evaluated");
+        error_with_location(size->location, "type size can't be explicitly evaluated");
       else
-	error_with_location(size->location, "variable-size type declared outside of any function");
+        error_with_location(size->location, "variable-size type declared outside of any function");
     }
   else if (pedantic)
     {
       if (size->cst)
-	pedwarn_with_location(size->location, "ANSI C forbids array `%s' whose size can't be evaluated", printname);
+        pedwarn_with_location(size->location, "ANSI C forbids array `%s' whose size can't be evaluated", printname);
       else
-	pedwarn_with_location(size->location, "ANSI C forbids variable-size array `%s'", printname);
+        pedwarn_with_location(size->location, "ANSI C forbids variable-size array `%s'", printname);
     }
 }
 
 void parse_declarator(type_element modifiers, declarator d, bool bitfield, 
-		      bool require_parm_names,
-		      int *oclass, scflags *oscf,
-		      const char **ointf, const char **oname,
-		      type *ot, bool *owarn_defaulted_int,
-		      function_declarator *ofunction_declarator,
-		      dd_list *oattributes)
+                      bool require_parm_names,
+                      int *oclass, scflags *oscf,
+                      const char **ointf, const char **oname,
+                      type *ot, bool *owarn_defaulted_int,
+                      function_declarator *ofunction_declarator,
+                      dd_list *oattributes)
 {
   location loc = d ? d->location : modifiers->location;
   int specbits = 0, nclasses = 0;
@@ -678,103 +678,103 @@ void parse_declarator(type_element modifiers, declarator d, bool bitfield,
       type newtype = NULL;
 
       switch (spec->kind)
-	{
-	case kind_rid:
-	  {
-	    rid rspec = CAST(rid, spec);
-	    int id = rspec->id;
+        {
+        case kind_rid:
+          {
+            rid rspec = CAST(rid, spec);
+            int id = rspec->id;
 
-	    switch (id)
-	      {
-	      case RID_INT: newtype = int_type; break;
-	      case RID_CHAR: newtype = char_type; break;
-	      case RID_FLOAT: newtype = float_type; break;
-	      case RID_DOUBLE: newtype = double_type; break;
-	      case RID_VOID: newtype = void_type; break;
-	      case RID_AUTO: case RID_STATIC: case RID_EXTERN:
-	      case RID_REGISTER: case RID_TYPEDEF: case RID_COMMAND:
-	      case RID_EVENT: case RID_TASK:
-		*oclass = id;
-		nclasses++;
-		break;
+            switch (id)
+              {
+              case RID_INT: newtype = int_type; break;
+              case RID_CHAR: newtype = char_type; break;
+              case RID_FLOAT: newtype = float_type; break;
+              case RID_DOUBLE: newtype = double_type; break;
+              case RID_VOID: newtype = void_type; break;
+              case RID_AUTO: case RID_STATIC: case RID_EXTERN:
+              case RID_REGISTER: case RID_TYPEDEF: case RID_COMMAND:
+              case RID_EVENT: case RID_TASK:
+                *oclass = id;
+                nclasses++;
+                break;
 
-	      case RID_LONG: /* long long detection */
-		if (specbits & 1 << RID_LONG) 
-		  {
-		    if (longlong)
-		      error_with_location(spec->location,
-					  "`long long long' is too long for GCC");
-		    else
-		      {
-			if (pedantic && !current.lex.input->l.in_system_header)
-			  pedwarn_with_location(spec->location,
-						"ANSI C does not support `long long'");
-			longlong = TRUE;
-		      }
-		    break;
-		  }
-		/* Fall through */
-	      default:
-		check_duplicate_rid(specbits, rspec);
-		break;
-	      }
-	    specbits |= 1 << id;
-	    break;
-	  }
-	case kind_qualifier:
-	  {
-	    qualifier q = CAST(qualifier, spec);
-	    int id = q->id;
+              case RID_LONG: /* long long detection */
+                if (specbits & 1 << RID_LONG) 
+                  {
+                    if (longlong)
+                      error_with_location(spec->location,
+                                          "`long long long' is too long for GCC");
+                    else
+                      {
+                        if (pedantic && !current.lex.input->l.in_system_header)
+                          pedwarn_with_location(spec->location,
+                                                "ANSI C does not support `long long'");
+                        longlong = TRUE;
+                      }
+                    break;
+                  }
+                /* Fall through */
+              default:
+                check_duplicate_rid(specbits, rspec);
+                break;
+              }
+            specbits |= 1 << id;
+            break;
+          }
+        case kind_qualifier:
+          {
+            qualifier q = CAST(qualifier, spec);
+            int id = q->id;
             
-	    check_duplicate_qualifiers1(loc, id, specquals);
-	    specquals |= id;
-	    break;
-	  }
-	case kind_typename: case kind_component_typeref:
-	  newtype = CAST(typename, spec)->ddecl->type;
-	  break;
-	case kind_typeof_type:
-	  newtype = CAST(typeof_type, spec)->asttype->type;
-	  break;
-	case kind_typeof_expr:
-	  newtype = CAST(typeof_expr, spec)->arg1->type;
-	  if (type_generic(newtype) ||
-	      (type_functional(newtype) && !type_function(newtype)))
-	    {
-	      error_with_location(spec->location,
-				  "expression does not have a valid type");
-	      newtype = error_type;
-	    }
-	  else if (type_unknown(newtype))
-	    {
-	      error_with_location(spec->location,
-				  "typeof an expression based on an @integer() or @number() type not supported");
-	      newtype = error_type;
-	    }
-	  break;
-	case kind_struct_ref: case kind_union_ref: case kind_enum_ref:
-	case kind_nx_struct_ref: case kind_nx_union_ref:
-	  newtype = make_tagged_type(CAST(tag_ref, spec)->tdecl);
-	  break;
-	case kind_attribute_ref:
-	  error_with_location(spec->location,
-			      "attributes cannot be used as types");
-	  newtype = error_type;
-	  break;
-	case kind_gcc_attribute: case kind_target_attribute: case kind_nesc_attribute:
-	  attributes = push_attribute(attributes, CAST(attribute, spec));
-	  break;
-	default: assert(0); break;
-	}
+            check_duplicate_qualifiers1(loc, id, specquals);
+            specquals |= id;
+            break;
+          }
+        case kind_typename: case kind_component_typeref:
+          newtype = CAST(typename, spec)->ddecl->type;
+          break;
+        case kind_typeof_type:
+          newtype = CAST(typeof_type, spec)->asttype->type;
+          break;
+        case kind_typeof_expr:
+          newtype = CAST(typeof_expr, spec)->arg1->type;
+          if (type_generic(newtype) ||
+              (type_functional(newtype) && !type_function(newtype)))
+            {
+              error_with_location(spec->location,
+                                  "expression does not have a valid type");
+              newtype = error_type;
+            }
+          else if (type_unknown(newtype))
+            {
+              error_with_location(spec->location,
+                                  "typeof an expression based on an @integer() or @number() type not supported");
+              newtype = error_type;
+            }
+          break;
+        case kind_struct_ref: case kind_union_ref: case kind_enum_ref:
+        case kind_nx_struct_ref: case kind_nx_union_ref:
+          newtype = make_tagged_type(CAST(tag_ref, spec)->tdecl);
+          break;
+        case kind_attribute_ref:
+          error_with_location(spec->location,
+                              "attributes cannot be used as types");
+          newtype = error_type;
+          break;
+        case kind_gcc_attribute: case kind_target_attribute: case kind_nesc_attribute:
+          attributes = push_attribute(attributes, CAST(attribute, spec));
+          break;
+        default: assert(0); break;
+        }
 
       if (newtype)
-	{
-	  if (t)
-	    error_with_location(spec->location,
-	       "two or more data types in declaration of `%s'", printname);
-	  else
-	    t = newtype;
-	}
+        {
+          if (t)
+            error_with_location(spec->location,
+               "two or more data types in declaration of `%s'", printname);
+          else
+            t = newtype;
+        }
     }
 
   /* Long double is a special combination.  */
@@ -785,34 +785,34 @@ void parse_declarator(type_element modifiers, declarator d, bool bitfield,
     }
 
   modified = !!(specbits & (1 << RID_LONG | 1 << RID_SHORT |
-			    1 << RID_SIGNED | 1 << RID_UNSIGNED));
+                            1 << RID_SIGNED | 1 << RID_UNSIGNED));
 
   /* No type at all: default to `int', or `double' (if complex specified
      and no long/short/signed/unsigned) */
   if (!t)
     {
       if (specbits & 1 << RID_COMPLEX)
-	{
-	  if (!modified)
-	    {
-	      specbits |= 1 << RID_DOUBLE;
-	      t = double_type;
-	    }
-	  else
-	    {
-	      specbits |= 1 << RID_INT;
-	      t = int_type;
-	    }
-	}
+        {
+          if (!modified)
+            {
+              specbits |= 1 << RID_DOUBLE;
+              t = double_type;
+            }
+          else
+            {
+              specbits |= 1 << RID_INT;
+              t = int_type;
+            }
+        }
       else
-	{
-	  /* Defer defaulted int warning to caller (msg depends on context) */
-	  if (!modified)
-	    *owarn_defaulted_int = TRUE;
+        {
+          /* Defer defaulted int warning to caller (msg depends on context) */
+          if (!modified)
+            *owarn_defaulted_int = TRUE;
 
-	  specbits |= 1 << RID_INT;
-	  t = int_type;
-	}
+          specbits |= 1 << RID_INT;
+          t = int_type;
+        }
     }
 
   if (nclasses > 1)
@@ -827,44 +827,44 @@ void parse_declarator(type_element modifiers, declarator d, bool bitfield,
       int ok = 0;
 
       if ((specbits & 1 << RID_LONG) && (specbits & 1 << RID_SHORT))
-	error_with_location(loc, "both long and short specified for `%s'", printname);
+        error_with_location(loc, "both long and short specified for `%s'", printname);
       else if ((specbits & 1 << RID_SHORT) && !(specbits & 1 << RID_INT))
-	{
-	  static int already = 0;
+        {
+          static int already = 0;
 
-	  error_with_location(loc, "short invalid for `%s'", printname);
-	  if (!already && !pedantic)
-	    {
-	      error_with_location(loc, "short is only valid with int");
-	      already = 1;
-	    }
-	}
+          error_with_location(loc, "short invalid for `%s'", printname);
+          if (!already && !pedantic)
+            {
+              error_with_location(loc, "short is only valid with int");
+              already = 1;
+            }
+        }
       else if ((specbits & 1 << RID_LONG) && !(specbits & 1 << RID_INT))
-	{
-	  static int already = 0;
+        {
+          static int already = 0;
 
-	  error_with_location(loc, "long invalid for `%s'", printname);
-	  if (!already && !pedantic)
-	    {
-	      error_with_location(loc, "long is only valid with int or double");
-	      already = 1;
-	    }
-	}
+          error_with_location(loc, "long invalid for `%s'", printname);
+          if (!already && !pedantic)
+            {
+              error_with_location(loc, "long is only valid with int or double");
+              already = 1;
+            }
+        }
       else if ((specbits & 1 << RID_SIGNED) && (specbits & 1 << RID_UNSIGNED))
-	error_with_location(loc, "both signed and unsigned specified for `%s'", printname);
+        error_with_location(loc, "both signed and unsigned specified for `%s'", printname);
       else if (((specbits & 1 << RID_SIGNED) || (specbits & 1 << RID_UNSIGNED))
-	       && !(specbits & (1 << RID_INT | 1 << RID_CHAR)))
-	error_with_location(loc, "signed or unsigned invalid for `%s'", printname);
+               && !(specbits & (1 << RID_INT | 1 << RID_CHAR)))
+        error_with_location(loc, "signed or unsigned invalid for `%s'", printname);
       else
-	ok = 1;
+        ok = 1;
 
       /* Discard the type modifiers if they are invalid.  */
       if (! ok)
-	{
-	  specbits &= ~(1 << RID_LONG | 1 << RID_SHORT
-			| 1 << RID_UNSIGNED | 1 << RID_SIGNED);
-	  longlong = 0;
-	}
+        {
+          specbits &= ~(1 << RID_LONG | 1 << RID_SHORT
+                        | 1 << RID_UNSIGNED | 1 << RID_SIGNED);
+          longlong = 0;
+        }
     }
 
   if ((specbits & 1 << RID_COMPLEX) && !(type_integral(t) || type_floating(t)))
@@ -878,21 +878,21 @@ void parse_declarator(type_element modifiers, declarator d, bool bitfield,
   if ((specbits & 1 << RID_UNSIGNED)
       /* Traditionally, all bitfields are unsigned.  */
       || (bitfield && flag_traditional
-	  && (/*!explicit_flag_signed_bitfields ||*/ !flag_signed_bitfields))
+          && (/*!explicit_flag_signed_bitfields ||*/ !flag_signed_bitfields))
       || (bitfield && !flag_signed_bitfields
-	  && ((specbits & 1 << RID_INT) || (specbits & 1 << RID_CHAR))
-	  && !(specbits & 1 << RID_SIGNED)))
+          && ((specbits & 1 << RID_INT) || (specbits & 1 << RID_CHAR))
+          && !(specbits & 1 << RID_SIGNED)))
     {
       if (longlong)
-	t = unsigned_long_long_type;
+        t = unsigned_long_long_type;
       else if (specbits & 1 << RID_LONG)
-	t = unsigned_long_type;
+        t = unsigned_long_type;
       else if (specbits & 1 << RID_SHORT)
-	t = unsigned_short_type;
+        t = unsigned_short_type;
       else if (t == char_type)
-	t = unsigned_char_type;
+        t = unsigned_char_type;
       else
-	t = unsigned_int_type;
+        t = unsigned_int_type;
     }
   else if ((specbits & 1 << RID_SIGNED) && (specbits & 1 << RID_CHAR))
     t = signed_char_type;
@@ -933,169 +933,169 @@ void parse_declarator(type_element modifiers, declarator d, bool bitfield,
   while (d && d->kind != kind_identifier_declarator)
     {
       switch (d->kind)
-	{
-	case kind_array_declarator:
-	  {
-	    array_declarator ad = CAST(array_declarator, d);
-	    expression size = ad->arg1;
+        {
+        case kind_array_declarator:
+          {
+            array_declarator ad = CAST(array_declarator, d);
+            expression size = ad->arg1;
 
-	    d = ad->declarator;
+            d = ad->declarator;
 
-	    /* Check for some types that there cannot be arrays of.  */
-	    if (type_void(t))
-	      {
-		error_with_location(ad->location,
-				    "declaration of `%s' as array of voids", printname);
-		t = error_type;
-	      }
+            /* Check for some types that there cannot be arrays of.  */
+            if (type_void(t))
+              {
+                error_with_location(ad->location,
+                                    "declaration of `%s' as array of voids", printname);
+                t = error_type;
+              }
 
-	    if (type_function(t))
-	      {
-		error_with_location(ad->location,
-				    "declaration of `%s' as array of functions", printname);
-		t = error_type;
-	      }
+            if (type_function(t))
+              {
+                error_with_location(ad->location,
+                                    "declaration of `%s' as array of functions", printname);
+                t = error_type;
+              }
 
-	    if (size && is_error_expr(size))
-	      t = error_type;
+            if (size && is_error_expr(size))
+              t = error_type;
 
-	    if (t == error_type)
-	      continue;
+            if (t == error_type)
+              continue;
 
-	    if (size)
-	      {
-		if (!type_integer(size->type))
-		  {
-		    error_with_location(ad->location,
-					"size of array `%s' has non-integer type", printname);
-		    size = oneexpr;
-		  }
-		else
-		  check_array_size(size, printname);
-	      }
+            if (size)
+              {
+                if (!type_integer(size->type))
+                  {
+                    error_with_location(ad->location,
+                                        "size of array `%s' has non-integer type", printname);
+                    size = oneexpr;
+                  }
+                else
+                  check_array_size(size, printname);
+              }
 
-	    /* Build the array type itself, then merge any constancy or
-	       volatility  */
-	    t = make_array_type(t, size);
-	    break;
-	  }
+            /* Build the array type itself, then merge any constancy or
+               volatility  */
+            t = make_array_type(t, size);
+            break;
+          }
 
-	case kind_function_declarator:
-	  {
-	    function_declarator fd = CAST(function_declarator, d);
-	    bool newstyle;
+        case kind_function_declarator:
+          {
+            function_declarator fd = CAST(function_declarator, d);
+            bool newstyle;
 
-	    d = fd->declarator;
-	    if (ofunction_declarator)
-	      *ofunction_declarator = fd;
+            d = fd->declarator;
+            if (ofunction_declarator)
+              *ofunction_declarator = fd;
 
-	    /* Declaring a function type.
-	       Make sure we have a valid type for the function to return.  */
-	    if (t == error_type)
-	      t = int_type;
+            /* Declaring a function type.
+               Make sure we have a valid type for the function to return.  */
+            if (t == error_type)
+              t = int_type;
 
-	    /* Warn about some types functions can't return.  */
-	    if (type_function(t))
-	      {
-		error_with_location(fd->location,
-				    "`%s' declared as function returning a function",
-		      printname);
-		t = int_type;
-	      }
-	    if (type_array(t))
-	      {
-		error_with_location(fd->location,
-				    "`%s' declared as function returning an array",
-		      printname);
-		t = int_type;
-	      }
+            /* Warn about some types functions can't return.  */
+            if (type_function(t))
+              {
+                error_with_location(fd->location,
+                                    "`%s' declared as function returning a function",
+                      printname);
+                t = int_type;
+              }
+            if (type_array(t))
+              {
+                error_with_location(fd->location,
+                                    "`%s' declared as function returning an array",
+                      printname);
+                t = int_type;
+              }
 
 #ifndef TRADITIONAL_RETURN_FLOAT
-	    /* Traditionally, declaring return type float means double.  */
-	    if (flag_traditional && type_float(t))
-	      t = qualify_type1(double_type, t);
+            /* Traditionally, declaring return type float means double.  */
+            if (flag_traditional && type_float(t))
+              t = qualify_type1(double_type, t);
 #endif /* TRADITIONAL_RETURN_FLOAT */
 
-	    /* Require new-style declarations */
-	    if (current.language != l_c)
-	      {
-		/* Force empty parameter lists to void */
-		if (!fd->parms)
-		  fd->parms = make_void_parm(fd->location);
-		newstyle = !is_oldidentifier_decl(fd->parms);
-		if (!newstyle)
-		  error("old-style parameter lists not supported");
-	      }
-	    else
-	      newstyle = new_style(fd->parms);
+            /* Require new-style declarations */
+            if (current.language != l_c)
+              {
+                /* Force empty parameter lists to void */
+                if (!fd->parms)
+                  fd->parms = make_void_parm(fd->location);
+                newstyle = !is_oldidentifier_decl(fd->parms);
+                if (!newstyle)
+                  error("old-style parameter lists not supported");
+              }
+            else
+              newstyle = new_style(fd->parms);
 
-	    if (newstyle)
-	      {
-		bool definition = require_parm_names && 
-		  d && d->kind == kind_identifier_declarator;
-		bool varargs;
-		typelist argtypes = make_arg_types(definition, fd->parms,
-						   &varargs);
+            if (newstyle)
+              {
+                bool definition = require_parm_names && 
+                  d && d->kind == kind_identifier_declarator;
+                bool varargs;
+                typelist argtypes = make_arg_types(definition, fd->parms,
+                                                   &varargs);
 
-		if (*oclass == RID_TASK)
-		  {
-		    if (!is_void_parms(fd->parms))
-		      error_with_location(fd->location,
-		        "`%s' declared as a task with parameters", printname);
-		    if (!type_void(t))
-		      error_with_location(fd->location,
-			"task `%s' must return void", printname);
-		  }
+                if (*oclass == RID_TASK)
+                  {
+                    if (!is_void_parms(fd->parms))
+                      error_with_location(fd->location,
+                        "`%s' declared as a task with parameters", printname);
+                    if (!type_void(t))
+                      error_with_location(fd->location,
+                        "task `%s' must return void", printname);
+                  }
 
-		t = make_nesc_function_type(*oclass, t, argtypes, varargs);
+                t = make_nesc_function_type(*oclass, t, argtypes, varargs);
 
-		if (fd->gparms)
-		  {
-		    argtypes = make_arg_types(definition, fd->gparms, &varargs);
-		    t = make_generic_type(t, argtypes);
-		  }
-	      }
-	    else  /* Old-style function */
-	      t = make_function_type(t, NULL, FALSE, TRUE);
+                if (fd->gparms)
+                  {
+                    argtypes = make_arg_types(definition, fd->gparms, &varargs);
+                    t = make_generic_type(t, argtypes);
+                  }
+              }
+            else  /* Old-style function */
+              t = make_function_type(t, NULL, FALSE, TRUE);
 
-	    t = parse_qualifiers(t, fd->location, fd->qualifiers, NULL);
-	    break;
-	  }
+            t = parse_qualifiers(t, fd->location, fd->qualifiers, NULL);
+            break;
+          }
 
-	case kind_pointer_declarator:
-	  {
-	    pointer_declarator pd = CAST(pointer_declarator, d);
+        case kind_pointer_declarator:
+          {
+            pointer_declarator pd = CAST(pointer_declarator, d);
 
-	    d = pd->declarator;
-	    t = make_pointer_type(t);
-	    break;
-	  }
+            d = pd->declarator;
+            t = make_pointer_type(t);
+            break;
+          }
 
-	case kind_qualified_declarator:
-	  {
-	    qualified_declarator qd = CAST(qualified_declarator, d);
+        case kind_qualified_declarator:
+          {
+            qualified_declarator qd = CAST(qualified_declarator, d);
 
-	    d = qd->declarator;
-	    t = parse_qualifiers(t, qd->location, qd->modifiers, &attributes);
-	    break;
-	  }
+            d = qd->declarator;
+            t = parse_qualifiers(t, qd->location, qd->modifiers, &attributes);
+            break;
+          }
 
-	case kind_interface_ref_declarator:
-	  {
-	    interface_ref_declarator id = CAST(interface_ref_declarator, d);
+        case kind_interface_ref_declarator:
+          {
+            interface_ref_declarator id = CAST(interface_ref_declarator, d);
 
-	    d = id->declarator;
-	    if (ointf)
-	      *ointf = id->word1->cstring.data;
-	    else
-	      error_with_location(id->location,
-		"unexpected interface reference in declaration of `%s'",
-				  printname);
-	    break;
-	  }
+            d = id->declarator;
+            if (ointf)
+              *ointf = id->word1->cstring.data;
+            else
+              error_with_location(id->location,
+                "unexpected interface reference in declaration of `%s'",
+                                  printname);
+            break;
+          }
 
-	default: assert(0);
-	}
+        default: assert(0);
+        }
     }
 
   *ot = t;
@@ -1112,23 +1112,23 @@ static declarator finish_function_declarator(function_declarator fd)
   if (new_style(fd->parms) && !is_void_parms(fd->parms))
     scan_declaration (parm, fd->parms)
       if (!is_ellipsis_decl(parm) && !is_error_decl(parm))
-	{
-	  variable_decl vp = CAST(variable_decl, CAST(data_decl, parm)->decls);
+        {
+          variable_decl vp = CAST(variable_decl, CAST(data_decl, parm)->decls);
 
-	  if (!vp->ddecl)
-	    {
-	      error_with_location(fd->location, "parameter declared void");
-	      vp->ddecl = bad_decl;
-	    }
-	  else if (!vp->ddecl->isused)
-	    {
-	      /* ok, so it's not really a field */
-	      const char *pname = nice_field_name(vp->ddecl->name);
+          if (!vp->ddecl)
+            {
+              error_with_location(fd->location, "parameter declared void");
+              vp->ddecl = bad_decl;
+            }
+          else if (!vp->ddecl->isused)
+            {
+              /* ok, so it's not really a field */
+              const char *pname = nice_field_name(vp->ddecl->name);
 
-	      error_with_location(fd->location,
-		"parameter `%s' has just a forward declaration", pname);
-	    }
-	}
+              error_with_location(fd->location,
+                "parameter `%s' has just a forward declaration", pname);
+            }
+        }
 
   parmlist_tags_warning(penv);
 
@@ -1153,8 +1153,8 @@ declarator finish_array_or_fn_declarator(declarator nested, nested_declarator d)
    where the identifier should go.  */
 
 static char *redeclaration_error_message(data_declaration newdecl,
-					 data_declaration olddecl,
-					 bool newinitialised)
+                                         data_declaration olddecl,
+                                         bool newinitialised)
 {
   if (olddecl->islimbo)
     return 0;
@@ -1162,23 +1162,23 @@ static char *redeclaration_error_message(data_declaration newdecl,
   if (newdecl->kind == decl_typedef)
     {
       if (flag_traditional && type_compatible(newdecl->type, olddecl->type))
-	return 0;
+        return 0;
       /* This gets a warning later */
       if (olddecl->in_system_header || newdecl->in_system_header)
-	return 0;
+        return 0;
       return "redefinition of `%s'";
     }
   else if (newdecl->kind == decl_function)
     {
       /* Declarations of functions can insist on internal linkage
-	 but they can't be inconsistent with internal linkage,
-	 so there can be no error on that account.
-	 However defining the same name twice is no good.  */
+         but they can't be inconsistent with internal linkage,
+         so there can be no error on that account.
+         However defining the same name twice is no good.  */
       if (olddecl->definition && newdecl->definition
-	  /* However, defining once as extern inline and a second
-	     time in another way is ok.  */
-	  && !(olddecl->isexterninline && !newdecl->isexterninline))
-	return "redefinition of `%s'";
+          /* However, defining once as extern inline and a second
+             time in another way is ok.  */
+          && !(olddecl->isexterninline && !newdecl->isexterninline))
+        return "redefinition of `%s'";
       return 0;
     }
   else if (newdecl->kind == decl_constant)
@@ -1188,28 +1188,28 @@ static char *redeclaration_error_message(data_declaration newdecl,
       /* Objects declared at top level:  */
       /* If at least one is a reference, it's ok.  */
       if (newdecl->isfilescoperef || olddecl->isfilescoperef)
-	return 0;
+        return 0;
       /* Reject two definitions with initialisation.  */
       if (newinitialised && olddecl->initialiser)
-	return "redefinition of `%s'";
+        return "redefinition of `%s'";
       /* Now we have two tentative defs, or one tentative and one real def.  */
       /* Insist that the linkage match.  */
       if (olddecl->isexternalscope != newdecl->isexternalscope)
-	return "conflicting declarations of `%s'";
+        return "conflicting declarations of `%s'";
       return 0;
     }
   else
     {
       /* Newdecl has block scope.  If olddecl has block scope also, then
-	 reject two definitions, and reject a definition together with an
-	 external reference.  Otherwise, it is OK, because newdecl must
-	 be an extern reference to olddecl.  */
+         reject two definitions, and reject a definition together with an
+         external reference.  Otherwise, it is OK, because newdecl must
+         be an extern reference to olddecl.  */
       if (!(newdecl->isexternalscope && olddecl->isexternalscope))
 #if 0
-	Why check the context ?
-	  && DECL_CONTEXT (newdecl) == DECL_CONTEXT (olddecl)
+        Why check the context ?
+          && DECL_CONTEXT (newdecl) == DECL_CONTEXT (olddecl)
 #endif
-	return "redeclaration of `%s'";
+        return "redeclaration of `%s'";
       return 0;
     }
 }
@@ -1230,16 +1230,16 @@ static bool looks_like_malloc_redeclaration(type t1, type t2)
 }
 
 void show_previous_decl(void (*message)(declaration d, const char *format, ...),
-			data_declaration olddecl)
+                        data_declaration olddecl)
 {
   if (olddecl->kind == decl_function && olddecl->ftype == function_implicit)
     message(olddecl->ast, "previous implicit declaration of `%s'", olddecl->name);
   else if (ddecl_is_command_or_event(olddecl) && olddecl->definition)
     message(olddecl->definition, "previous declaration of `%s'",
-	    decl_printname(olddecl));
+            decl_printname(olddecl));
   else
     message(olddecl->ast, "previous declaration of `%s'",
-	    decl_printname(olddecl));
+            decl_printname(olddecl));
 }
 
 /* Handle when a new declaration NEWDECL
@@ -1254,7 +1254,7 @@ void show_previous_decl(void (*message)(declaration d, const char *format, ...),
    and OLDDECL is in an outer binding level and should thus not be changed.  */
 
 int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
-		    bool different_binding_level, bool newinitialised)
+                    bool different_binding_level, bool newinitialised)
 {
   type oldtype = olddecl->type;
   type newtype = newdecl->type;
@@ -1263,7 +1263,7 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
   bool types_match;
 
   assert(!(newdecl->kind == decl_function &&
-	   newdecl->ftype == function_implicit));
+           newdecl->ftype == function_implicit));
 
   /* New decl is completely inconsistent with the old one =>
      tell caller to replace the old one. This is an error,
@@ -1271,10 +1271,10 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
   if (newdecl->kind != olddecl->kind)
     {
       bool iswarning = 
-	(flag_traditional && different_binding_level) || olddecl->islimbo;
+        (flag_traditional && different_binding_level) || olddecl->islimbo;
 
       warning_or_error(iswarning,
-		       "`%s' redeclared as different kind of symbol", decl_printname(olddecl));
+                       "`%s' redeclared as different kind of symbol", decl_printname(olddecl));
       show_previous_decl(iswarning ? warning_with_decl : error_with_decl, olddecl);
       newdecl->shadowed = olddecl;
       return 0;
@@ -1308,201 +1308,201 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
   /* Permit char *foo () to match void *foo (...) if not pedantic,
      if one of them came from a system header file.  */
   else if (!types_match && olddecl->kind == decl_function
-	   && (olddecl->in_system_header || newdecl->in_system_header)
-	   && (looks_like_malloc_redeclaration(oldtype, newtype) ||
-	       looks_like_malloc_redeclaration(newtype, oldtype)))
+           && (olddecl->in_system_header || newdecl->in_system_header)
+           && (looks_like_malloc_redeclaration(oldtype, newtype) ||
+               looks_like_malloc_redeclaration(newtype, oldtype)))
     {
       if (pedantic)
-	pedwarn_with_decl(newdecl->ast, "conflicting types for `%s'", decl_printname(olddecl));
+        pedwarn_with_decl(newdecl->ast, "conflicting types for `%s'", decl_printname(olddecl));
       /* Make sure we keep void * as ret type, not char *.  */
       if (type_void(type_points_to(type_function_return_type(oldtype))))
-	newdecl->type = newtype = oldtype;
+        newdecl->type = newtype = oldtype;
 
       /* Set IN_SYSTEM_HEADER, so that if we see another declaration
-	 we will come back here again.  */
+         we will come back here again.  */
       newdecl->in_system_header = TRUE;
     }
   else if (!types_match
-	   /* Permit char *foo (int, ...); followed by char *foo ();
-	      if not pedantic.  */
-	   && !(olddecl->kind == decl_function && !pedantic
-		&& type_function_oldstyle(newtype)
-		/* Return types must still match.  */
-		&& type_compatible(type_function_return_type(oldtype),
-				   type_function_return_type(newtype))))
+           /* Permit char *foo (int, ...); followed by char *foo ();
+              if not pedantic.  */
+           && !(olddecl->kind == decl_function && !pedantic
+                && type_function_oldstyle(newtype)
+                /* Return types must still match.  */
+                && type_compatible(type_function_return_type(oldtype),
+                                   type_function_return_type(newtype))))
     {
       void (*message)(const char *format, ...) =
-	olddecl->islimbo ? warning : error;
+        olddecl->islimbo ? warning : error;
 
       previous_message =
-	olddecl->islimbo ? warning_with_decl : error_with_decl;
+        olddecl->islimbo ? warning_with_decl : error_with_decl;
 
       message("conflicting types for `%s'", decl_printname(olddecl));
       /* Check for function type mismatch
-	 involving an empty arglist vs a nonempty one.  */
+         involving an empty arglist vs a nonempty one.  */
       if (newdecl->kind == decl_function
-	  && type_compatible(type_function_return_type(oldtype),
-			     type_function_return_type(newtype))
-	  && ((type_function_oldstyle(oldtype) && !olddecl->definition)
-	      || (type_function_oldstyle(newtype) && !newdecl->definition)))
-	{
-	  /* Classify the problem further.  */
-	  if (type_function_varargs(newtype) || type_function_varargs(oldtype))
-	    {
-	      message("A parameter list with an ellipsis can't match");
-	      message("an empty parameter name list declaration.");
-	    }
-	  else
-	    {
-	      typelist_scanner scanargs;
-	      type t;
-	      typelist args = type_function_arguments(oldtype);
+          && type_compatible(type_function_return_type(oldtype),
+                             type_function_return_type(newtype))
+          && ((type_function_oldstyle(oldtype) && !olddecl->definition)
+              || (type_function_oldstyle(newtype) && !newdecl->definition)))
+        {
+          /* Classify the problem further.  */
+          if (type_function_varargs(newtype) || type_function_varargs(oldtype))
+            {
+              message("A parameter list with an ellipsis can't match");
+              message("an empty parameter name list declaration.");
+            }
+          else
+            {
+              typelist_scanner scanargs;
+              type t;
+              typelist args = type_function_arguments(oldtype);
 
-	      if (!args)
-		args = type_function_arguments(newtype);
+              if (!args)
+                args = type_function_arguments(newtype);
 
-	      typelist_scan(args, &scanargs);
-	      while ((t = typelist_next(&scanargs)))
-		if (!type_self_promoting(t))
-		  {
-		    message("An argument type that has a default promotion");
-		    message("can't match an empty parameter name list declaration.");
-		    break;
-		  }
-	    }
-	}
+              typelist_scan(args, &scanargs);
+              while ((t = typelist_next(&scanargs)))
+                if (!type_self_promoting(t))
+                  {
+                    message("An argument type that has a default promotion");
+                    message("can't match an empty parameter name list declaration.");
+                    break;
+                  }
+            }
+        }
     }
   else
     {
       errmsg = redeclaration_error_message(newdecl, olddecl, newinitialised);
       if (errmsg)
-	{
-	  error_with_decl(newdecl->ast, errmsg, decl_printname(olddecl));
-	  previous_message = error_with_decl;
-	}
+        {
+          error_with_decl(newdecl->ast, errmsg, decl_printname(olddecl));
+          previous_message = error_with_decl;
+        }
       else if (newdecl->kind == decl_typedef &&
-	       (olddecl->in_system_header || newdecl->in_system_header))
-	{
-	  warning_with_decl(newdecl->ast, "redefinition of `%s'", decl_printname(olddecl));
-	  previous_message = warning_with_decl;
-	}
+               (olddecl->in_system_header || newdecl->in_system_header))
+        {
+          warning_with_decl(newdecl->ast, "redefinition of `%s'", decl_printname(olddecl));
+          previous_message = warning_with_decl;
+        }
       else if (olddecl->kind == decl_function
-	       && olddecl->oldstyle_args
-	       && !type_function_oldstyle(newtype))
-	{
-	  int nargs;
-	  typelist_scanner oldparms, newparms;
-	  /* Prototype decl follows defn w/o prototype.  */
+               && olddecl->oldstyle_args
+               && !type_function_oldstyle(newtype))
+        {
+          int nargs;
+          typelist_scanner oldparms, newparms;
+          /* Prototype decl follows defn w/o prototype.  */
 
-	  typelist_scan(olddecl->oldstyle_args, &oldparms);
-	  typelist_scan(type_function_arguments(newtype), &newparms);
-	  nargs = 1;
-	  errmsg = NULL;
-	  for (;;)
-	    {
-	      type oldparm = typelist_next(&oldparms);
-	      type newparm = typelist_next(&newparms);
+          typelist_scan(olddecl->oldstyle_args, &oldparms);
+          typelist_scan(type_function_arguments(newtype), &newparms);
+          nargs = 1;
+          errmsg = NULL;
+          for (;;)
+            {
+              type oldparm = typelist_next(&oldparms);
+              type newparm = typelist_next(&newparms);
 
-	      if (!oldparm && !newparm)
-		break;
+              if (!oldparm && !newparm)
+                break;
 
-	      if (!oldparm || !newparm)
-		{
-		  errmsg = "prototype for `%s' follows and number of arguments";
-		  break;
-		}
-	      /* Type for passing arg must be consistent
-		 with that declared for the arg.  */
-	      if (!type_compatible(oldparm, newparm)
-		  /* If -traditional, allow `unsigned int' instead of `int'
-		     in the prototype.  */
-		  && !(flag_traditional
-		       && type_equal_unqualified(oldparm, int_type)
-		       && type_equal_unqualified(newparm, unsigned_int_type)))
-		{
-		  errmsg = "prototype for `%s' follows and argument %d";
-		  break;
-		}
-	      nargs++;
-	    }
-	  if (errmsg)
-	    {
-	      warning_or_error_with_decl(olddecl->islimbo, newdecl->ast,
-					 errmsg, decl_printname(olddecl), nargs);
-	      warning_or_error_with_decl(olddecl->islimbo, olddecl->ast,
-			      "doesn't match non-prototype definition here");
-	    }
-	  else
-	    {
-	      warning_with_decl(newdecl->ast, "prototype for `%s' follows",
-				decl_printname(olddecl));
-	      warning_with_decl(olddecl->ast, "non-prototype definition here");
-	    }
-	}
+              if (!oldparm || !newparm)
+                {
+                  errmsg = "prototype for `%s' follows and number of arguments";
+                  break;
+                }
+              /* Type for passing arg must be consistent
+                 with that declared for the arg.  */
+              if (!type_compatible(oldparm, newparm)
+                  /* If -traditional, allow `unsigned int' instead of `int'
+                     in the prototype.  */
+                  && !(flag_traditional
+                       && type_equal_unqualified(oldparm, int_type)
+                       && type_equal_unqualified(newparm, unsigned_int_type)))
+                {
+                  errmsg = "prototype for `%s' follows and argument %d";
+                  break;
+                }
+              nargs++;
+            }
+          if (errmsg)
+            {
+              warning_or_error_with_decl(olddecl->islimbo, newdecl->ast,
+                                         errmsg, decl_printname(olddecl), nargs);
+              warning_or_error_with_decl(olddecl->islimbo, olddecl->ast,
+                              "doesn't match non-prototype definition here");
+            }
+          else
+            {
+              warning_with_decl(newdecl->ast, "prototype for `%s' follows",
+                                decl_printname(olddecl));
+              warning_with_decl(olddecl->ast, "non-prototype definition here");
+            }
+        }
       /* Warn about mismatches in various flags. */
       else if (newdecl->kind == decl_function)
-	{
-	  /* Warn if function is now inline
-	     but was previously declared not inline and has been called. */
-	  if (!olddecl->isinline && newdecl->isinline)
-	    {
-	      if (olddecl->isused)
-		{
-		  warning("`%s' declared inline after being called", decl_printname(olddecl));
-		  previous_message = warning_with_decl;
-		}
-	      if (olddecl->definition)
-		{
-		  warning("`%s' declared inline after its definition", decl_printname(olddecl));
-		  previous_message = warning_with_decl;
-		}
-	    }
+        {
+          /* Warn if function is now inline
+             but was previously declared not inline and has been called. */
+          if (!olddecl->isinline && newdecl->isinline)
+            {
+              if (olddecl->isused)
+                {
+                  warning("`%s' declared inline after being called", decl_printname(olddecl));
+                  previous_message = warning_with_decl;
+                }
+              if (olddecl->definition)
+                {
+                  warning("`%s' declared inline after its definition", decl_printname(olddecl));
+                  previous_message = warning_with_decl;
+                }
+            }
 
-	  /* Warn for static following external */
-	  if (newdecl->ftype == function_static &&
-	      olddecl->ftype == function_implicit)
-	    {
-	      pedwarn("`%s' was declared implicitly `extern' and later `static'", decl_printname(olddecl));
-	      previous_message = pedwarn_with_decl;
-	    }
-	  else if (newdecl->ftype == function_static &&
-		   olddecl->ftype == function_normal)
-	    {
-	      pedwarn("static declaration for `%s' follows non-static", decl_printname(olddecl));
-	      previous_message = pedwarn_with_decl;
-	    }
+          /* Warn for static following external */
+          if (newdecl->ftype == function_static &&
+              olddecl->ftype == function_implicit)
+            {
+              pedwarn("`%s' was declared implicitly `extern' and later `static'", decl_printname(olddecl));
+              previous_message = pedwarn_with_decl;
+            }
+          else if (newdecl->ftype == function_static &&
+                   olddecl->ftype == function_normal)
+            {
+              pedwarn("static declaration for `%s' follows non-static", decl_printname(olddecl));
+              previous_message = pedwarn_with_decl;
+            }
 
-	  /* Warn for mismatched async */
-	  if (newdecl->async != olddecl->async)
-	    {
-	      error("`%s': async mismatch with declaration",
-		    decl_printname(olddecl));
-	      previous_message = error_with_decl;
-	    }
-	}
+          /* Warn for mismatched async */
+          if (newdecl->async != olddecl->async)
+            {
+              error("`%s': async mismatch with declaration",
+                    decl_printname(olddecl));
+              previous_message = error_with_decl;
+            }
+        }
       else if (newdecl->kind == decl_variable)
-	{
-	  /* If pedantic, warn when static declaration follows a non-static
-	     declaration. */
-	  if (pedantic &&
-	      olddecl->isexternalscope && !newdecl->isexternalscope)
-	    {
-	      pedwarn("static declaration for `%s' follows non-static", decl_printname(olddecl));
-	      previous_message = pedwarn_with_decl;
-	    }
-	  /* Warn when const declaration follows a non-const declaration */
-	  if (!type_const(oldtype) && type_const(newtype))
-	    warning("const declaration for `%s' follows non-const", decl_printname(olddecl));
-	  /* These bits are logically part of the type, for variables. */
-	  else if (pedantic && 
-		   (type_const(oldtype) != type_const(newtype)
-		    || type_volatile(oldtype) != type_volatile(newtype)))
-	    {
-	      pedwarn("type qualifiers for `%s' conflict with previous decl",
-		      decl_printname(olddecl));
-	      previous_message = pedwarn_with_decl;
-	    }
-	}
+        {
+          /* If pedantic, warn when static declaration follows a non-static
+             declaration. */
+          if (pedantic &&
+              olddecl->isexternalscope && !newdecl->isexternalscope)
+            {
+              pedwarn("static declaration for `%s' follows non-static", decl_printname(olddecl));
+              previous_message = pedwarn_with_decl;
+            }
+          /* Warn when const declaration follows a non-const declaration */
+          if (!type_const(oldtype) && type_const(newtype))
+            warning("const declaration for `%s' follows non-const", decl_printname(olddecl));
+          /* These bits are logically part of the type, for variables. */
+          else if (pedantic && 
+                   (type_const(oldtype) != type_const(newtype)
+                    || type_volatile(oldtype) != type_volatile(newtype)))
+            {
+              pedwarn("type qualifiers for `%s' conflict with previous decl",
+                      decl_printname(olddecl));
+              previous_message = pedwarn_with_decl;
+            }
+        }
     }
 
   /* Optionally warn about more than one declaration for the same name.  */
@@ -1537,10 +1537,10 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
       /* newdecl must be a reference to something at file scope */
       assert(newdecl->isfilescoperef && !newdecl->needsmemory);
       assert(!(newdecl->kind == decl_variable &&
-	       newdecl->vtype == variable_static));
+               newdecl->vtype == variable_static));
       assert(!(newdecl->kind == decl_function &&
-	       (newdecl->ftype == function_implicit ||
-		newdecl->ftype == function_nested)));
+               (newdecl->ftype == function_implicit ||
+                newdecl->ftype == function_nested)));
 
       /* We copy some info over to the newdecl which will shadow olddecl */
       newdecl->shadowed = olddecl;
@@ -1549,7 +1549,7 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
       newdecl->isexterninline = olddecl->isexterninline;
       newdecl->oldstyle_args = olddecl->oldstyle_args;
       if (olddecl->in_system_header)
-	newdecl->in_system_header = TRUE;
+        newdecl->in_system_header = TRUE;
 
       newdecl->isexternalscope = olddecl->isexternalscope;
 
@@ -1590,22 +1590,22 @@ int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
   if (newdecl->kind == decl_function)
     {
       if (olddecl->ftype != function_static)
-	olddecl->ftype = newdecl->ftype;
+        olddecl->ftype = newdecl->ftype;
 
       /* Also set isexterninline correctly */
       if ((olddecl->definition && !olddecl->isexterninline) ||
-	  (newdecl->definition && !newdecl->isexterninline))
-	olddecl->isexterninline = FALSE;
+          (newdecl->definition && !newdecl->isexterninline))
+        olddecl->isexterninline = FALSE;
       else if (olddecl->isexterninline || newdecl->isexterninline)
-	olddecl->isexterninline = TRUE;
+        olddecl->isexterninline = TRUE;
       /* the last case is 2 non-inline externs, so isexterninline is correct */
     }
   else if (newdecl->kind == decl_variable)
     {
       /* static overrides extern (the combinations with register
-	 are errors anyway) */ 
+         are errors anyway) */ 
       if (olddecl->vtype != variable_static)
-	olddecl->vtype = variable_static;
+        olddecl->vtype = variable_static;
     }
 
   olddecl->in_system_header = newdecl->in_system_header =
@@ -1630,8 +1630,8 @@ bool is_doublecharstar(type t)
 }
 
 void check_function(data_declaration dd, declaration fd, int class,
-		    scflags scf, const char *name, type function_type,
-		    bool nested, bool isdeclaration, bool defaulted_int)
+                    scflags scf, const char *name, type function_type,
+                    bool nested, bool isdeclaration, bool defaulted_int)
 {
   type return_type, actual_function_type;
 
@@ -1668,52 +1668,52 @@ void check_function(data_declaration dd, declaration fd, int class,
   if (current.language == l_c && warn_main && !strcmp("main", name) && !nested)
     {
       if (!type_equal_unqualified(return_type, int_type))
-	pedwarn("return type of `%s' is not `int'", name);
+        pedwarn("return type of `%s' is not `int'", name);
 
       /* Just being "bug"-compatible w/ GCC here */
       if (!type_function_oldstyle(function_type))
-	{
-	  typelist_scanner scanargs;
-	  type argtype;
-	  int argct = 0;
+        {
+          typelist_scanner scanargs;
+          type argtype;
+          int argct = 0;
 
-	  typelist_scan(type_function_arguments(function_type), &scanargs);
-	  while ((argtype = typelist_next(&scanargs)))
-	    {
-	      ++argct;
-	      switch (argct)
-		{
-		case 1:
-		  if (!type_equal_unqualified(argtype, int_type))
-		    pedwarn("first argument of `%s' should be `int'", name);
-		  break;
+          typelist_scan(type_function_arguments(function_type), &scanargs);
+          while ((argtype = typelist_next(&scanargs)))
+            {
+              ++argct;
+              switch (argct)
+                {
+                case 1:
+                  if (!type_equal_unqualified(argtype, int_type))
+                    pedwarn("first argument of `%s' should be `int'", name);
+                  break;
 
-		case 2:
-		  if (!is_doublecharstar(argtype))
-		    pedwarn("second argument of `%s' should be `char **'",
-			    name);
-		  break;
+                case 2:
+                  if (!is_doublecharstar(argtype))
+                    pedwarn("second argument of `%s' should be `char **'",
+                            name);
+                  break;
 
-		case 3:
-		  if (!is_doublecharstar(argtype))
-		    pedwarn("third argument of `%s' should probably be `char **'",
-			    name);
-		  break;
-		}
-	    }
+                case 3:
+                  if (!is_doublecharstar(argtype))
+                    pedwarn("third argument of `%s' should probably be `char **'",
+                            name);
+                  break;
+                }
+            }
 
-	  /* It is intentional that this message does not mention the third
-	     argument, which is warned for only pedantically, because it's
-	     blessed by mention in an appendix of the standard. */
-	  if (argct > 0 && (argct < 2 || argct > 3))
-	    pedwarn("`%s' takes only zero or two arguments", name);
+          /* It is intentional that this message does not mention the third
+             argument, which is warned for only pedantically, because it's
+             blessed by mention in an appendix of the standard. */
+          if (argct > 0 && (argct < 2 || argct > 3))
+            pedwarn("`%s' takes only zero or two arguments", name);
 
-	  if (argct == 3 && pedantic)
-	    pedwarn("third argument of `%s' is deprecated", name);
+          if (argct == 3 && pedantic)
+            pedwarn("third argument of `%s' is deprecated", name);
 
-	  if (class == RID_STATIC)
-	    pedwarn("`%s' is normally a non-static function", name);
-	}
+          if (class == RID_STATIC)
+            pedwarn("`%s' is normally a non-static function", name);
+        }
     }
 
   init_data_declaration(dd, fd, name, function_type);
@@ -1740,9 +1740,9 @@ void check_function(data_declaration dd, declaration fd, int class,
   if (scf & scf_async)
     {
       if (dd->ftype == function_command || dd->ftype == function_event)
-	dd->async = TRUE;
+        dd->async = TRUE;
       else
-	error("`async' is for commands and events only");
+        error("`async' is for commands and events only");
     }
 }
 
@@ -1753,7 +1753,7 @@ data_declaration declare_string(const char *name, cstring value, bool wide)
   type value_type = make_array_type(wide ? wchar_type : char_type, expr_l);
 
   init_data_declaration(&tempdecl, new_error_decl(parse_region, dummy_location),
-			name, value_type);
+                        name, value_type);
   tempdecl.kind = decl_magic_string;
   tempdecl.needsmemory = TRUE;
   tempdecl.in_system_header = TRUE;
@@ -1781,7 +1781,7 @@ data_declaration declare_builtin_type(const char *name, type t)
   struct data_declaration tempdecl;
 
   init_data_declaration(&tempdecl, new_error_decl(parse_region, dummy_location),
-			name, t);
+                        name, t);
   tempdecl.kind = decl_typedef;
   tempdecl.in_system_header = TRUE;
 
@@ -1791,7 +1791,7 @@ data_declaration declare_builtin_type(const char *name, type t)
 static tag_declaration make_anonymous_struct(void)
 {
   tag_ref tref = newkind_tag_ref(parse_region, kind_struct_ref, dummy_location,
-				 NULL, NULL, NULL, TRUE);
+                                 NULL, NULL, NULL, TRUE);
 
   return declare_global_tag(tref);
 }
@@ -1808,7 +1808,7 @@ static data_declaration declare_builtin(const char *name, data_kind kind, type t
   struct data_declaration tempdecl;
 
   init_data_declaration(&tempdecl, new_error_decl(parse_region, dummy_location),
-			name, t);
+                        name, t);
   tempdecl.kind = kind;
   tempdecl.needsmemory = TRUE;
   tempdecl.in_system_header = TRUE;
@@ -1876,7 +1876,7 @@ static void detect_bogus_env(void)
   while (!current.function_decl && current.env->parm_level)
     {
       /* This should only be possible after a (parse) error. Ensure that
-	 we aren't confused... */
+         we aren't confused... */
       assert(errorcount > 0);
       poplevel();
     }
@@ -1888,7 +1888,7 @@ static void detect_bogus_env(void)
    Returns false in case of error.
    Sets current.function_decl to the declaration for this function */
 bool start_function(type_element elements, declarator d, attribute attribs,
-		    bool nested)
+                    bool nested)
 {
   int class;
   scflags scf;
@@ -1911,8 +1911,8 @@ bool start_function(type_element elements, declarator d, attribute attribs,
     error_assert(current.env->global_level && current.function_decl == NULL);
 
   parse_declarator(elements, d, FALSE, TRUE, &class, &scf,
-		   &intf, &name, &function_type, &defaulted_int, &fdeclarator,
-		   &extra_attr);
+                   &intf, &name, &function_type, &defaulted_int, &fdeclarator,
+                   &extra_attr);
 
   actual_function_type = type_generic(function_type) ?
     type_function_return_type(function_type) : function_type;
@@ -1923,7 +1923,7 @@ bool start_function(type_element elements, declarator d, attribute attribs,
   /* We don't set current.function_decl yet so that error messages do not
      say "In function <thisfunctioname>" as we're not "in" the function yet */
   fdecl = new_function_decl(parse_region, d->location, d, elements, attribs,
-			    NULL, NULL, current.function_decl, NULL);
+                            NULL, NULL, current.function_decl, NULL);
   fdecl->declared_type = function_type;
   fdecl->undeclared_variables = new_env(parse_region, NULL);
   fdecl->current_loop = NULL;
@@ -1931,7 +1931,7 @@ bool start_function(type_element elements, declarator d, attribute attribs,
   if (class == RID_AUTO)
     {
       if (pedantic || !nested)
-	pedwarn("function definition declared `auto'");
+        pedwarn("function definition declared `auto'");
       class = 0;
     }
   else if (class == RID_REGISTER)
@@ -1952,22 +1952,22 @@ bool start_function(type_element elements, declarator d, attribute attribs,
   else if ((class == RID_STATIC || scf & scf_inline) && nested)
     {
       if (pedantic)
-	pedwarn("invalid storage class for function `%s'", name);
+        pedwarn("invalid storage class for function `%s'", name);
       class = 0;
     }
   
   if (class == RID_COMMAND || class == RID_EVENT || class == RID_TASK)
     {
       if (nested)
-	{
-	  error("commands, events or tasks cannot be nested");
-	  class = 0;
-	}
+        {
+          error("commands, events or tasks cannot be nested");
+          class = 0;
+        }
       else if (current.language == l_c)
-	{
-	  error("commands, events or tasks not allowed in C files");
-	  class = 0;
-	}
+        {
+          error("commands, events or tasks not allowed in C files");
+          class = 0;
+        }
     }
 
   if (fdeclarator->gparms && !(class == RID_COMMAND || class == RID_EVENT))
@@ -1985,17 +1985,17 @@ bool start_function(type_element elements, declarator d, attribute attribs,
 
       /* Yuck */
       t = make_function_type(void_type,
-			     type_function_arguments(actual_function_type),
-			     type_function_varargs(actual_function_type),
-			     type_function_oldstyle(actual_function_type));
+                             type_function_arguments(actual_function_type),
+                             type_function_varargs(actual_function_type),
+                             type_function_oldstyle(actual_function_type));
       if (type_generic(function_type))
-	t = make_generic_type(t, type_function_arguments(function_type));
+        t = make_generic_type(t, type_function_arguments(function_type));
 
       function_type = qualify_type1(t, function_type);
     }
 
   check_function(&tempdecl, CAST(declaration, fdecl), class, scf,
-		 name, function_type, nested, FALSE, defaulted_int);
+                 name, function_type, nested, FALSE, defaulted_int);
   tempdecl.definition = tempdecl.ast;
   if (current.container)
     tempdecl.safe = current.container->safe;
@@ -2009,19 +2009,19 @@ bool start_function(type_element elements, declarator d, attribute attribs,
 
       old_decl = NULL;
       if (!iref || iref->kind != decl_interface_ref)
-	error("unknown interface `%s'", intf);
+        error("unknown interface `%s'", intf);
       else
-	{
-	  old_decl = interface_lookup(iref, name);
-	  if (!old_decl)
-	    error("`%s' is not in interface `%s'", name, intf);
-	}
+        {
+          old_decl = interface_lookup(iref, name);
+          if (!old_decl)
+            error("`%s' is not in interface `%s'", name, intf);
+        }
     }
   else if (class == RID_COMMAND || class == RID_EVENT)
     {
       old_decl = lookup_id(name, FALSE);
       if (!old_decl)
-	error("unknown command or event `%s'", name);
+        error("unknown command or event `%s'", name);
     }
   else
     old_decl = lookup_id(name, !tempdecl.Cname);
@@ -2029,16 +2029,16 @@ bool start_function(type_element elements, declarator d, attribute attribs,
   if (old_decl)
     {
       if (((class == RID_COMMAND || class == RID_EVENT) && !old_decl->defined)
-	  ^ ((scf & scf_default) != 0))
-	{
-	  if (scf & scf_default)
-	    {
-	      error("`%s' is defined, not used, in this component", name);
-	      error("(default implementations are only for used commands or events)");
-	    }
-	  else
-	    error("`%s' is used, not defined, in this component", name);
-	}
+          ^ ((scf & scf_default) != 0))
+        {
+          if (scf & scf_default)
+            {
+              error("`%s' is defined, not used, in this component", name);
+              error("(default implementations are only for used commands or events)");
+            }
+          else
+            error("`%s' is used, not defined, in this component", name);
+        }
     }
   else
     scf &= ~scf_default;
@@ -2054,22 +2054,22 @@ bool start_function(type_element elements, declarator d, attribute attribs,
     warning("function declaration isn't a prototype");
   /* Optionally warn of any global def with no previous prototype.  */
   else if (warn_missing_prototypes
-	   && normal_function && !old_decl_has_prototype
-	   && strcmp("main", name))
+           && normal_function && !old_decl_has_prototype
+           && strcmp("main", name))
     warning("no previous prototype for `%s'", name);
   /* Optionally warn of any def with no previous prototype
      if the function has already been used.  */
   else if (warn_missing_prototypes
-	   && old_decl && old_decl->ftype == function_implicit)
+           && old_decl && old_decl->ftype == function_implicit)
     warning("`%s' was used with no prototype before its definition", name);
   /* Optionally warn of any global def with no previous declaration.  */
   else if (warn_missing_declarations
-	   && normal_function && !old_decl && strcmp("main", name))
+           && normal_function && !old_decl && strcmp("main", name))
     warning("no previous declaration for `%s'", name);
   /* Optionally warn of any def with no previous declaration
      if the function has already been used.  */
   else if (warn_missing_declarations
-	   && old_decl && old_decl->ftype == function_implicit)
+           && old_decl && old_decl->ftype == function_implicit)
     warning("`%s' was used with no declaration before its definition", name);
 
   /* If return types match and old declaraton has a prototype and new
@@ -2077,13 +2077,13 @@ bool start_function(type_element elements, declarator d, attribute attribs,
      in store_parm_decls. */
   if (old_decl_has_prototype && type_function_oldstyle(function_type) &&
       type_compatible(type_function_return_type(old_decl->type),
-		      type_function_return_type(function_type)))
+                      type_function_return_type(function_type)))
     {
       function_type = qualify_type1
-	(make_function_type(type_function_return_type(function_type),
-			    type_function_arguments(old_decl->type),
-			    type_function_varargs(old_decl->type),
-			    FALSE), old_decl->type);
+        (make_function_type(type_function_return_type(function_type),
+                            type_function_arguments(old_decl->type),
+                            type_function_varargs(old_decl->type),
+                            FALSE), old_decl->type);
 
       tempdecl.type = function_type;
     }
@@ -2099,7 +2099,7 @@ bool start_function(type_element elements, declarator d, attribute attribs,
 
   fdecl->base_labels = fdecl->scoped_labels =
     new_env(parse_region,
-	    current.function_decl ? current.function_decl->scoped_labels : NULL);
+            current.function_decl ? current.function_decl->scoped_labels : NULL);
   fdecl->ddecl = ddecl;
   fdecl->fdeclarator = fdeclarator;
 
@@ -2122,10 +2122,10 @@ bool start_function(type_element elements, declarator d, attribute attribs,
       data_declaration iddecl = idval;
 
       if (iddecl->kind == decl_variable)
-	{
-	  assert(iddecl->isparameter);
-	  iddecl->id = current.function_decl->nlocals++;
-	}
+        {
+          assert(iddecl->isparameter);
+          iddecl->id = current.function_decl->nlocals++;
+        }
     }
 
   return TRUE;
@@ -2149,7 +2149,7 @@ data_declaration implicitly_declare(identifier fnid)
     CAST(declaration, new_implicit_decl(parse_region, fnid->location, fnid));
 
   init_data_declaration(&tempdecl, pseudo_ast,
-			fnid->cstring.data, implicit_function_type);
+                        fnid->cstring.data, implicit_function_type);
   tempdecl.kind = decl_function;
   tempdecl.isexternalscope = TRUE;
   tempdecl.isfilescoperef = TRUE;
@@ -2170,12 +2170,12 @@ void store_parm_decls(declaration old_parms)
   if (!oldstyle_function(current.function_decl))
     {
       /* This case is when the function was defined with an ANSI prototype.
-	 The parms already have decls, so we need not do anything here
-	 except record them as in effect
-	 and complain if any redundant old-style parm decls were written.  */
+         The parms already have decls, so we need not do anything here
+         except record them as in effect
+         and complain if any redundant old-style parm decls were written.  */
       if (old_parms)
-	error_with_decl(CAST(declaration, current.function_decl),
-			"parm types given both in parmlist and separately");
+        error_with_decl(CAST(declaration, current.function_decl),
+                        "parm types given both in parmlist and separately");
     }
   else
     {
@@ -2183,21 +2183,21 @@ void store_parm_decls(declaration old_parms)
 
       current.function_decl->old_parms = old_parms;
       /* Need to either:
-	 - compare arg types to previous prototype
-	 - or build pseudo-prototype for this function
+         - compare arg types to previous prototype
+         - or build pseudo-prototype for this function
       */
       parms = CAST(oldidentifier_decl,
-		   current.function_decl->fdeclarator->parms);
+                   current.function_decl->fdeclarator->parms);
       scan_oldidentifier_decl (parm, parms)
-	/* If no declaration given, default to int.  */
-	if (parm->ddecl->type == void_type)
-	  {
-	    parm->ddecl->type = int_type;
-	    if (extra_warnings)
-	      warning_with_decl(CAST(declaration, parm),
-				"type of `%s' defaults to `int'",
-				parm->cstring.data);
-	  }
+        /* If no declaration given, default to int.  */
+        if (parm->ddecl->type == void_type)
+          {
+            parm->ddecl->type = int_type;
+            if (extra_warnings)
+              warning_with_decl(CAST(declaration, parm),
+                                "type of `%s' defaults to `int'",
+                                parm->cstring.data);
+          }
     }
 
   /* Declare __FUNCTION__ and __PRETTY_FUNCTION__ for this function.  */
@@ -2254,17 +2254,17 @@ void declarator_name(declarator d, const char **oname, const char **iname)
   while (d)
     {
       switch (d->kind)
-	{
-	case kind_identifier_declarator:
-	  *oname = CAST(identifier_declarator, d)->cstring.data;
-	  return;
-	case kind_interface_ref_declarator:
-	  *iname = CAST(interface_ref_declarator, d)->word1->cstring.data;
-	  /* fall through */
-	default:
-	  d = CAST(nested_declarator, d)->declarator;
-	  break;
-	}
+        {
+        case kind_identifier_declarator:
+          *oname = CAST(identifier_declarator, d)->cstring.data;
+          return;
+        case kind_interface_ref_declarator:
+          *iname = CAST(interface_ref_declarator, d)->word1->cstring.data;
+          /* fall through */
+        default:
+          d = CAST(nested_declarator, d)->declarator;
+          break;
+        }
     }
 }
 
@@ -2285,7 +2285,7 @@ const char *nice_declarator_name(declarator d)
 }
 
 dd_list check_parameter(data_declaration dd,
-			type_element elements, variable_decl vd)
+                        type_element elements, variable_decl vd)
 /* Returns: Attributes found while parsing the declarator */
 {
   int class;
@@ -2296,8 +2296,8 @@ dd_list check_parameter(data_declaration dd,
   dd_list extra_attr;
 
   parse_declarator(elements, vd->declarator, FALSE, FALSE,
-		   &class, &scf, NULL, &name, &parm_type,
-		   &defaulted_int, NULL, &extra_attr);
+                   &class, &scf, NULL, &name, &parm_type,
+                   &defaulted_int, NULL, &extra_attr);
   vd->declared_type = parm_type;
   printname = name ? name : "type name";
 
@@ -2359,11 +2359,11 @@ static bool error_signature(type fntype)
    Returns the declaration for the variable.
 */
 declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
-		       bool initialised, attribute attributes)
+                       bool initialised, attribute attributes)
 {
   variable_decl vd = 
     new_variable_decl(parse_region, d->location, d, attributes, NULL,
-		      astmt, NULL);
+                      astmt, NULL);
   dd_list extra_attr;
   struct data_declaration tempdecl;
   data_declaration ddecl = NULL, old_decl;
@@ -2379,46 +2379,46 @@ declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
       handle_decl_dd_attributes(extra_attr, &tempdecl);
 
       if (type_void(tempdecl.type))
-	{
-	  error("parameter `%s' declared void", tempdecl.name);
-	  tempdecl.type = int_type;
-	}
+        {
+          error("parameter `%s' declared void", tempdecl.name);
+          tempdecl.type = int_type;
+        }
 
       /* Update environment for old-style declarations only if function
-	 doesn't have a prototype. We will report an error message later
-	 for arguments specified for functions with prototypes. */
+         doesn't have a prototype. We will report an error message later
+         for arguments specified for functions with prototypes. */
       if (oldstyle_function(current.function_decl))
-	{
-	  /* Traditionally, a parm declared float is actually a double.  */
-	  if (flag_traditional &&
-	      type_equal_unqualified(tempdecl.type, float_type))
-	    tempdecl.type = qualify_type1(double_type, tempdecl.type);
+        {
+          /* Traditionally, a parm declared float is actually a double.  */
+          if (flag_traditional &&
+              type_equal_unqualified(tempdecl.type, float_type))
+            tempdecl.type = qualify_type1(double_type, tempdecl.type);
 
-	  old_decl = lookup_id(tempdecl.name, TRUE);
+          old_decl = lookup_id(tempdecl.name, TRUE);
 
-	  if (old_decl && duplicate_decls(&tempdecl, old_decl, FALSE, FALSE))
-	    {
-	      /* Don't allow more than one "real" duplicate
-		 of a forward parm decl.  */
-	      ddecl = old_decl;
-	      ddecl->type = tempdecl.type;
-	      ddecl->ast = CAST(declaration, vd);
-	      ddecl->isused = TRUE;
-	    }
-	  else
-	    {
-	      error("declaration for parameter `%s' but no such parameter",
-		    tempdecl.name);
-	      ddecl = declare(current.env, &tempdecl, FALSE);
-	    }
-	}
+          if (old_decl && duplicate_decls(&tempdecl, old_decl, FALSE, FALSE))
+            {
+              /* Don't allow more than one "real" duplicate
+                 of a forward parm decl.  */
+              ddecl = old_decl;
+              ddecl->type = tempdecl.type;
+              ddecl->ast = CAST(declaration, vd);
+              ddecl->isused = TRUE;
+            }
+          else
+            {
+              error("declaration for parameter `%s' but no such parameter",
+                    tempdecl.name);
+              ddecl = declare(current.env, &tempdecl, FALSE);
+            }
+        }
       else
-	/* Make a dummy decl to keep everyone happy */
-	ddecl = declare(current.env, &tempdecl, FALSE);
+        /* Make a dummy decl to keep everyone happy */
+        ddecl = declare(current.env, &tempdecl, FALSE);
 
       if (initialised)
-	error("parameter `%s' is initialized",
-	      vd->ddecl ? vd->ddecl->name : "type name");
+        error("parameter `%s' is initialized",
+              vd->ddecl ? vd->ddecl->name : "type name");
     }
   else
     {
@@ -2431,56 +2431,56 @@ declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
       function_declarator fdeclarator = NULL;
 
       parse_declarator(elements, d, FALSE, FALSE,
-		       &class, &scf, NULL, &name, &var_type,
-		       &defaulted_int, &fdeclarator, &extra_attr);
+                       &class, &scf, NULL, &name, &var_type,
+                       &defaulted_int, &fdeclarator, &extra_attr);
       vd->declared_type = var_type;
       printname = name ? name : "type name";
 
       if (current.language == l_interface)
-	{
-	  if (!(type_command(var_type) || type_event(var_type)))
-	    {
-	      error("only commands and events can be defined in interfaces");
-	      class = RID_COMMAND;
-	      var_type = dummy_function_type;
-	      fdeclarator = dummy_function_declarator;
-	    }
-	}
+        {
+          if (!(type_command(var_type) || type_event(var_type)))
+            {
+              error("only commands and events can be defined in interfaces");
+              class = RID_COMMAND;
+              var_type = dummy_function_type;
+              fdeclarator = dummy_function_declarator;
+            }
+        }
       else if (current.language == l_component)
-	{
-	  if (type_command(var_type) || type_event(var_type))
-	    {
-	      if (current.spec_section == spec_normal)
-		error("commands/events must be provided or used");
-	    }
-	  else if (class == RID_TYPEDEF)
-	    {
-	      if (current.spec_section != spec_normal)
-		error("typedefs cannot be provided or used");
-	    }
-	  else
-	    {
-	      error("variables and functions cannot be declared in component specifications");
-	      var_type = error_type;
-	    }
-	}
+        {
+          if (type_command(var_type) || type_event(var_type))
+            {
+              if (current.spec_section == spec_normal)
+                error("commands/events must be provided or used");
+            }
+          else if (class == RID_TYPEDEF)
+            {
+              if (current.spec_section != spec_normal)
+                error("typedefs cannot be provided or used");
+            }
+          else
+            {
+              error("variables and functions cannot be declared in component specifications");
+              var_type = error_type;
+            }
+        }
       else if (current.language == l_implementation &&
-	       current.container->configuration)
-	{
-	  if (class != RID_TYPEDEF)
-	    error("only types and constants can be declared in configurations");
-	}
+               current.container->configuration)
+        {
+          if (class != RID_TYPEDEF)
+            error("only types and constants can be declared in configurations");
+        }
       else if (class == RID_COMMAND || class == RID_EVENT)
-	{
-	  if (current.language == l_implementation)
-	    error("commands or events can only be defined, not declared");
-	  else
-	    error("commands or events not allowed in C files");
-	  class = 0;
-	}
+        {
+          if (current.language == l_implementation)
+            error("commands or events can only be defined, not declared");
+          else
+            error("commands or events not allowed in C files");
+          class = 0;
+        }
 
       if (warn_implicit_int && defaulted_int && !type_function(var_type))
-	warning("type defaults to `int' in declaration of `%s'", printname);
+        warning("type defaults to `int' in declaration of `%s'", printname);
 
       init_data_declaration(&tempdecl, CAST(declaration, vd), name, var_type);
 
@@ -2488,146 +2488,146 @@ declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
 
       /* `extern' with initialization is invalid if not at top level.  */
       if (class == RID_EXTERN && initialised)
-	{
-	  if (current.env->global_level)
-	    warning("`%s' initialized and declared `extern'", printname);
-	  else
-	    error("`%s' has both `extern' and initializer", printname);
-	}
+        {
+          if (current.env->global_level)
+            warning("`%s' initialized and declared `extern'", printname);
+          else
+            error("`%s' has both `extern' and initializer", printname);
+        }
 
       if (class == RID_AUTO && current.env->global_level)
-	{
-	  error("top-level declaration of `%s' specifies `auto'", printname);
-	  class = 0;
-	}
+        {
+          error("top-level declaration of `%s' specifies `auto'", printname);
+          class = 0;
+        }
 
       if (class == RID_TYPEDEF)
-	{
-	  /* typedef foo = bar  means give foo the same type as bar.
-	     We haven't parsed bar yet, so `finish_decl' will fix that up.
-	     Any other case of an initialization in a TYPE_DECL is an error. */
-	  if (initialised && (pedantic || elements->next))
-	    error("typedef `%s' is initialized", printname);
+        {
+          /* typedef foo = bar  means give foo the same type as bar.
+             We haven't parsed bar yet, so `finish_decl' will fix that up.
+             Any other case of an initialization in a TYPE_DECL is an error. */
+          if (initialised && (pedantic || elements->next))
+            error("typedef `%s' is initialized", printname);
 
-	  tempdecl.kind = decl_typedef;
-	  tempdecl.definition = tempdecl.ast;
-	  tempdecl.isexternalscope = FALSE;
-	  tempdecl.isfilescoperef = FALSE;
-	  tempdecl.needsmemory = FALSE;
+          tempdecl.kind = decl_typedef;
+          tempdecl.definition = tempdecl.ast;
+          tempdecl.isexternalscope = FALSE;
+          tempdecl.isfilescoperef = FALSE;
+          tempdecl.needsmemory = FALSE;
 
-	  /* XXX: should give errors for silly values of scf
-	     (but gcc doesn't even complain about
-	     inline typedef int foo;) */
-	}
+          /* XXX: should give errors for silly values of scf
+             (but gcc doesn't even complain about
+             inline typedef int foo;) */
+        }
       else if (type_functional(var_type) || type_generic(var_type))
-	{
-	  /* Note: type_generic here can only be for generic functions
-	     (generic interfaces only show up in components), and use
-	     declare_interface_ref */
-	  bool nested = !current.env->global_level && class == RID_AUTO;
+        {
+          /* Note: type_generic here can only be for generic functions
+             (generic interfaces only show up in components), and use
+             declare_interface_ref */
+          bool nested = !current.env->global_level && class == RID_AUTO;
 
-	  if (initialised)
-	    error("function `%s' is initialized like a variable",
-		  printname);
+          if (initialised)
+            error("function `%s' is initialized like a variable",
+                  printname);
 
-	  if (class == RID_AUTO && pedantic)
-	    pedwarn("invalid storage class for function `%s'", name);
-	  if (class == RID_REGISTER)
-	    {
-	      error("invalid storage class for function `%s'", name);
-	      class = 0;
-	    }
-	  /* Function declaration not at top level.
-	     Storage classes other than `extern' are not allowed
-	     and `extern' makes no difference.  */
-	  if (!current.env->global_level && pedantic
-	      && (class == RID_STATIC || class == RID_INLINE))
-	    pedwarn("invalid storage class for function `%s'", name);
+          if (class == RID_AUTO && pedantic)
+            pedwarn("invalid storage class for function `%s'", name);
+          if (class == RID_REGISTER)
+            {
+              error("invalid storage class for function `%s'", name);
+              class = 0;
+            }
+          /* Function declaration not at top level.
+             Storage classes other than `extern' are not allowed
+             and `extern' makes no difference.  */
+          if (!current.env->global_level && pedantic
+              && (class == RID_STATIC || class == RID_INLINE))
+            pedwarn("invalid storage class for function `%s'", name);
 
-	  if (fdeclarator && fdeclarator->gparms)
-	    {
-	      if (current.language == l_interface)
-		error("generic parameters not allowed in interfaces");
-	      else if (!(class == RID_COMMAND || class == RID_EVENT))
-		error("generic parameters not allowed on functions");
-	    }
+          if (fdeclarator && fdeclarator->gparms)
+            {
+              if (current.language == l_interface)
+                error("generic parameters not allowed in interfaces");
+              else if (!(class == RID_COMMAND || class == RID_EVENT))
+                error("generic parameters not allowed on functions");
+            }
 
-	  if ((type_command(var_type) || type_event(var_type)) &&
-	      type_function_varargs(var_type) && !error_signature(var_type))
-	    error("varargs commands and events are not supported");
+          if ((type_command(var_type) || type_event(var_type)) &&
+              type_function_varargs(var_type) && !error_signature(var_type))
+            error("varargs commands and events are not supported");
 
-	  check_function(&tempdecl, CAST(declaration, vd), class, scf,
-			 name, var_type, nested, TRUE, defaulted_int);
-	}
+          check_function(&tempdecl, CAST(declaration, vd), class, scf,
+                         name, var_type, nested, TRUE, defaulted_int);
+        }
       else
-	{
-	  int extern_ref = !initialised && class == RID_EXTERN;
+        {
+          int extern_ref = !initialised && class == RID_EXTERN;
 
-	  if (type_void(var_type) &&
-	      !(class == RID_EXTERN ||
-		(current.env->global_level &&
-		 !(class == RID_STATIC || class == RID_REGISTER))))
-	    {
-	      error("variable `%s' declared void", printname);
-	      var_type = int_type;
-	    }
+          if (type_void(var_type) &&
+              !(class == RID_EXTERN ||
+                (current.env->global_level &&
+                 !(class == RID_STATIC || class == RID_REGISTER))))
+            {
+              error("variable `%s' declared void", printname);
+              var_type = int_type;
+            }
 
-	  /* It's a variable.  */
-	  check_variable_scflags(scf, d->location, "variable", printname);
+          /* It's a variable.  */
+          check_variable_scflags(scf, d->location, "variable", printname);
 #if 0
-	  /* Don't allow initializations for incomplete types
-	     except for arrays which might be completed by the initialization.  */
-	  if (TYPE_SIZE (TREE_TYPE (decl)) != 0)
-	    {
-	      /* A complete type is ok if size is fixed.  */
+          /* Don't allow initializations for incomplete types
+             except for arrays which might be completed by the initialization.  */
+          if (TYPE_SIZE (TREE_TYPE (decl)) != 0)
+            {
+              /* A complete type is ok if size is fixed.  */
 
-	      if (TREE_CODE (TYPE_SIZE (TREE_TYPE (decl))) != INTEGER_CST
-		  || C_DECL_VARIABLE_SIZE (decl))
-		{
-		  error ("variable-sized object may not be initialized");
-		  initialised = 0;
-		}
-	    }
-	  else if (TREE_CODE (TREE_TYPE (decl)) != ARRAY_TYPE)
-	    {
-	      error ("variable `%s' has initializer but incomplete type",
-		     IDENTIFIER_POINTER (DECL_NAME (decl)));
-	      initialised = 0;
-	    }
-	  else if (TYPE_SIZE (TREE_TYPE (TREE_TYPE (decl))) == 0)
-	    {
-	      error ("elements of array `%s' have incomplete type",
-		     IDENTIFIER_POINTER (DECL_NAME (decl)));
-	      initialised = 0;
-	    }
+              if (TREE_CODE (TYPE_SIZE (TREE_TYPE (decl))) != INTEGER_CST
+                  || C_DECL_VARIABLE_SIZE (decl))
+                {
+                  error ("variable-sized object may not be initialized");
+                  initialised = 0;
+                }
+            }
+          else if (TREE_CODE (TREE_TYPE (decl)) != ARRAY_TYPE)
+            {
+              error ("variable `%s' has initializer but incomplete type",
+                     IDENTIFIER_POINTER (DECL_NAME (decl)));
+              initialised = 0;
+            }
+          else if (TYPE_SIZE (TREE_TYPE (TREE_TYPE (decl))) == 0)
+            {
+              error ("elements of array `%s' have incomplete type",
+                     IDENTIFIER_POINTER (DECL_NAME (decl)));
+              initialised = 0;
+            }
 #endif
-	  tempdecl.kind = decl_variable;
-	  tempdecl.vtype =
-	    class == RID_REGISTER ? variable_register :
-	    class == RID_STATIC ? variable_static :
-	    variable_normal;
-	  tempdecl.isfilescoperef = extern_ref;
-	  if (!extern_ref)
-	    tempdecl.definition = tempdecl.ast;
-	  if (current.env->global_level)
-	    {
-	      tempdecl.isexternalscope =
-		class != RID_STATIC && class != RID_REGISTER;
-	      tempdecl.needsmemory = !extern_ref;
-	      tempdecl.islocal = FALSE;
-	    }
-	  else
-	    {
-	      tempdecl.isexternalscope = extern_ref;
-	      tempdecl.needsmemory = class == RID_STATIC;
-	      tempdecl.islocal = !(extern_ref || class == RID_STATIC);
-	    }
-	  tempdecl.norace = (scf & scf_norace) != 0;
-	}
+          tempdecl.kind = decl_variable;
+          tempdecl.vtype =
+            class == RID_REGISTER ? variable_register :
+            class == RID_STATIC ? variable_static :
+            variable_normal;
+          tempdecl.isfilescoperef = extern_ref;
+          if (!extern_ref)
+            tempdecl.definition = tempdecl.ast;
+          if (current.env->global_level)
+            {
+              tempdecl.isexternalscope =
+                class != RID_STATIC && class != RID_REGISTER;
+              tempdecl.needsmemory = !extern_ref;
+              tempdecl.islocal = FALSE;
+            }
+          else
+            {
+              tempdecl.isexternalscope = extern_ref;
+              tempdecl.needsmemory = class == RID_STATIC;
+              tempdecl.islocal = !(extern_ref || class == RID_STATIC);
+            }
+          tempdecl.norace = (scf & scf_norace) != 0;
+        }
 
       if (warn_nested_externs && tempdecl.isfilescoperef &&
-	  !current.env->global_level && !tempdecl.in_system_header)
-	warning("nested extern declaration of `%s'", printname);
+          !current.env->global_level && !tempdecl.in_system_header)
+        warning("nested extern declaration of `%s'", printname);
 
       handle_decl_attributes(attributes, &tempdecl);
       handle_decl_dd_attributes(extra_attr, &tempdecl);
@@ -2635,29 +2635,29 @@ declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
       old_decl = lookup_id(name, !tempdecl.Cname);
 
       if ((current.language == l_interface || current.language == l_component)
-	  && current.env->global_level)
-	{
-	  if (old_decl)
-	    error("redefinition of `%s'", printname);
-	  old_decl = NULL;
-	}
+          && current.env->global_level)
+        {
+          if (old_decl)
+            error("redefinition of `%s'", printname);
+          old_decl = NULL;
+        }
       else if (!old_decl && tempdecl.isfilescoperef)
-	{
-	  /* Check the global environment if declaring something with file
-	     scope */
-	  old_decl = lookup_global_id(name);
-	  /* global typedefs don't count */
-	  if (old_decl && old_decl->kind == decl_typedef)
-	    old_decl = NULL;
-	  if (old_decl)
-	    different_binding_level = TRUE;
-	}
+        {
+          /* Check the global environment if declaring something with file
+             scope */
+          old_decl = lookup_global_id(name);
+          /* global typedefs don't count */
+          if (old_decl && old_decl->kind == decl_typedef)
+            old_decl = NULL;
+          if (old_decl)
+            different_binding_level = TRUE;
+        }
 
       if (old_decl &&
-	  duplicate_decls(&tempdecl, old_decl, different_binding_level, initialised))
-	ddecl = old_decl;
+          duplicate_decls(&tempdecl, old_decl, different_binding_level, initialised))
+        ddecl = old_decl;
       else
-	ddecl = declare(current.env, &tempdecl, FALSE);
+        ddecl = declare(current.env, &tempdecl, FALSE);
 
       ddecl->defined = current.spec_section == spec_provides;
     }
@@ -2690,49 +2690,49 @@ declaration finish_decl(declaration decl, expression init)
   if (init)
     {
       if (dd->kind == decl_typedef)
-	dd->type = init->type;
+        dd->type = init->type;
       else if (type_array(dd->type))
-	{
-	  /* Incomplete array types get their size from the initialiser
-	     (this is set correctly for both strings and init_lists) */
-	  if (!type_array_size(dd->type))
-	    dd->type = init->type;
-	}
+        {
+          /* Incomplete array types get their size from the initialiser
+             (this is set correctly for both strings and init_lists) */
+          if (!type_array_size(dd->type))
+            dd->type = init->type;
+        }
       else if (type_network_base_type(dd->type))
-	error_with_decl(decl, "initialisation of network base types not yet supported");
+        error_with_decl(decl, "initialisation of network base types not yet supported");
     }
   /* Check for a size */
   if (type_array(dd->type))
     {
       /* Don't you love gcc code? */
       int do_default
-	= (dd->needsmemory
-	   /* Even if pedantic, an external linkage array
-	      may have incomplete type at first.  */
-	   ? pedantic && !dd->isexternalscope
-	   : !dd->isfilescoperef);
+        = (dd->needsmemory
+           /* Even if pedantic, an external linkage array
+              may have incomplete type at first.  */
+           ? pedantic && !dd->isexternalscope
+           : !dd->isfilescoperef);
 
       if (!type_array_size(dd->type))
-	{
-	  if (do_default)
-	    error_with_decl(decl, "array size missing in `%s'",
-			    decl_printname(dd));
-	  /* This is what gcc has to say about the next line
-	     (see comment/question above):
-	     If a `static' var's size isn't known,
-	     make it extern as well as static, so it does not get
-	     allocated.
-	     If it is not `static', then do not mark extern;
-	     finish_incomplete_decl will give it a default size
-	     and it will get allocated.  */
-	  else if (!pedantic && dd->needsmemory && !dd->isexternalscope)
-	    dd->isfilescoperef = 1;
-	}
+        {
+          if (do_default)
+            error_with_decl(decl, "array size missing in `%s'",
+                            decl_printname(dd));
+          /* This is what gcc has to say about the next line
+             (see comment/question above):
+             If a `static' var's size isn't known,
+             make it extern as well as static, so it does not get
+             allocated.
+             If it is not `static', then do not mark extern;
+             finish_incomplete_decl will give it a default size
+             and it will get allocated.  */
+          else if (!pedantic && dd->needsmemory && !dd->isexternalscope)
+            dd->isfilescoperef = 1;
+        }
     }
 
   if (is_module_local_static(dd) && use_nido)
     dd_add_last(regionof(current.container->local_statics),
-		current.container->local_statics, dd);
+                current.container->local_statics, dd);
 
   return decl;
 }
@@ -2742,7 +2742,7 @@ declaration finish_decl(declaration decl, expression init)
    Returns the declaration for the parameter.
 */
 declaration declare_parameter(declarator d, type_element elements,
-			      attribute attributes)
+                              attribute attributes)
 {
   /* There must be at least a declarator or some form of type specification */
   location l =
@@ -2763,7 +2763,7 @@ declaration declare_parameter(declarator d, type_element elements,
   if (old_decl && duplicate_decls(&tempdecl, old_decl, FALSE, FALSE))
     {
       /* Don't allow more than one "real" duplicate
-	 of a forward parm decl.  */
+         of a forward parm decl.  */
       ddecl = old_decl;
       ddecl->isused = TRUE;
     }
@@ -2774,7 +2774,7 @@ declaration declare_parameter(declarator d, type_element elements,
     {
       /* Forward transparent union property from union to parameter */
       if (type_union(ddecl->type) && type_tag(ddecl->type)->transparent_union)
-	transparent_union_argument(ddecl);
+        transparent_union_argument(ddecl);
 
       handle_decl_attributes(attributes, ddecl);
       handle_decl_dd_attributes(extra_attr, ddecl);
@@ -2800,19 +2800,19 @@ void allow_parameter_redeclaration(declaration parms, bool mark_forward)
   scan_declaration (parm, parms)
     if (is_data_decl(parm)) /* skip errors */
       {
-	data_decl pd = CAST(data_decl, parm);
-	variable_decl vd = CAST(variable_decl, pd->decls);
-	
-	if (mark_forward)
-	  vd->forward = TRUE;
-	if (vd->ddecl)
-	  {
-	    vd->ddecl->isused = FALSE;
-	    /* This being non-NULL is used to detect redeclarations 
-	       in handle_fdecl_doc_tags - it being non-NULL is an indication
-	       that we're not working on a "fresh" (just-parsed) AST */
-	    assert(vd->ddecl->ast->parent == NULL);
-	  }
+        data_decl pd = CAST(data_decl, parm);
+        variable_decl vd = CAST(variable_decl, pd->decls);
+        
+        if (mark_forward)
+          vd->forward = TRUE;
+        if (vd->ddecl)
+          {
+            vd->ddecl->isused = FALSE;
+            /* This being non-NULL is used to detect redeclarations 
+               in handle_fdecl_doc_tags - it being non-NULL is an indication
+               that we're not working on a "fresh" (just-parsed) AST */
+            assert(vd->ddecl->ast->parent == NULL);
+          }
       }
 }
 
@@ -2830,7 +2830,7 @@ declaration declare_old_parameter(location l, cstring id)
       /* The void type indicates that this is an old-style declaration */
       /* Note that isused is left FALSE to allow one declaration */
       init_data_declaration(&tempdecl, CAST(declaration, d), id.data,
-			    void_type);
+                            void_type);
       tempdecl.kind = decl_variable;
       tempdecl.definition = tempdecl.ast;
       tempdecl.isexternalscope = FALSE;
@@ -2856,11 +2856,11 @@ type_element start_struct(location l, AST_kind skind, word tag)
   if (tdecl && tdecl->kind == skind)
     {
       if (tdecl->defined || tdecl->being_defined)
-	{
-	  error("redefinition of `%s %s'",
-		tagkind_name(skind), tag->cstring.data);
-	  tdecl = declare_tag(tref);
-	}
+        {
+          error("redefinition of `%s %s'",
+                tagkind_name(skind), tag->cstring.data);
+          tdecl = declare_tag(tref);
+        }
     }
   else
     tdecl = declare_tag(tref);
@@ -2874,9 +2874,9 @@ type_element start_struct(location l, AST_kind skind, word tag)
 }
 
 static field_declaration *declare_field(tag_declaration tdecl,
-					field_declaration fdecl,
-					location floc,
-					field_declaration *nextfield)
+                                        field_declaration fdecl,
+                                        location floc,
+                                        field_declaration *nextfield)
 {
   type field_type = fdecl->type;
   const char *name = fdecl->name;
@@ -2887,9 +2887,9 @@ static field_declaration *declare_field(tag_declaration tdecl,
     {
       type base_field_type = type_base(field_type);
       if (type_const(base_field_type) ||
-	  ((type_struct(base_field_type) || type_union(base_field_type)) &&
-	   type_tag(base_field_type)->fields_const))
-	tdecl->fields_const = TRUE;
+          ((type_struct(base_field_type) || type_union(base_field_type)) &&
+           type_tag(base_field_type)->fields_const))
+        tdecl->fields_const = TRUE;
     }
 
   /* XXX: Surely we should do the same as for const here ? */
@@ -2899,7 +2899,7 @@ static field_declaration *declare_field(tag_declaration tdecl,
   if (name)
     {
       if (env_lookup(tdecl->fields, name, TRUE))
-	error_with_location(floc, "duplicate member `%s'", name);
+        error_with_location(floc, "duplicate member `%s'", name);
       env_add(tdecl->fields, name, fdecl);
     }
 
@@ -2930,17 +2930,17 @@ cval check_bitfield_width(field_declaration fdecl)
       largest_uint width = constant_uint_value(cwidth);
 
       if (pedantic && printmsg)
-	constant_overflow_warning(cwidth);
+        constant_overflow_warning(cwidth);
 
       /* Detect and ignore out of range field width.  */
       if (!type_unsigned(cwidth->type) && constant_sint_value(cwidth) < 0)
-	errormsg = "negative width in bit-field `%s'";
+        errormsg = "negative width in bit-field `%s'";
       else if (width > type_size_int(fdecl->type) * BITSPERBYTE)
-	errormsg = "width of `%s' exceeds its type";
+        errormsg = "width of `%s' exceeds its type";
       else if (width == 0 && fdecl->name)
-	errormsg = "zero width for bit-field `%s'";
+        errormsg = "zero width for bit-field `%s'";
       else
-	bitwidth = cval_cast(cwidth->cval, size_t_type);
+        bitwidth = cval_cast(cwidth->cval, size_t_type);
     }
 
   if (printmsg && errormsg)
@@ -2992,165 +2992,165 @@ void layout_struct(tag_declaration tdecl)
 
       // Get the next data_decl in the struct
       if (!flist)
-	{
-	  data_decl decl;
+        {
+          data_decl decl;
 
-	  if (!dlist)
-	    break;
+          if (!dlist)
+            break;
 
-	  decl = CAST(data_decl, ignore_extensions(dlist));
-	  dlist = CAST(declaration, dlist->next);
+          decl = CAST(data_decl, ignore_extensions(dlist));
+          dlist = CAST(declaration, dlist->next);
 
-	  // Is this a struct/union we should merge in?
-	  if (decl->decls)
-	    flist = CAST(field_decl, decl->decls); // No.
-	  else
-	    {
-	      tag_declaration anon_tdecl = get_unnamed_tag_decl(decl);
-	      field_declaration anon_field;
+          // Is this a struct/union we should merge in?
+          if (decl->decls)
+            flist = CAST(field_decl, decl->decls); // No.
+          else
+            {
+              tag_declaration anon_tdecl = get_unnamed_tag_decl(decl);
+              field_declaration anon_field;
 
-	      // No?
-	      if (!anon_tdecl || !anon_tdecl->defined || anon_tdecl->name)
-		continue;
+              // No?
+              if (!anon_tdecl || !anon_tdecl->defined || anon_tdecl->name)
+                continue;
 
-	      // Yes. Get size, alignment of struct/union
-	      fsize = cval_times(anon_tdecl->size, cval_bitsperbyte);
-	      falign = cval_times(anon_tdecl->alignment, cval_bitsperbyte);
+              // Yes. Get size, alignment of struct/union
+              fsize = cval_times(anon_tdecl->size, cval_bitsperbyte);
+              falign = cval_times(anon_tdecl->alignment, cval_bitsperbyte);
 
-	      /* Adjust copied anonymous fields */
-	      offset = cval_align_to(offset, falign);
-	      for (anon_field = anon_tdecl->fieldlist; anon_field;
-		   anon_field = anon_field->next, fdecl = fdecl->next)
-		fdecl->offset = cval_add(anon_field->offset, offset);
-	    }
-	}
+              /* Adjust copied anonymous fields */
+              offset = cval_align_to(offset, falign);
+              for (anon_field = anon_tdecl->fieldlist; anon_field;
+                   anon_field = anon_field->next, fdecl = fdecl->next)
+                fdecl->offset = cval_add(anon_field->offset, offset);
+            }
+        }
 
       if (flist)
-	{
-	  /* decode field_decl field */
-	  type field_type = fdecl->type;
-	  cval bitwidth = cval_top;
+        {
+          /* decode field_decl field */
+          type field_type = fdecl->type;
+          cval bitwidth = cval_top;
 
-	  if (flist->arg1)
-	    bitwidth = check_bitfield_width(fdecl);
+          if (flist->arg1)
+            bitwidth = check_bitfield_width(fdecl);
 
-	  /* Check for network type fields in network structures once
-	     the type is known. Avoid duplicate error messages. */
-	  if (isnetwork && !flist->type_checked && !type_variable(field_type))
-	    {
-	      flist->type_checked = TRUE;
-	      if (!type_network(field_type))
-		error_with_location(flist->location, "field `%s' must be a network type",
-				    fdecl->name);
-	    }
+          /* Check for network type fields in network structures once
+             the type is known. Avoid duplicate error messages. */
+          if (isnetwork && !flist->type_checked && !type_variable(field_type))
+            {
+              flist->type_checked = TRUE;
+              if (!type_network(field_type))
+                error_with_location(flist->location, "field `%s' must be a network type",
+                                    fdecl->name);
+            }
 
-	  fdecl->bitwidth = bitwidth;
+          fdecl->bitwidth = bitwidth;
 
-	  if (type_size_cc(field_type))
-	    fsize = cval_times(type_size(field_type), cval_bitsperbyte);
-	  else
-	    fsize = cval_top;
+          if (type_size_cc(field_type))
+            fsize = cval_times(type_size(field_type), cval_bitsperbyte);
+          else
+            fsize = cval_top;
 
-	  /* don't care about alignment if no size (type_incomplete(field_type)
-	     is true, so we got an error above */
-	  if (fdecl->packed || tdecl->packed)
-	    falign = cval_bitsperbyte;
-	  else
-	    falign = cval_times
-	      (type_has_size(field_type) ? type_alignment(field_type) : cval_top,
-	       cval_bitsperbyte);
+          /* don't care about alignment if no size (type_incomplete(field_type)
+             is true, so we got an error above */
+          if (fdecl->packed || tdecl->packed)
+            falign = cval_bitsperbyte;
+          else
+            falign = cval_times
+              (type_has_size(field_type) ? type_alignment(field_type) : cval_top,
+               cval_bitsperbyte);
 
-	  if (target->adjust_field_align && !type_realigned(field_type))
-	    falign = target->adjust_field_align(fdecl, falign);
+          if (target->adjust_field_align && !type_realigned(field_type))
+            falign = target->adjust_field_align(fdecl, falign);
 
-	  if (cval_istop(bitwidth)) /* regular field */
-	    offset = cval_align_to(offset, falign); 
-	  else if (cval_isunknown(bitwidth))
-	    {
-	      if (!cval_istop(offset))
-		offset = cval_unknown_number;
-	    }
-	  else if (!cval_boolvalue(bitwidth)) /* ie, 0 */
-	    {
-	      if (target->pcc_bitfield_type_matters || isnetwork)
-		{
-		  offset = cval_align_to(offset, falign);
-		  falign = make_type_cval(1); /* No structure alignment implications */
-		}
-	      else
-		{
-		  /* I'm not to blame for gcc's weirdness. */
-		  if (!type_realigned(field_type))
-		    falign = make_type_cval(1);
-		  falign = cval_lcm(falign, make_cval_unsigned(target->empty_field_boundary, size_t_type));
-		  offset = cval_align_to(offset, falign);
-		}
-	      fsize = bitwidth;
-	    }
-	  else
-	    {
-	      assert(cval_intcompare(bitwidth, cval_zero) > 0);
-	      if (target->pcc_bitfield_type_matters && !isnetwork)
-		{
-		  /* skip to next unit on crossing falign-sized boundary.
-		     align struct to falign (note the inconsistency with
-		     the 0-width bitfield). */
+          if (cval_istop(bitwidth)) /* regular field */
+            offset = cval_align_to(offset, falign); 
+          else if (cval_isunknown(bitwidth))
+            {
+              if (!cval_istop(offset))
+                offset = cval_unknown_number;
+            }
+          else if (!cval_boolvalue(bitwidth)) /* ie, 0 */
+            {
+              if (target->pcc_bitfield_type_matters || isnetwork)
+                {
+                  offset = cval_align_to(offset, falign);
+                  falign = make_type_cval(1); /* No structure alignment implications */
+                }
+              else
+                {
+                  /* I'm not to blame for gcc's weirdness. */
+                  if (!type_realigned(field_type))
+                    falign = make_type_cval(1);
+                  falign = cval_lcm(falign, make_cval_unsigned(target->empty_field_boundary, size_t_type));
+                  offset = cval_align_to(offset, falign);
+                }
+              fsize = bitwidth;
+            }
+          else
+            {
+              assert(cval_intcompare(bitwidth, cval_zero) > 0);
+              if (target->pcc_bitfield_type_matters && !isnetwork)
+                {
+                  /* skip to next unit on crossing falign-sized boundary.
+                     align struct to falign (note the inconsistency with
+                     the 0-width bitfield). */
 
-		  /* This tests 
-		     ((offset + bitwidth + falign - 1) / falign -
-		     offset / falign) > fsize / falign
-		  */
-		  cval val1 = cval_sub(cval_add(cval_add(offset, bitwidth),
-						falign),
-				       make_type_cval(1));
-		  cval val2 = cval_sub(cval_divide(val1, falign),
-				       cval_divide(offset, falign));
+                  /* This tests 
+                     ((offset + bitwidth + falign - 1) / falign -
+                     offset / falign) > fsize / falign
+                  */
+                  cval val1 = cval_sub(cval_add(cval_add(offset, bitwidth),
+                                                falign),
+                                       make_type_cval(1));
+                  cval val2 = cval_sub(cval_divide(val1, falign),
+                                       cval_divide(offset, falign));
 
-		  // if falign or offset are top or unknown, this will
-		  // contaminate val2 as appropriate
-		  if (!cval_knownvalue(val2))
-		    offset = val2;
-		  else if (cval_intcompare(val2, cval_divide(fsize, falign)) > 0)
-		    offset = cval_align_to(offset, falign);
-		}
-	      else
-		{
-		  /* More network type bitfield fun: when switching between
-		     big and little-endian bitfields, we align to the next
-		     byte boundary (otherwise we could start filling bytes
-		     from opposing ends, which would be very confusing) */
-		  if (isnetwork && type_network_base_type(field_type))
-		    {
-		      bool isbe = type_networkdef(field_type)->isbe;
+                  // if falign or offset are top or unknown, this will
+                  // contaminate val2 as appropriate
+                  if (!cval_knownvalue(val2))
+                    offset = val2;
+                  else if (cval_intcompare(val2, cval_divide(fsize, falign)) > 0)
+                    offset = cval_align_to(offset, falign);
+                }
+              else
+                {
+                  /* More network type bitfield fun: when switching between
+                     big and little-endian bitfields, we align to the next
+                     byte boundary (otherwise we could start filling bytes
+                     from opposing ends, which would be very confusing) */
+                  if (isnetwork && type_network_base_type(field_type))
+                    {
+                      bool isbe = type_networkdef(field_type)->isbe;
 
-		      if (isbe != lastbitfield_be)
-			offset = cval_align_to(offset, cval_bitsperbyte);
-		      lastbitfield_be = isbe;
-		    }
+                      if (isbe != lastbitfield_be)
+                        offset = cval_align_to(offset, cval_bitsperbyte);
+                      lastbitfield_be = isbe;
+                    }
 
-		  // more gcc fun
-		  if (type_realigned(field_type)) 
-		    offset = cval_align_to(offset, falign);
-		  else // don't align, don't affect struct alignment
-		    falign = cval_bitsperbyte;
-		}
+                  // more gcc fun
+                  if (type_realigned(field_type)) 
+                    offset = cval_align_to(offset, falign);
+                  else // don't align, don't affect struct alignment
+                    falign = cval_bitsperbyte;
+                }
 
-	      fsize = bitwidth;
-	    }
+              fsize = bitwidth;
+            }
 
-	  fdecl->offset = offset;
+          fdecl->offset = offset;
 
-	  flist = CAST(field_decl, flist->next);
-	  fdecl = fdecl->next;
-	}
+          flist = CAST(field_decl, flist->next);
+          fdecl = fdecl->next;
+        }
 
       if (!isunion)
-	{
-	  offset = cval_add(offset, fsize);
-	  size = offset;
-	}
+        {
+          offset = cval_add(offset, fsize);
+          size = offset;
+        }
       else
-	size = cval_max(fsize, size);
+        size = cval_max(fsize, size);
 
       alignment = cval_lcm(alignment, falign);
     }
@@ -3167,7 +3167,7 @@ void layout_struct(tag_declaration tdecl)
    Computes size and alignment of struct/union (see ASSUME: comments).
    Returns t */
 type_element finish_struct(type_element t, declaration fields,
-			   attribute attribs)
+                           attribute attribs)
 {
   tag_ref s = CAST(tag_ref, t);
   tag_declaration tdecl = s->tdecl;
@@ -3188,130 +3188,130 @@ type_element finish_struct(type_element t, declaration fields,
       field_decl field;
 
       if (!flist->decls) /* possibly a struct/union we should merge in */
-	{
-	  tag_declaration anon_tdecl = get_unnamed_tag_decl(flist);
-	  field_declaration anon_field;
-	  location floc = flist->location;
+        {
+          tag_declaration anon_tdecl = get_unnamed_tag_decl(flist);
+          field_declaration anon_field;
+          location floc = flist->location;
 
-	  if (!anon_tdecl)
-	    error_with_location(floc,
-	      "unnamed fields of type other than struct or union are not allowed");
-	  else if (!anon_tdecl->defined)
-	    error_with_location(floc, "anonymous field has incomplete type");
-	  else if (anon_tdecl->name)
-	    warning_with_location(floc, "declaration does not declare anything");
-	  else if (isnetwork && !is_nx_tag(anon_tdecl))
-	    error_with_location(floc, "field `%s' must be a network type",
-				nice_field_name(NULL));
-	  else
-	    {
-	      /* Process alignment to this struct/union in "main" loop below */
-	      anon_tdecl->collapsed = TRUE;
+          if (!anon_tdecl)
+            error_with_location(floc,
+              "unnamed fields of type other than struct or union are not allowed");
+          else if (!anon_tdecl->defined)
+            error_with_location(floc, "anonymous field has incomplete type");
+          else if (anon_tdecl->name)
+            warning_with_location(floc, "declaration does not declare anything");
+          else if (isnetwork && !is_nx_tag(anon_tdecl))
+            error_with_location(floc, "field `%s' must be a network type",
+                                nice_field_name(NULL));
+          else
+            {
+              /* Process alignment to this struct/union in "main" loop below */
+              anon_tdecl->collapsed = TRUE;
 
-	      /* Copy fields */
-	      for (anon_field = anon_tdecl->fieldlist; anon_field;
-		   anon_field = anon_field->next)
-		{
-		  field_declaration fdecl = ralloc(parse_region, struct field_declaration);
+              /* Copy fields */
+              for (anon_field = anon_tdecl->fieldlist; anon_field;
+                   anon_field = anon_field->next)
+                {
+                  field_declaration fdecl = ralloc(parse_region, struct field_declaration);
 
-		  *fdecl = *anon_field;
-		  fdecl->ast = NULL;
-		  nextfield = declare_field(tdecl, fdecl, floc, nextfield);
-		  if (fdecl->name)
-		    hasmembers = TRUE;
-		}
-	    }
-	}
+                  *fdecl = *anon_field;
+                  fdecl->ast = NULL;
+                  nextfield = declare_field(tdecl, fdecl, floc, nextfield);
+                  if (fdecl->name)
+                    hasmembers = TRUE;
+                }
+            }
+        }
       else
-	scan_field_decl (field, CAST(field_decl, flist->decls))
-	  {
-	    /* decode field_decl field */
-	    field_declaration fdecl;
-	    type field_type;
-	    const char *name;
-	    int class;
-	    scflags scf;
-	    const char *printname;
-	    bool defaulted_int;
-	    type tmpft;
-	    location floc = field->location;
-	    dd_list extra_attr;
+        scan_field_decl (field, CAST(field_decl, flist->decls))
+          {
+            /* decode field_decl field */
+            field_declaration fdecl;
+            type field_type;
+            const char *name;
+            int class;
+            scflags scf;
+            const char *printname;
+            bool defaulted_int;
+            type tmpft;
+            location floc = field->location;
+            dd_list extra_attr;
 
-	    fdecl = ralloc(parse_region, struct field_declaration);
+            fdecl = ralloc(parse_region, struct field_declaration);
 
-	    parse_declarator(flist->modifiers, field->declarator,
-			     field->arg1 != NULL, FALSE,
-			     &class, &scf, NULL, &name, &tmpft,
-			     &defaulted_int, NULL, &extra_attr);
-	    field_type = tmpft;
+            parse_declarator(flist->modifiers, field->declarator,
+                             field->arg1 != NULL, FALSE,
+                             &class, &scf, NULL, &name, &tmpft,
+                             &defaulted_int, NULL, &extra_attr);
+            field_type = tmpft;
 
-	    /* Grammar doesn't allow scspec: */
-	    assert(scf == 0 && class == 0);
+            /* Grammar doesn't allow scspec: */
+            assert(scf == 0 && class == 0);
 
-	    printname = nice_field_name(name);
+            printname = nice_field_name(name);
 
-	    /* Support "flexible arrays" (y[] as field member) --
-	       simply make the size 0 which we already handle */
-	    if (type_array(field_type) && !type_array_size(field_type))
-	      field_type = make_array_type(type_array_of(field_type),
-					   build_zero(parse_region, dummy_location));
+            /* Support "flexible arrays" (y[] as field member) --
+               simply make the size 0 which we already handle */
+            if (type_array(field_type) && !type_array_size(field_type))
+              field_type = make_array_type(type_array_of(field_type),
+                                           build_zero(parse_region, dummy_location));
 
-	    if (type_function(field_type))
-	      {
-		error_with_location(floc, "field `%s' declared as a function", printname);
-		field_type = make_pointer_type(field_type);
-	      }
-	    else if (type_void(field_type))
-	      {
-		error_with_location(floc, "field `%s' declared void", printname);
-		field_type = error_type;
-	      }
-	    else if (type_incomplete(field_type)) 
-	      {
-		error_with_location(floc, "field `%s' has incomplete type", printname);
-		field_type = error_type;
-	      }
+            if (type_function(field_type))
+              {
+                error_with_location(floc, "field `%s' declared as a function", printname);
+                field_type = make_pointer_type(field_type);
+              }
+            else if (type_void(field_type))
+              {
+                error_with_location(floc, "field `%s' declared void", printname);
+                field_type = error_type;
+              }
+            else if (type_incomplete(field_type)) 
+              {
+                error_with_location(floc, "field `%s' has incomplete type", printname);
+                field_type = error_type;
+              }
 
-	    fdecl->type = field_type;
-	    handle_field_attributes(field->attributes, fdecl);
-	    handle_field_dd_attributes(extra_attr, fdecl);
-	    field_type = fdecl->type; /* attributes might change type */
+            fdecl->type = field_type;
+            handle_field_attributes(field->attributes, fdecl);
+            handle_field_dd_attributes(extra_attr, fdecl);
+            field_type = fdecl->type; /* attributes might change type */
 
-	    if (field->arg1)
-	      {
-		const char *errmsg = NULL;
+            if (field->arg1)
+              {
+                const char *errmsg = NULL;
 
-		if (!type_integer(field_type))
-		  errmsg = "bit-field `%s' has invalid type";
-		else if (!(type_integer(field->arg1->type)))
-		  errmsg = "bit-field `%s' width not an integer constant";
-		else if (type_network_base_type(field_type))
-		  {
-		    if (!type_networkdef(field_type)->bf_encoder)
-		      errmsg = "type of `%s' cannot be used as a bit-field";
-		    else if (!isnetwork)
-		      errmsg = "bit-field `%s' of network type used inside non-network type";
-		  }
+                if (!type_integer(field_type))
+                  errmsg = "bit-field `%s' has invalid type";
+                else if (!(type_integer(field->arg1->type)))
+                  errmsg = "bit-field `%s' width not an integer constant";
+                else if (type_network_base_type(field_type))
+                  {
+                    if (!type_networkdef(field_type)->bf_encoder)
+                      errmsg = "type of `%s' cannot be used as a bit-field";
+                    else if (!isnetwork)
+                      errmsg = "bit-field `%s' of network type used inside non-network type";
+                  }
 
-		if (errmsg)
-		  {
-		    error_with_location(floc, errmsg, printname);
-		    field->arg1 = NULL;
-		  }
-	      }
+                if (errmsg)
+                  {
+                    error_with_location(floc, errmsg, printname);
+                    field->arg1 = NULL;
+                  }
+              }
 
-	    fdecl->ast = field;
-	    field->fdecl = fdecl;
-	    fdecl->name = name;
-	    nextfield = declare_field(tdecl, fdecl, floc, nextfield);
-	    if (name)
-	      hasmembers = TRUE;
-	  }
+            fdecl->ast = field;
+            field->fdecl = fdecl;
+            fdecl->name = name;
+            nextfield = declare_field(tdecl, fdecl, floc, nextfield);
+            if (name)
+              hasmembers = TRUE;
+          }
     }
 
   if (pedantic && !is_attribute_ref(s) && !hasmembers)
     pedwarn("%s has no %smembers", tagkind_name(s->kind),
-	    (fields ? "named " : ""));
+            (fields ? "named " : ""));
 
   tdecl->defined = TRUE;
   tdecl->being_defined = FALSE;
@@ -3362,20 +3362,20 @@ void layout_enum_end(tag_declaration tdecl)
       smallest = largest = value_of_enumerator(values);
 
       if (!cval_isunknown(smallest))
-	scan_enumerator (v, CAST(enumerator, values->next))
+        scan_enumerator (v, CAST(enumerator, values->next))
          {
-	   cval vv = value_of_enumerator(v);
+           cval vv = value_of_enumerator(v);
 
-	   if (cval_isunknown(vv))
-	     {
-	       smallest = vv;
-	       break;
-	     }
-	   if (cval_intcompare(vv, largest) > 0)
-	     largest = vv;
-	   if (cval_intcompare(vv, smallest) < 0)
-	     smallest = vv;
-	 }
+           if (cval_isunknown(vv))
+             {
+               smallest = vv;
+               break;
+             }
+           if (cval_intcompare(vv, largest) > 0)
+             largest = vv;
+           if (cval_intcompare(vv, smallest) < 0)
+             smallest = vv;
+         }
     }
 
   if (cval_isunknown(smallest))
@@ -3388,23 +3388,23 @@ void layout_enum_end(tag_declaration tdecl)
       type_largest = type_for_cval(largest, enum_isunsigned);
       assert(type_smallest);
       if (!type_largest)
-	{
-	  assert(!enum_isunsigned);
-	  warning("enumeration values exceed range of largest integer");
-	  type_largest = long_long_type;
-	}
+        {
+          assert(!enum_isunsigned);
+          warning("enumeration values exceed range of largest integer");
+          type_largest = long_long_type;
+        }
       if (type_size_int(type_smallest) > type_size_int(type_largest))
-	enum_reptype = type_smallest;
+        enum_reptype = type_smallest;
       else
-	enum_reptype = type_largest;
+        enum_reptype = type_largest;
 
       /* We use int as the enum type if that fits, except if both:
-	 - the values fit in a (strictly) smaller type
-	 - the packed attribute was specified 
+         - the values fit in a (strictly) smaller type
+         - the packed attribute was specified 
       */
       if (cval_inrange(smallest, int_type) && cval_inrange(largest, int_type) &&
-	  !(tdecl->packed && type_size_int(enum_reptype) < type_size_int(int_type)))
-	enum_reptype = int_type;
+          !(tdecl->packed && type_size_int(enum_reptype) < type_size_int(int_type)))
+        enum_reptype = int_type;
     }
 
   tdecl->reptype = enum_reptype;
@@ -3430,43 +3430,43 @@ known_cst layout_enum_value(enumerator e)
     {
       cst = value->cst;
       if (check_constant_once(value, cst_numerical))
-	{
-	  if (!value->cst || !constant_integral(value->cst))
-	    {
-	      error("enumerator value for `%s' not integer constant", name);
-	      cst = NULL;
-	    }
-	}
+        {
+          if (!value->cst || !constant_integral(value->cst))
+            {
+              error("enumerator value for `%s' not integer constant", name);
+              cst = NULL;
+            }
+        }
     }
 
   if (!cst)
     {
       /* Last value + 1 */
       if (last_enum_value)
-	{
-	  /* No clear logic anywhere to specify which type we should use
-	     (ANSI C must specify int, cf warning below) */
-	  type addtype = type_unsigned(last_enum_value->type) ?
-	    unsigned_long_long_type : long_long_type;
+        {
+          /* No clear logic anywhere to specify which type we should use
+             (ANSI C must specify int, cf warning below) */
+          type addtype = type_unsigned(last_enum_value->type) ?
+            unsigned_long_long_type : long_long_type;
 
-	  cst = fold_add(addtype, last_enum_value, onecst);
-	}
+          cst = fold_add(addtype, last_enum_value, onecst);
+        }
       else
-	cst = zerocst;
+        cst = zerocst;
     }
 
   if (constant_integral(cst))
     {
       if (pedantic && !cval_inrange(cst->cval, int_type))
-	{
-	  pedwarn("ANSI C restricts enumerator values to range of `int'");
-	  cst = zerocst;
-	}
+        {
+          pedwarn("ANSI C restricts enumerator values to range of `int'");
+          cst = zerocst;
+        }
 
       if (type_size_int(cst->type) < type_size_int(int_type))
-	cst->type =
-	  type_for_size(type_size(int_type),
-			flag_traditional && type_unsigned(cst->type));
+        cst->type =
+          type_for_size(type_size(int_type),
+                        flag_traditional && type_unsigned(cst->type));
     }
   last_enum_value = cst;
 
@@ -3484,7 +3484,7 @@ type_element start_enum(location l, word tag)
   if (tdecl && tdecl->kind == kind_enum_ref)
     {
       if (tdecl->defined)
-	error("redefinition of `enum %s'", tag->cstring.data);
+        error("redefinition of `enum %s'", tag->cstring.data);
     }
   else
     tdecl = declare_tag(tref);
@@ -3501,7 +3501,7 @@ type_element start_enum(location l, word tag)
 /* Finish definition of enum furnishing the names and attribs.
    Returns t */
 type_element finish_enum(type_element t, declaration names,
-			 attribute attribs)
+                         attribute attribs)
 {
   tag_ref s = CAST(tag_ref, t);
   tag_declaration tdecl = s->tdecl;
@@ -3541,7 +3541,7 @@ declaration make_enumerator(location loc, cstring id, expression value)
     {
       error("only commands and events can be defined in interfaces");
       /* We don't want the symbol in the interface's env, so give
-	 it it's own private home! */
+         it it's own private home! */
       env = new_environment(parse_region, NULL, FALSE, FALSE);
     }
 
@@ -3563,14 +3563,14 @@ declaration make_enumerator(location loc, cstring id, expression value)
    Returns the declaration for the field.
 */
 declaration make_field(declarator d, expression bitfield,
-		       type_element elements, attribute attributes)
+                       type_element elements, attribute attributes)
 {
   /* We get at least one of a declarator or a bitfield */
   location l = d ? d->location : bitfield->location;
 
   return
     CAST(declaration,
-	 new_field_decl(parse_region, l, d, attributes, bitfield));
+         new_field_decl(parse_region, l, d, attributes, bitfield));
 }
 
 
@@ -3586,8 +3586,8 @@ asttype make_type(type_element elements, declarator d)
   dd_list extra_attr;
 
   parse_declarator(t->qualifiers, t->declarator, FALSE, FALSE,
-		   &class, &scf, NULL, &name, 
-		   &t->type, &defaulted_int, NULL, &extra_attr);
+                   &class, &scf, NULL, &name, 
+                   &t->type, &defaulted_int, NULL, &extra_attr);
   assert(t->type && !(class || scf || name));
 
   return t;
@@ -3647,10 +3647,10 @@ statement chain_with_labels(statement l1, statement l2)
       labeled_stmt ls = CAST(labeled_stmt, last_label);
 
       if (!ls->stmt) /* An unfinished labeled statement */
-	{
-	  ls->stmt = l2;
-	  return l1;
-	}
+        {
+          ls->stmt = l2;
+          return l1;
+        }
       last_label = CAST(node, ls->stmt);
     }
 
@@ -3692,7 +3692,7 @@ void init_semantics(void)
 }
 
 void start_semantics(source_language l, nesc_declaration container,
-		     environment env)
+                     environment env)
 {
   current.env = env;
   current.language = l;
@@ -3732,12 +3732,12 @@ bool handle_mode_attribute(location loc, data_declaration ddecl, const char *mod
   if (type_pointer(t))
     {
       /* Simplified pointer handling. We only allow modes that specify
-	 the pointer size (in which case we do nothing). In all other
-	 cases, we'll report an error. Most targets do not support more
-	 than one pointer mode (the exceptions seem to be s390 and mips,
-	 that allow both 32 and 64 bit pointers) */
+         the pointer size (in which case we do nothing). In all other
+         cases, we'll report an error. Most targets do not support more
+         than one pointer mode (the exceptions seem to be s390 and mips,
+         that allow both 32 and 64 bit pointers) */
       if (type_size_int(t) != type_size_int(tm))
-	error("invalid pointer mode `%s'", mode);
+        error("invalid pointer mode `%s'", mode);
     }
   else if (samekind(t, tm) ||
       (type_complex(t) && type_complex(tm) &&

--- a/src/semantics.h
+++ b/src/semantics.h
@@ -65,7 +65,7 @@ declarator finish_array_or_fn_declarator(declarator nested, nested_declarator d)
    Returns false in case of error.
    Sets current.function_decl to the declaration for this function */
 bool start_function(type_element elements, declarator d, attribute attribs,
-		    bool nested);
+                    bool nested);
 
 /* Add old-style parameter declarations old_parms to the current function */
 void store_parm_decls(declaration old_parms);
@@ -90,7 +90,7 @@ enum { var_typedef, var_register, var_normal, var_static, var_extern };
    Returns the declaration for the variable.
 */
 declaration start_decl(declarator d, asm_stmt astmt, type_element elements,
-		       bool initialised, attribute attributes);
+                       bool initialised, attribute attributes);
 
 /* Finish definition of decl, furnishing the optional initialiser init.
    Returns decl */
@@ -101,7 +101,7 @@ declaration finish_decl(declaration decl, expression init);
    Returns the declaration for the parameter.
 */
 declaration declare_parameter(declarator d, type_element elements,
-			      attribute attributes);
+                              attribute attributes);
 
 /* Allow parameters to be redeclared. mark_forward should be TRUE
    if these are "forward" parameter declarations (gcc extension) */
@@ -116,7 +116,7 @@ type_element start_struct(location l, AST_kind skind, word tag);
 /* Finish definition of struct/union furnishing the fields and attribs.
    Returns t */
 type_element finish_struct(type_element t, declaration fields,
-			   attribute attribs);
+                           attribute attribs);
 
 /* Return a reference to struct/union/enum (indicated by skind) type tag */
 type_element xref_tag(location l, AST_kind skind, word tag);
@@ -127,7 +127,7 @@ type_element start_enum(location l, word tag);
 /* Finish definition of enum furnishing the names and attribs.
    Returns t */
 type_element finish_enum(type_element t, declaration names,
-			 attribute attribs);
+                         attribute attribs);
 
 /* Create declaration of field 'elements d : bitfield' with attributes
    extra_attributes and attributes.
@@ -135,7 +135,7 @@ type_element finish_enum(type_element t, declaration names,
    Returns the declaration for the field.
 */
 declaration make_field(declarator d, expression bitfield,
-		       type_element elements, attribute attributes);
+                       type_element elements, attribute attributes);
 
 declaration make_enumerator(location loc, cstring id, expression value);
 
@@ -164,15 +164,15 @@ void push_label_level(void);
 void pop_label_level(void);
 
 void init_data_declaration(data_declaration dd, declaration ast,
-			   const char *name, type t);
+                           const char *name, type t);
 data_declaration declare(environment env, data_declaration from,
-			 bool ignore_shadow);
+                         bool ignore_shadow);
 
 /* Build a declaration object for a string */
 data_declaration declare_string(const char *name, cstring value, bool wide);
 
 environment new_environment(region r, environment parent,
-			    bool global_level, bool parm_level);
+                            bool global_level, bool parm_level);
 
 tag_declaration declare_tag(tag_ref t);
 tag_declaration lookup_tag(tag_ref t, bool this_level_only);
@@ -181,31 +181,31 @@ tag_declaration lookup_global_tag(tag_ref t);
 
 void init_semantics(void);
 void start_semantics(source_language l, nesc_declaration container,
-		     environment parent_env);
+                     environment parent_env);
 
 struct semantic_state
 {
-  region fileregion;		/* A per-file region.
-				   "Renewed" at the start of each file and
-				   of each implementation section */
-  source_language language;	/* The current language */
-  environment env;		/* The current environment */
-  nesc_declaration file;	/* The nesC entity of the file being compiled
-				   (different from container while dealing
-				   with C declarations at the beginning of
-				   the file) */
-  nesc_declaration container;	/* The nesC entity being compiled (NULL for C) */
-  function_decl function_decl;	/* The function currently being defined */
-  tag_ref pending_invalid_xref;	/* Internal use */
-  enum {			/* Within a component specification, are we: */
-    spec_normal,		/*   - neither in provides or in uses */
-    spec_provides,		/*   - in a provides section */
-    spec_uses			/*   - in a uses section */
-  } spec_section;	
+  region fileregion;                /* A per-file region.
+                                   "Renewed" at the start of each file and
+                                   of each implementation section */
+  source_language language;        /* The current language */
+  environment env;                /* The current environment */
+  nesc_declaration file;        /* The nesC entity of the file being compiled
+                                   (different from container while dealing
+                                   with C declarations at the beginning of
+                                   the file) */
+  nesc_declaration container;        /* The nesC entity being compiled (NULL for C) */
+  function_decl function_decl;        /* The function currently being defined */
+  tag_ref pending_invalid_xref;        /* Internal use */
+  enum {                        /* Within a component specification, are we: */
+    spec_normal,                /*   - neither in provides or in uses */
+    spec_provides,                /*   - in a provides section */
+    spec_uses                        /*   - in a uses section */
+  } spec_section;        
 
-  atomic_stmt in_atomic;		/* The lexically containing atomic statement
-				   (NULL for none) */
-  char *preprocessed_file;	/* Temp file holding preprocessor output */
+  atomic_stmt in_atomic;                /* The lexically containing atomic statement
+                                   (NULL for none) */
+  char *preprocessed_file;        /* Temp file holding preprocessor output */
   struct lex_state lex;
 };
 
@@ -215,18 +215,18 @@ extern dd_list spontaneous_calls;
 /* List of spontaneously-called functions */
 
 void check_variable_scflags(scflags scf,
-			    location l, const char *kind, const char *name);
+                            location l, const char *kind, const char *name);
 
 void parse_declarator(type_element modifiers, declarator d, bool bitfield, 
-		      bool require_parm_names,
-		      int *oclass, scflags *oscf,
-		      const char **ointf, const char **oname,
-		      type *ot, bool *owarn_defaulted_int,
-		      function_declarator *ofunction_declarator,
-		      dd_list *oattributes);
+                      bool require_parm_names,
+                      int *oclass, scflags *oscf,
+                      const char **ointf, const char **oname,
+                      type *ot, bool *owarn_defaulted_int,
+                      function_declarator *ofunction_declarator,
+                      dd_list *oattributes);
 
 int duplicate_decls(data_declaration newdecl, data_declaration olddecl,
-		    bool different_binding_level, bool newinitialised);
+                    bool different_binding_level, bool newinitialised);
 
 void check_array_size(expression size, const char *printname);
 

--- a/src/stmt.c
+++ b/src/stmt.c
@@ -95,7 +95,7 @@ void check_return(expression e)
   if (type_void(ret))
     {
       if (pedantic || !type_void(e->type))
-	warning("`return' with a value, in function returning void");
+        warning("`return' with a value, in function returning void");
     }
   else
     {
@@ -115,8 +115,8 @@ statement make_return(location loc, expression arg)
 
       pushlevel(FALSE);
       temp = CAST(declaration,
-		  build_declaration(parse_region, current.env, current_return_type(),
-				    "__nesc_temp", arg, &ddecl));
+                  build_declaration(parse_region, current.env, current_return_type(),
+                                    "__nesc_temp", arg, &ddecl));
       arg = build_identifier(parse_region, loc, ddecl);
     }
 
@@ -126,7 +126,7 @@ statement make_return(location loc, expression arg)
 
   if (temp)
     ret = CAST(statement,
-	       new_compound_stmt(parse_region, loc, NULL, temp, ret, poplevel()));
+               new_compound_stmt(parse_region, loc, NULL, temp, ret, poplevel()));
 
   return ret;
 }
@@ -160,14 +160,14 @@ void lookup_label(id_label label)
   if (!current.function_decl)
     {
       error ("label %s referenced outside of any function",
-	     label->cstring.data);
+             label->cstring.data);
       /* A dummy decl to make everybody happy. */
       label->ldecl = new_label_declaration(parse_region, label->cstring.data, label);
       return;
     }
 
   ldecl = env_lookup(current.function_decl->scoped_labels, label->cstring.data,
-		     FALSE);
+                     FALSE);
 
   /* Only explicitly declared labels are visible in nested functions */
   if (ldecl && !ldecl->explicitly_declared &&
@@ -182,7 +182,7 @@ void lookup_label(id_label label)
   else
     if (ldecl->containing_atomic != current.in_atomic)
       error("label %s is referenced in different atomic statements",
-	    label->cstring.data);
+            label->cstring.data);
 
   label->ldecl = ldecl;
 }
@@ -197,9 +197,9 @@ static void duplicate_label_error(id_label label)
 {
   error("duplicate label declaration `%s'", label->cstring.data);
   error_with_location(label->ldecl->definition ?
-		      label->ldecl->definition->location :
-		      label->ldecl->firstuse->location,
-		      "this is a previous declaration");
+                      label->ldecl->definition->location :
+                      label->ldecl->firstuse->location,
+                      "this is a previous declaration");
 }
 
 void define_label(id_label label)
@@ -241,11 +241,11 @@ void check_labels(void)
       label_declaration ldecl = ld;
 
       if (!ldecl->definition)
-	error_with_location(ldecl->firstuse->location,
-			    "label `%s' used but not defined", lname);
+        error_with_location(ldecl->firstuse->location,
+                            "label `%s' used but not defined", lname);
       else if (!ldecl->used && warn_unused)
-	warning_with_location(ldecl->firstuse->location,
-			      "label `%s' defined but not used", lname);
+        warning_with_location(ldecl->firstuse->location,
+                              "label `%s' defined but not used", lname);
     }
 }
 
@@ -279,16 +279,16 @@ static statement containing_switch(label l)
 
       /* XXX: no duplicate case check */
       while (*last)
-	{
-	  if (is_default_label(*last) && lisdefault)
-	    {
-	      error("multiple default labels in one switch");
-	      error_with_location((*last)->location,
-				  "this is the first default label");
-	      lisdefault = FALSE; /* Only one error */
-	    }
-	  last = &(*last)->next_label;
-	}
+        {
+          if (is_default_label(*last) && lisdefault)
+            {
+              error("multiple default labels in one switch");
+              error_with_location((*last)->location,
+                                  "this is the first default label");
+              lisdefault = FALSE; /* Only one error */
+            }
+          last = &(*last)->next_label;
+        }
 
       fail_different_atomic(sw->containing_atomic);
 
@@ -303,7 +303,7 @@ void check_case_value(expression e)
   if (check_constant_once(e, cst_numerical))
     if (!e->cst || !(e->type == error_type || type_integer(e->type)))
       error_with_location(e->location,
-			  "case label does not reduce to an integer constant");
+                          "case label does not reduce to an integer constant");
 }
 
 void check_case(label label0)

--- a/src/toplev.c
+++ b/src/toplev.c
@@ -164,18 +164,18 @@ static bool c_option(char *p)
     {
       extra_warnings = 1;
       /* We save the value of warn_uninitialized, since if they put
-	 -Wuninitialized on the command line, we need to generate a
-	 warning about not using it without also specifying -O.  */
+         -Wuninitialized on the command line, we need to generate a
+         warning about not using it without also specifying -O.  */
       if (warn_uninitialized != 1)
-	warn_uninitialized = 2;
+        warn_uninitialized = 2;
     }
   else if (!strcmp (p, "-Wall"))
     {
       /* We save the value of warn_uninitialized, since if they put
-	 -Wuninitialized on the command line, we need to generate a
-	 warning about not using it without also specifying -O.  */
+         -Wuninitialized on the command line, we need to generate a
+         warning about not using it without also specifying -O.  */
       if (warn_uninitialized != 1)
-	warn_uninitialized = 2;
+        warn_uninitialized = 2;
       warn_implicit_int = 1;
       mesg_implicit_function_declaration = 1;
       warn_return_type = 1;
@@ -186,7 +186,7 @@ static bool c_option(char *p)
       warn_parentheses = 1;
       warn_missing_braces = 1;
       /* We set this to 2 here, but 1 in -Wmain, so -ffreestanding can turn
-	 it off only if it's not explicit.  */
+         it off only if it's not explicit.  */
       warn_main = 2;
 
       warn_trigraphs = 1;
@@ -263,9 +263,9 @@ int region_main(int argc, char **argv) deletes
   p = argv[0] + strlen (argv[0]);
   while (p != argv[0] && p[-1] != '/'
 #ifdef DIR_SEPARATOR
-	 && p[-1] != DIR_SEPARATOR
+         && p[-1] != DIR_SEPARATOR
 #endif
-	 )
+         )
     --p;
   progname = p;
 
@@ -280,84 +280,84 @@ int region_main(int argc, char **argv) deletes
       int j;
 
       if (c_option(argv[i]) || nesc_option(argv[i]))
-	i++;
+        i++;
       else if (argv[i][0] == '-' && argv[i][1] != 0)
-	{
-	  char *str = argv[i++] + 1;
-	  char *arg = NULL;
+        {
+          char *str = argv[i++] + 1;
+          char *arg = NULL;
 
-	  if (strchr(OPTS_WITH_ARGS, str[0]))
-	    {
-	      if (!str[1])
-		if (i < argc)
-		  arg = argv[i++];
-		else
-		  {
-		    str = "";
-		    error("argument to `-%c' is missing", str[0]);
-		  }
-	      else
-		arg = str + 1;
-	    }
+          if (strchr(OPTS_WITH_ARGS, str[0]))
+            {
+              if (!str[1])
+                if (i < argc)
+                  arg = argv[i++];
+                else
+                  {
+                    str = "";
+                    error("argument to `-%c' is missing", str[0]);
+                  }
+              else
+                arg = str + 1;
+            }
 
-	  for (j = 0; j < sizeof opts_with_args / sizeof *opts_with_args; j++)
-	    if (!strcmp(str, opts_with_args[j]))
-	      {
-		if (i < argc)
-		  arg = argv[i++];
-		else
-		  {
-		    str = "";
-		    error("argument to `-%s' is missing", str);
-		  }
-		break;
-	      }
+          for (j = 0; j < sizeof opts_with_args / sizeof *opts_with_args; j++)
+            if (!strcmp(str, opts_with_args[j]))
+              {
+                if (i < argc)
+                  arg = argv[i++];
+                else
+                  {
+                    str = "";
+                    error("argument to `-%s' is missing", str);
+                  }
+                break;
+              }
 
-	  if (str[0] == 'o')
-	    targetfile = arg;
-	  else if (str[0] == 'I')
-	    add_nesc_dir(arg, CHAIN_BRACKET);
-	  else if (str[0] == 'D' || str[0] == 'U' || str[0] == 'A')
-	    save_cpp_option(str, arg);
-	  else if (str[0] == 'f' || str[0] == 'W')
-	    {
-	      char kind = str[0];
-	      char *p = &str[1];
+          if (str[0] == 'o')
+            targetfile = arg;
+          else if (str[0] == 'I')
+            add_nesc_dir(arg, CHAIN_BRACKET);
+          else if (str[0] == 'D' || str[0] == 'U' || str[0] == 'A')
+            save_cpp_option(str, arg);
+          else if (str[0] == 'f' || str[0] == 'W')
+            {
+              char kind = str[0];
+              char *p = &str[1];
 
-	      /* Some kind of -f or -W option.
-		 p's value is the option sans -f/W.
-		 Search for it in the table of options.  */
-	      for (j = 0;
-		   j < sizeof (fW_options) / sizeof (fW_options[0]);
-		   j++)
-		{
-		  if (kind == fW_options[j].c &&
-		      !strcmp (p, fW_options[j].string))
-		    {
-		      *fW_options[j].variable = fW_options[j].on_value;
-		      break;
-		    }
-		  if (kind == fW_options[j].c &&
-		      p[0] == 'n' && p[1] == 'o' && p[2] == '-' &&
-		      !strcmp (p+3, fW_options[j].string))
-		    {
-		      *fW_options[j].variable = ! fW_options[j].on_value;
-		      break;
-		    }
-		}
-	    }
-	  else if (!strcmp(str, "include"))
-	    add_nesc_include(arg, TRUE);
-	}
+              /* Some kind of -f or -W option.
+                 p's value is the option sans -f/W.
+                 Search for it in the table of options.  */
+              for (j = 0;
+                   j < sizeof (fW_options) / sizeof (fW_options[0]);
+                   j++)
+                {
+                  if (kind == fW_options[j].c &&
+                      !strcmp (p, fW_options[j].string))
+                    {
+                      *fW_options[j].variable = fW_options[j].on_value;
+                      break;
+                    }
+                  if (kind == fW_options[j].c &&
+                      p[0] == 'n' && p[1] == 'o' && p[2] == '-' &&
+                      !strcmp (p+3, fW_options[j].string))
+                    {
+                      *fW_options[j].variable = ! fW_options[j].on_value;
+                      break;
+                    }
+                }
+            }
+          else if (!strcmp(str, "include"))
+            add_nesc_include(arg, TRUE);
+        }
       else
-	filename = argv[i++];
+        filename = argv[i++];
     }
 
   /* Pass options on to the target too (this a bit hacky, but fine so far) */
   if (target->handle_option)
     for (i = 1; i < argc; i++)
       if (argv[i][0] == '-' && argv[i][1] != 0)
-	target->handle_option(argv[i]);
+        target->handle_option(argv[i]);
 
   if (target->preinit)
     target->preinit();

--- a/src/types.c
+++ b/src/types.c
@@ -35,8 +35,8 @@ Boston, MA 02111-1307, USA. */
 struct type
 {
   enum { tk_primitive, tk_complex, tk_tagged, tk_error, tk_void,
-	 tk_pointer, tk_function, tk_array, tk_iref, tk_variable,
-	 tk_cref } kind;
+         tk_pointer, tk_function, tk_array, tk_iref, tk_variable,
+         tk_cref } kind;
   type_quals qualifiers;
   enum { nx_no, nx_base, nx_derived } network;
   data_declaration combiner, basedecl, typedefdecl;
@@ -56,43 +56,43 @@ struct type
        The order reflects promotion order (for an arbitrary machine,
        see common_primitive_type) */
     enum { /* The elements of this enum must be ordered as follows:
-	      - all integral types before tp_first_floating
-	      - do not change the floating type order
-	      - the integral types are ordered by "rank" (see c9x std) and
-	        unsignedness (unsigned > signed) (common_primitive_type
-		relies on this order)
-	      - The tp_[u]int<n> types must be before tp_char (for the 
-	        assert in common_primitive_type). These types are only
-		used when the corresponding size is not available amongst
-		short/int/long/long long
-	        If this frontend followed c9x, these types would always exist
-	        and be special integer types distinct from the regular ones
-	        (see the rank stuff), but we're following gcc so they
-	        aren't. If this changes, common_primitive_type, 
-		default_conversion and type_default_conversion need revising.
-	   */
+              - all integral types before tp_first_floating
+              - do not change the floating type order
+              - the integral types are ordered by "rank" (see c9x std) and
+                unsignedness (unsigned > signed) (common_primitive_type
+                relies on this order)
+              - The tp_[u]int<n> types must be before tp_char (for the 
+                assert in common_primitive_type). These types are only
+                used when the corresponding size is not available amongst
+                short/int/long/long long
+                If this frontend followed c9x, these types would always exist
+                and be special integer types distinct from the regular ones
+                (see the rank stuff), but we're following gcc so they
+                aren't. If this changes, common_primitive_type, 
+                default_conversion and type_default_conversion need revising.
+           */
            tp_error,
 
-	   tp_int2, tp_uint2, tp_int4, tp_uint4, tp_int8, tp_uint8,
+           tp_int2, tp_uint2, tp_int4, tp_uint4, tp_int8, tp_uint8,
 
            tp_char, 
-	   tp_signed_char, tp_unsigned_char,
-	   tp_short, tp_unsigned_short,
-	   tp_int, tp_unsigned_int,
-	   tp_long, tp_unsigned_long,
-	   tp_long_long, tp_unsigned_long_long,
-	   /* Used as the rep type of enums whose constants are derived
-	      from template arguments and whose size is hence unknown.
-	      The unknown int type has the highest rank (its unsignedness
-	      is unknown, we assume its signed). */
-	   tp_unknown_int,
+           tp_signed_char, tp_unsigned_char,
+           tp_short, tp_unsigned_short,
+           tp_int, tp_unsigned_int,
+           tp_long, tp_unsigned_long,
+           tp_long_long, tp_unsigned_long_long,
+           /* Used as the rep type of enums whose constants are derived
+              from template arguments and whose size is hence unknown.
+              The unknown int type has the highest rank (its unsignedness
+              is unknown, we assume its signed). */
+           tp_unknown_int,
 
-	   tp_first_floating,
-	   tp_float = tp_first_floating, tp_double, tp_long_double,
+           tp_first_floating,
+           tp_float = tp_first_floating, tp_double, tp_long_double,
 
-	   /* Like tp_unknown_int, but might be a real or integer */
-	   tp_unknown_number,
-	   tp_last
+           /* Like tp_unknown_int, but might be a real or integer */
+           tp_unknown_number,
+           tp_last
     } primitive;
 
     /* tk_tagged */
@@ -244,7 +244,7 @@ type make_qualified_type(type t, type_quals qualifiers)
   /* Push const or volatile down to base type */
   if (t->kind == tk_array)
     return make_array_type(make_qualified_type(t->u.array.arrayof, qualifiers),
-			   t->u.array.size);
+                           t->u.array.size);
   else
     {
       type nt = copy_type(t);
@@ -284,7 +284,7 @@ type make_array_type(type t, expression size)
    If oldstyle is true, this is an oldstyle function type and
    argtypes is NULL */
 type make_function_type(type t, typelist argtypes, bool varargs,
-			bool oldstyle)
+                        bool oldstyle)
 {
   type nt = new_type(tk_function);
   nt->u.fn.fkind = tkf_c;
@@ -309,7 +309,7 @@ type build_function_type(region r, type returns, ...)
       type onearg = va_arg(args, type);
 
       if (!onearg)
-	break;
+        break;
       typelist_append(argtypes, onearg);
     }
 
@@ -340,7 +340,7 @@ bool type_network(type t)
 */
 
 static type make_primitive0(int pk, cval size, cval alignment,
-			    cval complex_size)
+                            cval complex_size)
 {
   type nt = new_type(tk_primitive), ct;
 
@@ -361,23 +361,23 @@ static type make_primitive0(int pk, cval size, cval alignment,
 static type make_primitive(int pk, int size, int alignment)
 {
   return make_primitive0(pk, make_type_cval(size), make_type_cval(alignment),
-			 make_type_cval(size * 2));
+                         make_type_cval(size * 2));
 }
 
 static type make_unknown_primitive(int pk)
 {
   return make_primitive0(pk, cval_unknown_number, cval_unknown_number,
-			 cval_unknown_number);
+                         cval_unknown_number);
 }
 
 static type lookup_primitive(int default_kind, int size, int alignment,
-			     bool isunsigned)
+                             bool isunsigned)
 {
   int i;
 
   for (i = tp_signed_char; i < tp_unknown_int; i++)
     if (cval_uint_value(primitive_types[i]->size) == size &&
-	type_unsigned(primitive_types[i]) == isunsigned)
+        type_unsigned(primitive_types[i]) == isunsigned)
       return primitive_types[i];
 
   return make_primitive(default_kind, size, alignment);
@@ -423,7 +423,7 @@ type type_for_cval(cval c, bool isunsigned)
 
   for (i = tp_signed_char; i < tp_unknown_int; i++)
     if (type_unsigned(primitive_types[i]) == isunsigned &&
-	cval_inrange(c, primitive_types[i]))
+        cval_inrange(c, primitive_types[i]))
       return primitive_types[i];
 
   return NULL;
@@ -592,7 +592,7 @@ bool type_unsigned(type t)
       case tp_unsigned_long:
       case tp_unsigned_long_long:
       case tp_uint2: case tp_uint4: case tp_uint8:
-	return TRUE;
+        return TRUE;
       default: break;
       }
   return FALSE;
@@ -832,14 +832,14 @@ static bool type_lists_equal(typelist al1, typelist al2)
   for (;;)
     {
       if (args1 == 0 && args2 == 0)
-	return TRUE;
+        return TRUE;
       /* If one list is shorter than the other,
-	 they fail to match.  */
+         they fail to match.  */
       if (args1 == 0 || args2 == 0)
-	return FALSE;
+        return FALSE;
 
       if (!type_equal(args1->t, args2->t))
-	return FALSE;
+        return FALSE;
 
       args1 = args1->next;
       args2 = args2->next;
@@ -851,7 +851,7 @@ bool function_equal(type t1, type t2)
 {
   /* Function kinds and return types must match */
   if (!(t1->u.fn.fkind == t2->u.fn.fkind &&
-	type_equal(t1->u.fn.returns, t2->u.fn.returns)))
+        type_equal(t1->u.fn.returns, t2->u.fn.returns)))
     return FALSE;
 
   if (!t1->u.fn.oldstyle && !t2->u.fn.oldstyle)
@@ -928,7 +928,7 @@ bool type_equal_unqualified(type t1, type t2)
 
     case tk_array:
       return type_equal(t1->u.array.arrayof, t2->u.array.arrayof) &&
-	array_sizes_match(t1, t2);
+        array_sizes_match(t1, t2);
 
     case tk_variable:
       return t1->u.tdecl == t2->u.tdecl;
@@ -988,14 +988,14 @@ static bool weird_parameter_match(type t1, type t2)
 
       /* We don't do this for types of unknown size */
       if (cval_isinteger(s1) && cval_isinteger(s2) &&
-	  cval_intcompare(s1, s2) == 0)
-	{
-	  field_declaration field;
+          cval_intcompare(s1, s2) == 0)
+        {
+          field_declaration field;
 
-	  for (field = t1decl->fieldlist; field; field = field->next)
-	    if (type_compatible(field->type, t2))
-	      return TRUE;
-	}
+          for (field = t1decl->fieldlist; field; field = field->next)
+            if (type_compatible(field->type, t2))
+              return TRUE;
+        }
     }
   return FALSE;
 }
@@ -1008,7 +1008,7 @@ static type weird_common_parameter(type t1, type t2)
   if (weird_parameter_match(t1, t2))
     {
       if (pedantic)
-	pedwarn("function types not truly compatible in ANSI C");
+        pedwarn("function types not truly compatible in ANSI C");
       return t2;
     }
   return NULL;
@@ -1027,22 +1027,22 @@ static int type_lists_compatible(typelist al1, typelist al2)
   while (1)
     {
       if (args1 == 0 && args2 == 0)
-	return val;
+        return val;
       /* If one list is shorter than the other,
-	 they fail to match.  */
+         they fail to match.  */
       if (args1 == 0 || args2 == 0)
-	return 0;
+        return 0;
 
       if (!(newval = type_compatible_unqualified(args1->t, args2->t)))
-	{
-	  if (!weird_parameter_match(args1->t, args2->t) &&
-	      !weird_parameter_match(args2->t, args1->t))
-	    return 0;
-	}
+        {
+          if (!weird_parameter_match(args1->t, args2->t) &&
+              !weird_parameter_match(args2->t, args1->t))
+            return 0;
+        }
 
       /* type_compatible said ok, but record if it said to warn.  */
       if (newval > val)
-	val = newval;
+        val = newval;
 
       args1 = args1->next;
       args2 = args2->next;
@@ -1064,7 +1064,7 @@ int function_compatible(type t1, type t2)
 
   /* Kinds and return types must match */
   if (!(t1->u.fn.fkind == t2->u.fn.fkind &&
-	type_compatible(t1->u.fn.returns, t2->u.fn.returns)))
+        type_compatible(t1->u.fn.returns, t2->u.fn.returns)))
     return 0;
 
   args1 = t1->u.fn.argtypes;
@@ -1076,25 +1076,25 @@ int function_compatible(type t1, type t2)
   if (t1->u.fn.oldstyle)
     {
       if (args2 && !self_promoting_args(t2))
-	return 0;
+        return 0;
 #if 0
       /* If one of these types comes from a non-prototype fn definition,
-	 compare that with the other type's arglist.
-	 If they don't match, ask for a warning (but no error).  */
+         compare that with the other type's arglist.
+         If they don't match, ask for a warning (but no error).  */
       if (TYPE_ACTUAL_ARG_TYPES (f1)
-	  && 1 != type_lists_compatible(args2, TYPE_ACTUAL_ARG_TYPES (f1)))
-	val = 2;
+          && 1 != type_lists_compatible(args2, TYPE_ACTUAL_ARG_TYPES (f1)))
+        val = 2;
 #endif
       return val;
     }
   if (t2->u.fn.oldstyle)
     {
       if (args1 && !self_promoting_args(t1))
-	return 0;
+        return 0;
 #if 0
       if (TYPE_ACTUAL_ARG_TYPES (f2)
-	  && 1 != type_lists_compatible(args1, TYPE_ACTUAL_ARG_TYPES (f2)))
-	val = 2;
+          && 1 != type_lists_compatible(args1, TYPE_ACTUAL_ARG_TYPES (f2)))
+        val = 2;
 #endif
       return val;
     }
@@ -1120,7 +1120,7 @@ static bool interface_equal(nesc_declaration i1, nesc_declaration i2)
   while (p1 && p2)
     {
       if (!type_equal(p1->ddecl->type, p2->ddecl->type))
-	return FALSE;
+        return FALSE;
       
       p1 = CAST(type_parm_decl, p1->next);
       p2 = CAST(type_parm_decl, p2->next);
@@ -1180,7 +1180,7 @@ bool type_compatible_unqualified(type t1, type t2)
 
     case tk_array:
       return type_compatible(t1->u.array.arrayof, t2->u.array.arrayof) &&
-	array_sizes_match(t1, t2);
+        array_sizes_match(t1, t2);
 
     case tk_iref:
       return interface_equal(t1->u.iref->itype, t2->u.iref->itype);
@@ -1248,29 +1248,29 @@ static int common_primitive_type(type t1, type t2)
 
       /* The simple cases */
       if (pk1 == tp_unknown_int || pk2 == tp_unknown_int)
-	return tp_unknown_int;
+        return tp_unknown_int;
 
       s1 = cval_uint_value(t1->size);
       s2 = cval_uint_value(t2->size);
       if (s1 < s2)
-	return pk2;
+        return pk2;
       else if (s1 > s2)
-	return pk1;
+        return pk1;
 
       /* The pain starts, see 6.3.1.8 of c9x */
       /* If the sizes are the same, then we can't have a tp_[u]int<n> or a 
-	 tp_char/short/int/long/etc pair (as we only have tp_[u]int<n> if there
-	 is no corresponding integer type of the same size. So we can compare rank
-	 by comparing pk1 and pk2 */
+         tp_char/short/int/long/etc pair (as we only have tp_[u]int<n> if there
+         is no corresponding integer type of the same size. So we can compare rank
+         by comparing pk1 and pk2 */
       assert(!((pk1 < tp_char && pk2 >= tp_char) ||
-	       (pk1 >= tp_char && pk2 < tp_char)));
+               (pk1 >= tp_char && pk2 < tp_char)));
 
       /* the higher rank wins, and if either of the types is unsigned, the
-	 result is unsigned (thus unsigned short + int == unsigned int if
-	 sizeof(short) == sizeof(int) */
+         result is unsigned (thus unsigned short + int == unsigned int if
+         sizeof(short) == sizeof(int) */
       if ((type_unsigned(t1) || type_unsigned(t2)) && !type_unsigned(primitive_types[pk]))
-	/* A bit inefficient, admittedly */
-	pk = make_unsigned_type(primitive_types[pk])->u.primitive;
+        /* A bit inefficient, admittedly */
+        pk = make_unsigned_type(primitive_types[pk])->u.primitive;
 
       return pk;
     }
@@ -1315,7 +1315,7 @@ type common_type(type t1, type t2)
   if (type_enum(t1))
     {
       if (type_equal_unqualified(t1, t2))
-	return make_combiner_type(qualify_type2(t1, t1, t2), combiner);
+        return make_combiner_type(qualify_type2(t1, t1, t2), combiner);
       t1 = qualify_type1(type_for_size(type_size(t1), TRUE), t1);
     }
   if (type_enum(t2))
@@ -1327,104 +1327,104 @@ type common_type(type t1, type t2)
     {
       int pk = common_primitive_type(t1, t2);
       assert((t1->kind == tk_primitive || t1->kind == tk_complex) && 
-	     (t2->kind == tk_primitive || t2->kind == tk_complex));
+             (t2->kind == tk_primitive || t2->kind == tk_complex));
       rtype = complex_types[pk];
     }
   else
     switch (t1->kind)
       {
       case tk_primitive:
-	/* We need to preserve equivalent network base types because
-	   common_type is used for redeclarations */
-	if (type_network_base_type(t1) && type_network_base_type(t2) &&
-	    t1->basedecl == t2->basedecl)
-	  rtype = make_qualified_type(t1, 0);
-	else
-	  {
-	    int pk = common_primitive_type(t1, t2);
-	    assert(t2->kind == tk_primitive);
-	    rtype = primitive_types[pk];
-	  
-	    break;
-	  }
+        /* We need to preserve equivalent network base types because
+           common_type is used for redeclarations */
+        if (type_network_base_type(t1) && type_network_base_type(t2) &&
+            t1->basedecl == t2->basedecl)
+          rtype = make_qualified_type(t1, 0);
+        else
+          {
+            int pk = common_primitive_type(t1, t2);
+            assert(t2->kind == tk_primitive);
+            rtype = primitive_types[pk];
+          
+            break;
+          }
 
       case tk_void: case tk_tagged: case tk_variable:
-	rtype = t1;
-	break;
+        rtype = t1;
+        break;
 
       case tk_pointer:
-	rtype = make_pointer_type(common_type(t1->u.pointsto, t2->u.pointsto));
-	break;
+        rtype = make_pointer_type(common_type(t1->u.pointsto, t2->u.pointsto));
+        break;
 
       case tk_array:
-	{
-	  /* Merge the element types, and have a size if either arg has one.  */
-	  type element_type =
-	    common_type(t1->u.array.arrayof, t2->u.array.arrayof);
-	  expression size1 = t1->u.array.size, size2 = t2->u.array.size;
+        {
+          /* Merge the element types, and have a size if either arg has one.  */
+          type element_type =
+            common_type(t1->u.array.arrayof, t2->u.array.arrayof);
+          expression size1 = t1->u.array.size, size2 = t2->u.array.size;
 
-	  rtype = make_array_type(element_type, size1 ? size1 : size2);
-	  break;
-	}
+          rtype = make_array_type(element_type, size1 ? size1 : size2);
+          break;
+        }
 
       case tk_function:
-	/* Function types: prefer the one that specified arg types.
-	   If both do, merge the arg types.  Also merge the return types.  */
-	{
-	  type valtype = common_type(t1->u.fn.returns, t2->u.fn.returns);
-	  typelist args;
-	  bool oldstyle, varargs;
+        /* Function types: prefer the one that specified arg types.
+           If both do, merge the arg types.  Also merge the return types.  */
+        {
+          type valtype = common_type(t1->u.fn.returns, t2->u.fn.returns);
+          typelist args;
+          bool oldstyle, varargs;
 
-	  if (t1->u.fn.oldstyle && t2->u.fn.oldstyle)
-	    {
-	      args = NULL;
-	      oldstyle = TRUE;
-	      varargs = FALSE;
-	    }
-	  else if (t1->u.fn.oldstyle)
-	    {
-	      args = t2->u.fn.argtypes;
-	      oldstyle = FALSE;
-	      varargs = t2->u.fn.varargs;
-	    }
-	  else if (t2->u.fn.oldstyle)
-	    {
-	      args = t1->u.fn.argtypes;
-	      oldstyle = FALSE;
-	      varargs = t1->u.fn.varargs;
-	    }
-	  else
-	    {
-	      /* If both args specify argument types, we must merge the two
-		 lists, argument by argument.  */
-	      struct typelist_element *args1 = t1->u.fn.argtypes->first;
-	      struct typelist_element *args2 = t2->u.fn.argtypes->first;
-	      type argtype;
+          if (t1->u.fn.oldstyle && t2->u.fn.oldstyle)
+            {
+              args = NULL;
+              oldstyle = TRUE;
+              varargs = FALSE;
+            }
+          else if (t1->u.fn.oldstyle)
+            {
+              args = t2->u.fn.argtypes;
+              oldstyle = FALSE;
+              varargs = t2->u.fn.varargs;
+            }
+          else if (t2->u.fn.oldstyle)
+            {
+              args = t1->u.fn.argtypes;
+              oldstyle = FALSE;
+              varargs = t1->u.fn.varargs;
+            }
+          else
+            {
+              /* If both args specify argument types, we must merge the two
+                 lists, argument by argument.  */
+              struct typelist_element *args1 = t1->u.fn.argtypes->first;
+              struct typelist_element *args2 = t2->u.fn.argtypes->first;
+              type argtype;
 
-	      oldstyle = FALSE;
-	      varargs = t1->u.fn.varargs;
-	      args = new_typelist(t1->u.fn.argtypes->r);
+              oldstyle = FALSE;
+              varargs = t1->u.fn.varargs;
+              args = new_typelist(t1->u.fn.argtypes->r);
 
-	      while (args1)
-		{
-		  (void) ((argtype = weird_common_parameter(args1->t, args2->t)) ||
-			  (argtype = weird_common_parameter(args2->t, args1->t)) ||
-			  (argtype = common_type(args1->t, args2->t)));
-		  typelist_append(args, argtype);
+              while (args1)
+                {
+                  (void) ((argtype = weird_common_parameter(args1->t, args2->t)) ||
+                          (argtype = weird_common_parameter(args2->t, args1->t)) ||
+                          (argtype = common_type(args1->t, args2->t)));
+                  typelist_append(args, argtype);
 
-		  args1 = args1->next;
-		  args2 = args2->next;
-		}
+                  args1 = args1->next;
+                  args2 = args2->next;
+                }
 
-	    }
-	  rtype = make_function_type(valtype, args, varargs, oldstyle);
-	  /* Hack up the function kind */
-	  rtype->u.fn.fkind = t1->u.fn.fkind;
-	  break;
-	}
+            }
+          rtype = make_function_type(valtype, args, varargs, oldstyle);
+          /* Hack up the function kind */
+          rtype->u.fn.fkind = t1->u.fn.fkind;
+          break;
+        }
 
       default:
-	assert(0); return NULL;
+        assert(0); return NULL;
       }
 
   rtype = qualify_type2(rtype, t1, t2);
@@ -1506,7 +1506,7 @@ static type_element qualifier2ast(region r, location loc, int keyword, type_elem
 }
 
 static type_element qualifiers2ast(region r, location loc, type_quals quals,
-				   type_element rest)
+                                   type_element rest)
 {
   if (quals & volatile_qualifier)
     rest = qualifier2ast(r, loc, volatile_qualifier, rest);
@@ -1516,7 +1516,7 @@ static type_element qualifiers2ast(region r, location loc, type_quals quals,
 }
 
 static type_element primitive2ast(region r, location loc, int primitive,
-				  type_element rest)
+                                  type_element rest)
 {
   bool isunsigned = FALSE;
   int keyword;
@@ -1585,20 +1585,20 @@ void name_tag(tag_declaration tag)
 
       sprintf(tagname, UNNAMED_STRUCT_PREFIX "%ld", nextid++);
       tag->definition->word1 = new_word(parse_region, dummy_location,
-					str2cstring(parse_region, tagname));
+                                        str2cstring(parse_region, tagname));
       tag->name = tag->definition->word1->cstring.data;
     }
 }
 
 static type_element tag2ast(region r, location loc, tag_declaration tag,
-			    type_element rest)
+                            type_element rest)
 {
   tag_ref tr;
 
   name_tag(tag);
   tr = newkind_tag_ref(r, tag->kind, loc, 
-		       new_word(r, loc, str2cstring(r, tag->name)),
-		       NULL, NULL, FALSE);
+                       new_word(r, loc, str2cstring(r, tag->name)),
+                       NULL, NULL, FALSE);
 
   tr->tdecl = tag;
   tr->next = CAST(node, rest);
@@ -1629,7 +1629,7 @@ static type_element tag2ast(region r, location loc, tag_declaration tag,
 }
 
 static type_element typevar2ast(region r, location loc, data_declaration tvar,
-				type_element rest)
+                                type_element rest)
 {
   type_element tname;
 
@@ -1662,7 +1662,7 @@ static declaration parameter2ast(region r, location loc, type t)
 /* Build AST nodes such that "MODIFIERS D" represents the declaration of
    "T INSIDE", at location loc, allocating in region r */
 void type2ast(region r, location loc, type t, declarator inside,
-	      declarator *d, type_element *modifiers)
+              declarator *d, type_element *modifiers)
 {
   /* XXX: De-recursify */
   type_element qualifiers = qualifiers2ast(r, loc, t->qualifiers, NULL);
@@ -1687,8 +1687,8 @@ void type2ast(region r, location loc, type t, declarator inside,
       break;
     case tk_complex:
       *modifiers =
-	rid2ast(r, loc, RID_COMPLEX, 
-	primitive2ast(r, loc, t->u.primitive, qualifiers));
+        rid2ast(r, loc, RID_COMPLEX, 
+        primitive2ast(r, loc, t->u.primitive, qualifiers));
       *d = inside;
       break;
     case tk_tagged:
@@ -1701,50 +1701,50 @@ void type2ast(region r, location loc, type t, declarator inside,
       break;
     case tk_pointer:
       if (qualifiers)
-	inside = CAST(declarator,
-		      new_qualified_declarator(r, loc, inside, qualifiers));
+        inside = CAST(declarator,
+                      new_qualified_declarator(r, loc, inside, qualifiers));
       inside = CAST(declarator,
-		    new_pointer_declarator(r, loc, inside));
+                    new_pointer_declarator(r, loc, inside));
       type2ast(r, loc, t->u.pointsto, inside, d, modifiers);
       break;
     case tk_array:
       assert(qualifiers == NULL);
       inside = CAST(declarator,
-		    new_array_declarator(r, loc, inside, t->u.array.size));
+                    new_array_declarator(r, loc, inside, t->u.array.size));
       type2ast(r, loc, t->u.array.arrayof, inside, d, modifiers);
       break;
     case tk_function: {
       declaration parms;
 
       assert(t->u.fn.fkind == tkf_c); /* XXX: not done for nesC stuff yet
-					 (not needed yet) */
+                                         (not needed yet) */
       /* XXX: doesn't rebuild fn qualifiers. Are we generating C here
-	 or not ? */
+         or not ? */
       /* XXX: Should build environment for parameters */
       if (t->u.fn.oldstyle)
-	parms = NULL;
+        parms = NULL;
       else if (empty_typelist(t->u.fn.argtypes))
-	parms = parameter2ast(r, loc, void_type);
+        parms = parameter2ast(r, loc, void_type);
       else
-	{
-	  struct typelist_element *args = t->u.fn.argtypes->first;
-	  declaration *lastparm = &parms;
+        {
+          struct typelist_element *args = t->u.fn.argtypes->first;
+          declaration *lastparm = &parms;
 
-	  while (args)
-	    {
-	      *lastparm = parameter2ast(r, loc, args->t);
-	      lastparm = (declaration *)&(*lastparm)->next;
-	      args = args->next;
-	    }
-	  if (t->u.fn.varargs)
-	    {
-	      *lastparm = CAST(declaration, new_ellipsis_decl(r, loc));
-	      lastparm = (declaration *)&(*lastparm)->next;
-	    }
-	  *lastparm = NULL;
-	}
+          while (args)
+            {
+              *lastparm = parameter2ast(r, loc, args->t);
+              lastparm = (declaration *)&(*lastparm)->next;
+              args = args->next;
+            }
+          if (t->u.fn.varargs)
+            {
+              *lastparm = CAST(declaration, new_ellipsis_decl(r, loc));
+              lastparm = (declaration *)&(*lastparm)->next;
+            }
+          *lastparm = NULL;
+        }
       inside = CAST(declarator,
-		    new_function_declarator(r, loc, inside, parms, NULL, NULL, NULL));
+                    new_function_declarator(r, loc, inside, parms, NULL, NULL, NULL));
       type2ast(r, loc, t->u.fn.returns, inside, d, modifiers);
       break;
     }
@@ -1805,9 +1805,9 @@ type type_default_conversion(type from)
     {
       /* Traditionally, unsignedness is preserved in default promotions. */
       if (flag_traditional && type_unsigned(from))
-	return unsigned_int_type;
+        return unsigned_int_type;
       else
-	return int_type;
+        return int_type;
     }
   /* Note: if we had a type of same size as int, but of lesser rank, we should be
      returning one of int/unsigned int here, but we don't support that kind of
@@ -1827,11 +1827,11 @@ type type_default_conversion(type from)
       data_declaration vdecl = type_variable_decl(from);
 
       switch (vdecl->typevar_kind)
-	{
-	case typevar_integer: return unknown_int_type;
-	case typevar_number: return unknown_number_type;
-	default: break;
-	}
+        {
+        case typevar_integer: return unknown_int_type;
+        case typevar_number: return unknown_number_type;
+        default: break;
+        }
     }
 
   return from;
@@ -2168,7 +2168,7 @@ type instantiate_type(type t)
     {
     case tk_tagged:
       if (t->u.tag->instantiation)
-	newt = make_tagged_type(t->u.tag->instantiation);
+        newt = make_tagged_type(t->u.tag->instantiation);
       break;
 
     case tk_pointer:
@@ -2180,7 +2180,7 @@ type instantiate_type(type t)
       typelist args = NULL;
 
       if (t->u.fn.argtypes)
-	args = instantiate_typelist(t->u.fn.argtypes);
+        args = instantiate_typelist(t->u.fn.argtypes);
 
       newt = make_function_type(ret, args, t->u.fn.varargs, t->u.fn.oldstyle);
       newt->u.fn.fkind = t->u.fn.fkind;
@@ -2188,23 +2188,23 @@ type instantiate_type(type t)
     }
     case tk_array:
       newt = make_array_type(instantiate_type(t->u.array.arrayof),
-			     !t->u.array.size ? NULL :
-			     CAST(expression, t->u.array.size->instantiation));
+                             !t->u.array.size ? NULL :
+                             CAST(expression, t->u.array.size->instantiation));
       break;
 
     case tk_iref:
       if (t->u.iref->instantiation)
-	newt = make_interface_type(t->u.iref->instantiation);
+        newt = make_interface_type(t->u.iref->instantiation);
       break;
 
     case tk_cref:
       if (t->u.cref->instantiation)
-	newt = make_component_type(t->u.cref->instantiation);
+        newt = make_component_type(t->u.cref->instantiation);
       break;
 
     case tk_variable:
       if (t->u.tdecl->instantiation)
-	newt = t->u.tdecl->instantiation->type;
+        newt = t->u.tdecl->instantiation->type;
       break;
 
     default:
@@ -2261,8 +2261,8 @@ static const char *add_qualifiers(region r, type_quals qs, const char *to)
   for (q = 1; q < last_qualifier; q <<= 1)
     if (qs & q)
       {
-	to = rconcat(r, " ", to);
-	to = rconcat(r, qualifier_name(q), to);
+        to = rconcat(r, " ", to);
+        to = rconcat(r, qualifier_name(q), to);
       }
 
   return to;
@@ -2276,7 +2276,7 @@ static const char *add_parens(region r, const char *to)
 }
 
 static void split_type_name(region r, type t, const char **prefix,
-			    const char **decls, bool decls_is_star)
+                            const char **decls, bool decls_is_star)
 {
   const char *basic;
 
@@ -2302,7 +2302,7 @@ static void split_type_name(region r, type t, const char **prefix,
     case tk_array:
       /* can't have qualifiers here - see make_qualified_type */
       if (decls_is_star)
-	*decls = add_parens(r, *decls);
+        *decls = add_parens(r, *decls);
       *decls = rconcat(r, *decls, "[]");
       split_type_name(r, t->u.array.arrayof, &basic, decls, FALSE);
       break;
@@ -2310,29 +2310,29 @@ static void split_type_name(region r, type t, const char **prefix,
       const char *args= "";
 
       if (!t->u.fn.oldstyle)
-	{
-	  typelist_scanner scanargs;
-	  type argt;
-	  bool first = TRUE;
+        {
+          typelist_scanner scanargs;
+          type argt;
+          bool first = TRUE;
 
-	  typelist_scan(t->u.fn.argtypes, &scanargs);
-	  while ((argt = typelist_next(&scanargs)))
-	    {
-	      if (!first)
-		args = rconcat(r, args, ", ");
-	      args = rconcat(r, args, type_name(r, argt));
-	      first = FALSE;
-	    }
-	  if (t->u.fn.varargs)
-	    args = rconcat(r, args, ", ...");
-	}
+          typelist_scan(t->u.fn.argtypes, &scanargs);
+          while ((argt = typelist_next(&scanargs)))
+            {
+              if (!first)
+                args = rconcat(r, args, ", ");
+              args = rconcat(r, args, type_name(r, argt));
+              first = FALSE;
+            }
+          if (t->u.fn.varargs)
+            args = rconcat(r, args, ", ...");
+        }
 
       if (decls_is_star)
-	*decls = add_parens(r, *decls);
+        *decls = add_parens(r, *decls);
 
       if (t->qualifiers)
-	/* This isn't legal C syntax, but seems the reasonable rep */
-	*decls = add_parens(r, add_qualifiers(r, t->qualifiers, *decls));
+        /* This isn't legal C syntax, but seems the reasonable rep */
+        *decls = add_parens(r, add_qualifiers(r, t->qualifiers, *decls));
 
       *decls = rconcat(r, *decls, add_parens(r, args));
 
@@ -2345,14 +2345,14 @@ static void split_type_name(region r, type t, const char **prefix,
       basic = rconcat(r, tagkind_name(tdecl->kind), " ");
 
       if (tdecl->container)
-	{
-	  basic = rconcat(r, basic, tdecl->container->name);
-	  basic = rconcat(r, basic, ".");
-	}
+        {
+          basic = rconcat(r, basic, tdecl->container->name);
+          basic = rconcat(r, basic, ".");
+        }
       if (tdecl->name)
-	basic = rconcat(r, basic, tdecl->name);
+        basic = rconcat(r, basic, tdecl->name);
       else
-	basic = rconcat(r, basic, "/*anon*/");
+        basic = rconcat(r, basic, "/*anon*/");
       basic = add_qualifiers(r, t->qualifiers, basic);
       break;
     }
@@ -2405,30 +2405,30 @@ void nxml_type(type t)
       xml_tag_end();
       xnewline();
       if (tdef)
-	{
-	  nxml_typedef(tdef);
-	  tdef = NULL;
-	}
+        {
+          nxml_typedef(tdef);
+          tdef = NULL;
+        }
     }
     
   switch (t->kind)
     {
     case tk_primitive:
       if (t->u.primitive < tp_first_floating)
-	xml_tag_start("type-int");
+        xml_tag_start("type-int");
       else
-	xml_tag_start("type-float");
+        xml_tag_start("type-float");
       xml_attr("cname", primname[t->u.primitive]);
       xml_attr_bool("unsigned", type_unsigned(t));
       break;
     case tk_complex:
       if (t->u.primitive < tp_first_floating)
-	{
-	  xml_tag_start("type-complex-int");
-	  xml_attr_bool("unsigned", type_unsigned(primitive_types[t->u.primitive]));
-	}
+        {
+          xml_tag_start("type-complex-int");
+          xml_attr_bool("unsigned", type_unsigned(primitive_types[t->u.primitive]));
+        }
       else
-	xml_tag_start("type-complex-float");
+        xml_tag_start("type-complex-float");
       xml_attr("cname", primname[t->u.primitive]);
       break;
     case tk_void:
@@ -2491,7 +2491,7 @@ void nxml_type(type t)
       xnewline(); xindent();
       nxml_type(t->u.fn.returns);
       if (!t->u.fn.oldstyle)
-	nxml_typelist("function-parameters", t->u.fn.argtypes);
+        nxml_typelist("function-parameters", t->u.fn.argtypes);
       xunindent();
       break;
     case tk_tagged:
@@ -2606,38 +2606,38 @@ bool type_contains(type parent, type child)
     case tk_complex:
       /* true if child is primitive or complex and same base primitive type */
       return (child->kind == tk_primitive || child->kind == tk_complex) &&
-	parent->u.primitive == child->u.primitive;
+        parent->u.primitive == child->u.primitive;
 
     case tk_tagged: {
       /* Same tags -> yes. Otherwise, for structs, unions: true if parent
-	 has a field type that contains child */
+         has a field type that contains child */
       field_declaration field;
 
       if (child->kind == tk_tagged && parent->u.tag == child->u.tag)
-	return TRUE;
+        return TRUE;
 
       if (parent->u.tag->kind == kind_enum_ref)
-	return FALSE;
+        return FALSE;
 
       for (field = parent->u.tag->fieldlist; field; field = field->next)
-	if (type_contains(field->type, child))
-	  return TRUE;
+        if (type_contains(field->type, child))
+          return TRUE;
 
       return FALSE;
     }
 
     case tk_pointer:
       /* base types must match, but can have different qualifiers
-	 (this is different from type_equal) */
+         (this is different from type_equal) */
       return 
-	child->kind == tk_pointer &&
-	type_equal_unqualified(parent->u.pointsto, child->u.pointsto);
+        child->kind == tk_pointer &&
+        type_equal_unqualified(parent->u.pointsto, child->u.pointsto);
 
     case tk_array: {
       type base_parent = parent;
     
       while (base_parent->kind == tk_array)
-	base_parent = base_parent->u.array.arrayof;
+        base_parent = base_parent->u.array.arrayof;
 
       return type_contains(base_parent, child);
     }
@@ -2713,22 +2713,22 @@ type type_for_mode(const char *mode, bool isunsigned)
   for (i = 0; i < sizeof modes / sizeof *modes; i++)
     if (is_attr_name(mode, modes[i].name))
       {
-	type t;
+        type t;
 
-	switch (modes[i].m)
-	  {
-	  case m_int: case m_cint:
-	    t = lookup_primitive(tp_error, modes[i].s, 0, isunsigned);
-	    break;
-	  case m_float: case m_cfloat:
-	    t = lookup_float(modes[i].s);
-	    break;
-	  }
-	if (t->u.primitive == tp_error)
-	  return NULL;
-	if (modes[i].m == m_cint || modes[i].m == m_cfloat)
-	  t = make_complex_type(t);
-	return t;
+        switch (modes[i].m)
+          {
+          case m_int: case m_cint:
+            t = lookup_primitive(tp_error, modes[i].s, 0, isunsigned);
+            break;
+          case m_float: case m_cfloat:
+            t = lookup_float(modes[i].s);
+            break;
+          }
+        if (t->u.primitive == tp_error)
+          return NULL;
+        if (modes[i].m == m_cint || modes[i].m == m_cfloat)
+          t = make_complex_type(t);
+        return t;
       }
   return NULL;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -176,7 +176,7 @@ bool type_unknown_number(type t);
 bool type_unknown(type t); /* unknown_int or unknown_number */
 
 bool type_tagged(type t);
-bool type_integral(type t);	/* Does not include enum's */
+bool type_integral(type t);        /* Does not include enum's */
 bool type_floating(type t);
 bool type_complex(type t);
 bool type_float(type t);
@@ -188,15 +188,15 @@ bool type_array(type t);
 bool type_pointer(type t);
 bool type_enum(type t);
 bool type_struct(type t);
-bool type_attribute(type t); 	/* For internal use for @attributes */
+bool type_attribute(type t);         /* For internal use for @attributes */
 bool type_union(type t);
-bool type_integer(type t);	/* Does include enum's */
+bool type_integer(type t);        /* Does include enum's */
 bool type_unsigned(type t);
 bool type_smallerthanint(type t);
 bool type_real(type t);
 bool type_arithmetic(type t);
 bool type_scalar(type t);
-bool type_aggregate(type t);	/* struct or union */
+bool type_aggregate(type t);        /* struct or union */
 
 type make_unsigned_type(type t);
 
@@ -221,7 +221,7 @@ type type_base(type t);
 /* Build AST nodes such that "MODIFIERS D" represents the declaration of
    "T INSIDE", at location loc, allocating in region r */
 void type2ast(region r, location loc, type t, declarator inside,
-	      declarator *d, type_element *modifiers);
+              declarator *d, type_element *modifiers);
 
 bool type_contains_pointers(type t);
 bool type_contains_cross_pointers(type t);

--- a/src/unparse.c
+++ b/src/unparse.c
@@ -15,7 +15,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with nesC; see the file COPYING.	If not, write to
+along with nesC; see the file COPYING.        If not, write to
 the Free Software Foundation, 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA. */
 
@@ -144,13 +144,13 @@ void output_quoted(const char *s)
   while (*s)
     {
       if (*s == '\n') /* don't confuse the line numbers */
-	fputs("\\n", of);
+        fputs("\\n", of);
       else 
-	{
-	  if (*s == '\\' || *s == '"')
-	    putc('\\', of);
-	  putc(*s, of);
-	}
+        {
+          if (*s == '\\' || *s == '"')
+            putc('\\', of);
+          putc(*s, of);
+        }
       s++;
     }
 }
@@ -166,17 +166,17 @@ void output_quoted_cs(cstring s)
       char c = s.data[i];
 
       if (c == '\n') /* don't confuse the line numbers */
-	fputs("\\n", of);
+        fputs("\\n", of);
       else if ((unsigned char)c == c && isprint(c))
-	{
-	  if (c == '\\' || c == '"')
-	    putc('\\', of);
-	  putc(c, of);
-	}
+        {
+          if (c == '\\' || c == '"')
+            putc('\\', of);
+          putc(c, of);
+        }
       else 
-	/* The "" at the end avoids confusion if the next character
-	   is '0'-'9', 'a'-'f' or 'A'-'F' */
-	output("\\x%lx\"\"", (unsigned long)c);
+        /* The "" at the end avoids confusion if the next character
+           is '0'-'9', 'a'-'f' or 'A'-'F' */
+        output("\\x%lx\"\"", (unsigned long)c);
     }
 }
 
@@ -281,13 +281,13 @@ void set_location(location l)
     {
       /* Just send some newlines for small changes */
       if (!fixed_location &&
-	  output_loc.lineno < l->lineno && output_loc.lineno + 10 >= l->lineno)
-	{
-	  while (output_loc.lineno != l->lineno)
-	    newline();
-	}
+          output_loc.lineno < l->lineno && output_loc.lineno + 10 >= l->lineno)
+        {
+          while (output_loc.lineno != l->lineno)
+            newline();
+        }
       else
-	output_line_directive(l, FALSE);
+        output_line_directive(l, FALSE);
     }
 }
 
@@ -316,8 +316,8 @@ static void output_complex(known_cst c)
 
 void output_constant(known_cst c)
 /* Requires: (constant_integral(c) || constant_float(c)) &&
-	     type_arithmetic(c->type)
-	     or c denotes a string constant && type_chararray(c->type, FALSE)
+             type_arithmetic(c->type)
+             or c denotes a string constant && type_chararray(c->type, FALSE)
    Effects: prints a parsable representable of c to f
  */
 {
@@ -341,8 +341,8 @@ void output_constant(known_cst c)
       assert(ddecl && ddecl->kind == decl_magic_string);
       output("\"");
       /* FIXME we ignore wide char issues, just outputting the raw bytes - 
-	 this should be ok for now as we don't actually allow wide-char
-	 strings as arguments to generics anyway */
+         this should be ok for now as we don't actually allow wide-char
+         strings as arguments to generics anyway */
       output_quoted_cs(ddecl->schars);
       output("\"");
     }
@@ -351,25 +351,25 @@ void output_constant(known_cst c)
       assert(type_integral(t));
 
       if (type_unsigned(t))
-	output("%llu", constant_uint_value(c));
+        output("%llu", constant_uint_value(c));
       else
-	output("%lld", constant_sint_value(c));
+        output("%lld", constant_sint_value(c));
 
       if (type_size_int(t) <= type_size_int(int_type))
-	{
-	  if (type_unsigned(t))
-	    output("U");
-	}
+        {
+          if (type_unsigned(t))
+            output("U");
+        }
       else if (type_long(t))
-	output("L");
+        output("L");
       else if (type_unsigned_long(t))
-	output("UL");
+        output("UL");
       else if (type_long_long(t))
-	output("LL");
+        output("LL");
       else if (type_unsigned_long_long(t))
-	output("ULL");
+        output("ULL");
       else
-	assert(0);
+        assert(0);
     }
 }
 
@@ -381,7 +381,7 @@ void prt_data_decl(data_decl d);
 void prt_ellipsis_decl(ellipsis_decl d);
 void prt_function_decl(function_decl d);
 void prt_variable_decl(type_element modifier, variable_decl d,
-		       psd_options options);
+                       psd_options options);
 void prt_interesting_elements(type_element elements, psd_options options);
 void prt_type_elements(type_element elements, psd_options options);
 bool prt_type_element(type_element em, psd_options options);
@@ -479,8 +479,8 @@ void unparse_start(FILE *to, FILE *symbols)
   if (unparse_header)
     dd_scan (header_line, unparse_header)
       {
-	output_string(DD_GET(const char *, header_line));
-	newline();
+        output_string(DD_GET(const char *, header_line));
+        newline();
       }
 }
 
@@ -594,7 +594,7 @@ void prt_ellipsis_decl(ellipsis_decl d)
 }
 
 static void prt_prefix(location loc, data_declaration ddecl,
-		       type_element modifiers)
+                       type_element modifiers)
 {
   bool pinline = FALSE, pstatic = FALSE;
   type_element em;
@@ -605,60 +605,60 @@ static void prt_prefix(location loc, data_declaration ddecl,
       !ddecl->spontaneous && ddecl->definition)
     {
       if (ddecl->ftype != function_static)
-	{
-	  output("static ");
-	  pstatic = TRUE;
-	}
+        {
+          output("static ");
+          pstatic = TRUE;
+        }
       if (ddecl->makeinline && flag_no_inline < 2)
-	{
-	  output("inline ");
-	  pinline = TRUE;
-	}
+        {
+          output("inline ");
+          pinline = TRUE;
+        }
     }
 
   scan_type_element (em, modifiers)
     if (is_rid(em))
       {
-	rid r = CAST(rid, em);
+        rid r = CAST(rid, em);
 
-	/* Filter-out rids that should not be printed by calling continue */
-	switch (r->id)
-	  {
-	  default:
-	    continue;
-	  case RID_EXTERN: case RID_STATIC:
-	    if (pstatic)
-	      continue;
-	    break;
-	  case RID_INLINE:
-	    if (pinline)
-	      continue;
-	    break;
-	  case RID_REGISTER: case RID_TYPEDEF:
-	    break;
-	  }
-	set_location(r->location);
-	output("%s ", rid_name(r));
+        /* Filter-out rids that should not be printed by calling continue */
+        switch (r->id)
+          {
+          default:
+            continue;
+          case RID_EXTERN: case RID_STATIC:
+            if (pstatic)
+              continue;
+            break;
+          case RID_INLINE:
+            if (pinline)
+              continue;
+            break;
+          case RID_REGISTER: case RID_TYPEDEF:
+            break;
+          }
+        set_location(r->location);
+        output("%s ", rid_name(r));
       }
 }
-		       
+                       
 
 void prt_symbol_name(FILE *f, data_declaration ddecl)
 {
   if (!ddecl->Cname)
     {
       if (ddecl->container)
-	{
-	  print_stripped_string(f, ddecl->container->name);
-	  fputs(function_separator, f);
-	}
+        {
+          print_stripped_string(f, ddecl->container->name);
+          fputs(function_separator, f);
+        }
       if (ddecl->kind == decl_function && ddecl->interface)
-	{
-	  print_stripped_string(f, ddecl->interface->name);
-	  fputs(function_separator, f);
-	}
+        {
+          print_stripped_string(f, ddecl->interface->name);
+          fputs(function_separator, f);
+        }
       if (!ddecl->defined && ddecl_is_command_or_event(ddecl))
-	fprintf(f, "default%s", function_separator);
+        fprintf(f, "default%s", function_separator);
     }
 
   print_stripped_string(f, ddecl->name);
@@ -679,20 +679,20 @@ void prt_symbol_info(data_declaration ddecl)
       prt_symbol_name(symf, ddecl);
 
       if (ddecl->kind == decl_function)
-	{
-	  if (ddecl->makeinline || ddecl->isinline || ddecl->isexterninline)
-	    fprintf(symf, " FNINLINE\n");
-	  else
-	    fprintf(symf, " FN\n");
-	}
+        {
+          if (ddecl->makeinline || ddecl->isinline || ddecl->isexterninline)
+            fprintf(symf, " FNINLINE\n");
+          else
+            fprintf(symf, " FN\n");
+        }
       else
-	{
-	  assert(ddecl->kind == decl_variable);
-	  if (ddecl->initialiser)
-	    fprintf(symf, " DATA\n");
-	  else
-	    fprintf(symf, " BSS\n");
-	}
+        {
+          assert(ddecl->kind == decl_variable);
+          if (ddecl->initialiser)
+            fprintf(symf, " DATA\n");
+          else
+            fprintf(symf, " BSS\n");
+        }
     }
 }
 
@@ -717,23 +717,23 @@ void prt_data_decl(data_decl d)
       psd_options vopts = opts;
 
       if (vdecl) /* because build_declaration does not make a
-		    data_declaration */
-	{
-	  /* Ignore unused non-local declarations 
-	     (local ones might have an initialiser which must still be
-	     executed) */
-	  if (((vdecl->kind == decl_function || vdecl->kind == decl_variable)
-	       && !vdecl->isused && !vdecl->islocal))
-	    continue;
-	  if (use_nido && is_module_local_static(vdecl))
-	    continue;
+                    data_declaration */
+        {
+          /* Ignore unused non-local declarations 
+             (local ones might have an initialiser which must still be
+             executed) */
+          if (((vdecl->kind == decl_function || vdecl->kind == decl_variable)
+               && !vdecl->isused && !vdecl->islocal))
+            continue;
+          if (use_nido && is_module_local_static(vdecl))
+            continue;
 
-	  if (prt_network_typedef(d, vdd))
-	    vopts |= psd_prefix_nxbase;
+          if (prt_network_typedef(d, vdd))
+            vopts |= psd_prefix_nxbase;
 
-	  if (type_task(vdecl->type) && vdecl->interface)
-	    continue;
-	}
+          if (type_task(vdecl->type) && vdecl->interface)
+            continue;
+        }
 
       prt_diff_info(vdecl);
 
@@ -776,19 +776,19 @@ void prt_function_decl(function_decl d)
       prt_diff_info(d->ddecl);
       prt_prefix(d->location, d->ddecl, d->modifiers);
       if (ret)
-	{
-	  prt_attribute_elements(d->modifiers);
-	  prt_declarator(ret->declarator, ret->qualifiers, NULL, d->ddecl,
-			 psd_print_default | psd_print_ddecl_fdeclarator);
-	}
+        {
+          prt_attribute_elements(d->modifiers);
+          prt_declarator(ret->declarator, ret->qualifiers, NULL, d->ddecl,
+                         psd_print_default | psd_print_ddecl_fdeclarator);
+        }
       else
-	prt_declarator(d->declarator, d->modifiers, NULL, d->ddecl,
-		       psd_print_default);
+        prt_declarator(d->declarator, d->modifiers, NULL, d->ddecl,
+                       psd_print_default);
       if (d->attributes)
-	{
-	  output(" ");
-	  prt_type_elements(CAST(type_element, d->attributes), 0);
-	}
+        {
+          output(" ");
+          prt_type_elements(CAST(type_element, d->attributes), 0);
+        }
       outputln(";");
     }
 }
@@ -802,7 +802,7 @@ void prt_function_body(function_decl d)
       bool extrablock;
 
       /* We set current.function_decl because unparsing may produce error
-	 messages */
+         messages */
       current.function_decl = d;
       current.container = d->ddecl->container;
 
@@ -810,20 +810,20 @@ void prt_function_body(function_decl d)
       prt_prefix(d->location, d->ddecl, d->modifiers);
       /* gcc wants the attributes here */
       prt_type_elements(CAST(type_element, d->attributes), 
-			flag_gccize ? 0 : psd_no_target_attributes);
+                        flag_gccize ? 0 : psd_no_target_attributes);
 
       if (ret)
-	{
-	  prt_attribute_elements(d->modifiers);
-	  prt_declarator(ret->declarator, ret->qualifiers, NULL, d->ddecl,
-			 psd_print_default | psd_print_ddecl_fdeclarator);
-	}
+        {
+          prt_attribute_elements(d->modifiers);
+          prt_declarator(ret->declarator, ret->qualifiers, NULL, d->ddecl,
+                         psd_print_default | psd_print_ddecl_fdeclarator);
+        }
       else
-	prt_declarator(d->declarator, d->modifiers, NULL, d->ddecl,
-		       psd_print_default);
+        prt_declarator(d->declarator, d->modifiers, NULL, d->ddecl,
+                       psd_print_default);
 
       if (!flag_gccize)
-	prt_type_elements(CAST(type_element, d->attributes), psd_only_target_attributes);
+        prt_type_elements(CAST(type_element, d->attributes), psd_only_target_attributes);
 
       startline();
       prt_parameter_declarations(d->old_parms);
@@ -832,17 +832,17 @@ void prt_function_body(function_decl d)
       prt_compound_stmt(CAST(compound_stmt, d->stmt), !d->ddecl->safe);
       newline();
       if (extrablock)
-	{
-	  unindent();
-	  outputln("}");
-	}
+        {
+          unindent();
+          outputln("}");
+        }
 
       current.function_decl = d->parent_function;
     }
 }
 
 void prt_variable_decl(type_element modifiers, variable_decl d,
-		       psd_options options)
+                       psd_options options)
 {
   function_declarator fd = get_fdeclarator(d->declarator);
   asttype ret;
@@ -854,7 +854,7 @@ void prt_variable_decl(type_element modifiers, variable_decl d,
     {
       prt_attribute_elements(modifiers);
       prt_declarator(ret->declarator, ret->qualifiers, NULL, d->ddecl,
-		     options | psd_print_ddecl_fdeclarator);
+                     options | psd_print_ddecl_fdeclarator);
     }
   else
     prt_declarator(d->declarator, modifiers, NULL, d->ddecl, options);
@@ -876,7 +876,7 @@ void prt_variable_decl(type_element modifiers, variable_decl d,
 }
 
 void prt_declarator(declarator d, type_element elements, attribute attributes,
-		    data_declaration ddecl, psd_options options)
+                    data_declaration ddecl, psd_options options)
 {
   psd_options te_opts = options & (psd_duplicate | psd_rewrite_nxbase);
 
@@ -907,14 +907,14 @@ void prt_plain_ddecl(data_declaration ddecl, psd_options options)
   if (!ddecl->Cname)
     {
       if (ddecl->container && !(options & psd_skip_container))
-	prt_container(ddecl->container);
+        prt_container(ddecl->container);
       if (/*ddecl->kind == decl_function &&*/ ddecl->interface)
-	output_stripped_string_dollar(ddecl->interface->name);
+        output_stripped_string_dollar(ddecl->interface->name);
       if ((options & psd_print_default) &&
-	  !ddecl->defined && ddecl_is_command_or_event(ddecl))
+          !ddecl->defined && ddecl_is_command_or_event(ddecl))
       {
-	output("default");
-	output_string(function_separator);
+        output("default");
+        output_string(function_separator);
       }
     }
 
@@ -941,133 +941,133 @@ void prt_ddecl_full_name(data_declaration ddecl, psd_options options)
 /* The return value is TRUE iff d is an identifier_declarator possibly
    prefixed with qualified_declarators */
 bool prt_simple_declarator(declarator d, data_declaration ddecl,
-			   psd_options options)
+                           psd_options options)
 {
   if (!d)
     {
       if (options & psd_print_ddecl_fdeclarator)
-	{
-	  if (is_function_decl(ddecl->ast))
-	    d = CAST(function_decl, ddecl->ast)->declarator;
-	  else
-	    d = CAST(variable_decl, ddecl->ast)->declarator;
-	  d = CAST(declarator, get_fdeclarator(d));
-	  options &= ~psd_print_ddecl_fdeclarator;
-	}
+        {
+          if (is_function_decl(ddecl->ast))
+            d = CAST(function_decl, ddecl->ast)->declarator;
+          else
+            d = CAST(variable_decl, ddecl->ast)->declarator;
+          d = CAST(declarator, get_fdeclarator(d));
+          options &= ~psd_print_ddecl_fdeclarator;
+        }
       else
-	{
-	  if (options & psd_print_ddecl)
-	    prt_ddecl_full_name(ddecl, options);
-	  else if (options & psd_rename_identifier)
-	    output("arg_%p", ddecl);
+        {
+          if (options & psd_print_ddecl)
+            prt_ddecl_full_name(ddecl, options);
+          else if (options & psd_rename_identifier)
+            output("arg_%p", ddecl);
 
-	  return FALSE;
-	}
+          return FALSE;
+        }
     }
 
   switch (d->kind)
     {
     case kind_function_declarator:
       {
-	function_declarator fd = CAST(function_declarator, d);
+        function_declarator fd = CAST(function_declarator, d);
 
-	prt_simple_declarator(fd->declarator, ddecl,
-			      options | psd_need_paren_for_star |
-			      psd_need_paren_for_qual);
-	prt_parameters(fd->gparms ? fd->gparms :
-		       ddecl ? ddecl_get_gparms(ddecl) : NULL,
-		       fd->parms, options & psd_rename_parameters);
-	break;
+        prt_simple_declarator(fd->declarator, ddecl,
+                              options | psd_need_paren_for_star |
+                              psd_need_paren_for_qual);
+        prt_parameters(fd->gparms ? fd->gparms :
+                       ddecl ? ddecl_get_gparms(ddecl) : NULL,
+                       fd->parms, options & psd_rename_parameters);
+        break;
       }
     case kind_array_declarator:
       {
-	array_declarator ad = CAST(array_declarator, d);
-	bool is_id;
+        array_declarator ad = CAST(array_declarator, d);
+        bool is_id;
 
-	is_id = prt_simple_declarator(ad->declarator, ddecl,
-				      options | psd_need_paren_for_star |
-				      psd_need_paren_for_qual);
-	if (!ad->arg1)
-	  {
-	    /* The array-type test is necessary because char x[] in a
-	       parameter declaration is really a pointer declaration */
-	    if (ddecl && is_id && type_array(ddecl->type))
-	      {
-		/* This is a declaration of an incomplete array type.
-		   The type of ddecl contains the size of the array if
-		   it is known. 
-		   We need to print the size because of tossim
-		   (a declaration like 'char foo[TOSNODES][]' would
-		   be illegal)
-		*/
-		expression dsize = type_array_size(ddecl->type);
+        is_id = prt_simple_declarator(ad->declarator, ddecl,
+                                      options | psd_need_paren_for_star |
+                                      psd_need_paren_for_qual);
+        if (!ad->arg1)
+          {
+            /* The array-type test is necessary because char x[] in a
+               parameter declaration is really a pointer declaration */
+            if (ddecl && is_id && type_array(ddecl->type))
+              {
+                /* This is a declaration of an incomplete array type.
+                   The type of ddecl contains the size of the array if
+                   it is known. 
+                   We need to print the size because of tossim
+                   (a declaration like 'char foo[TOSNODES][]' would
+                   be illegal)
+                */
+                expression dsize = type_array_size(ddecl->type);
 
-		if (dsize)
-		  output("[%lu]",
-			 (unsigned long)constant_uint_value(dsize->cst));
-		else /* we never found the size */
-		  output("[]");
-	      }
-	    else
-	      output("[]");
-	  }
-	else
-	  {
-	    set_location(ad->arg1->location);
-	    output("[");
-	    prt_expression(ad->arg1, P_TOP);
-	    output("]");
-	  }
-	break;
+                if (dsize)
+                  output("[%lu]",
+                         (unsigned long)constant_uint_value(dsize->cst));
+                else /* we never found the size */
+                  output("[]");
+              }
+            else
+              output("[]");
+          }
+        else
+          {
+            set_location(ad->arg1->location);
+            output("[");
+            prt_expression(ad->arg1, P_TOP);
+            output("]");
+          }
+        break;
       }
     case kind_qualified_declarator:
       {
-	qualified_declarator qd = CAST(qualified_declarator, d);
-	bool is_id;
+        qualified_declarator qd = CAST(qualified_declarator, d);
+        bool is_id;
 
-	set_location(qd->modifiers->location);
-	if (options & psd_need_paren_for_qual)
-	  output("(");
-	prt_type_elements(qd->modifiers, 0);
-	is_id = prt_simple_declarator(qd->declarator, ddecl,
-				      options & ~psd_need_paren_for_qual);
-	if (options & psd_need_paren_for_qual)
-	  output(")");
-	return is_id;
+        set_location(qd->modifiers->location);
+        if (options & psd_need_paren_for_qual)
+          output("(");
+        prt_type_elements(qd->modifiers, 0);
+        is_id = prt_simple_declarator(qd->declarator, ddecl,
+                                      options & ~psd_need_paren_for_qual);
+        if (options & psd_need_paren_for_qual)
+          output(")");
+        return is_id;
       }
     case kind_pointer_declarator:
       {
-	pointer_declarator pd = CAST(pointer_declarator, d);
+        pointer_declarator pd = CAST(pointer_declarator, d);
 
-	if (options & psd_need_paren_for_star)
-	  output("(");
-	output("*");
-	prt_simple_declarator(pd->declarator, ddecl,
-			      options & ~(psd_need_paren_for_star |
-					  psd_need_paren_for_qual));
-	if (options & psd_need_paren_for_star)
-	  output(")");
-	break;
+        if (options & psd_need_paren_for_star)
+          output("(");
+        output("*");
+        prt_simple_declarator(pd->declarator, ddecl,
+                              options & ~(psd_need_paren_for_star |
+                                          psd_need_paren_for_qual));
+        if (options & psd_need_paren_for_star)
+          output(")");
+        break;
       }
     case kind_identifier_declarator:
       set_location(d->location);
       if (options & psd_rename_identifier)
-	output("arg_%p", ddecl);
+        output("arg_%p", ddecl);
       else if (ddecl)
-	{
-	  prt_ddecl_full_name(ddecl, options);
-	  /* check that we printed the symbol info (too late if we get
-	     here) */
-	  assert(!(symf && ddecl->needsmemory && !ddecl->printed));
-	}
+        {
+          prt_ddecl_full_name(ddecl, options);
+          /* check that we printed the symbol info (too late if we get
+             here) */
+          assert(!(symf && ddecl->needsmemory && !ddecl->printed));
+        }
       else
-	output_stripped_cstring(CAST(identifier_declarator, d)->cstring);
+        output_stripped_cstring(CAST(identifier_declarator, d)->cstring);
       return TRUE;
 
     case kind_interface_ref_declarator:
       prt_simple_declarator(CAST(interface_ref_declarator, d)->declarator,
-			    ddecl, options | psd_need_paren_for_star |
-			    psd_need_paren_for_qual);
+                            ddecl, options | psd_need_paren_for_star |
+                            psd_need_paren_for_qual);
       break;
 
     default: assert(0); break;
@@ -1082,7 +1082,7 @@ void prt_type_elements(type_element elements, psd_options options)
   scan_type_element (em, elements)
     {
       if (prt_type_element(em, options))
-	output(" ");
+        output(" ");
     }
 }
 
@@ -1093,7 +1093,7 @@ void prt_attribute_elements(type_element elements)
   scan_type_element (em, elements)
     {
       if (prt_attribute_element(em))
-	output(" ");
+        output(" ");
     }
 }
 
@@ -1127,26 +1127,26 @@ bool prt_type_element(type_element em, psd_options options)
     case kind_gcc_attribute: prt_gcc_attribute(CAST(gcc_attribute, em)); break;
     case kind_target_attribute: 
       if (flag_gccize)
-	prt_gcc_attribute(CAST(gcc_attribute, em)); 
+        prt_gcc_attribute(CAST(gcc_attribute, em)); 
       else
-	prt_target_attribute(CAST(target_attribute, em)); 
+        prt_target_attribute(CAST(target_attribute, em)); 
       break;
     case kind_nesc_attribute: prt_nesc_attribute(CAST(nesc_attribute, em)); break;
     case kind_qualifier: prt_qualifier(CAST(qualifier, em)); break;
     case kind_rid:
       {
-	rid r = CAST(rid, em);
+        rid r = CAST(rid, em);
 
-	if (!documentation_mode && r->id >= RID_LASTTYPE)
-	  return FALSE;
-	prt_rid(r, options);
-	break;
+        if (!documentation_mode && r->id >= RID_LASTTYPE)
+          return FALSE;
+        prt_rid(r, options);
+        break;
       }    
     default:
       if (is_tag_ref(em))
-	prt_tag_ref(CAST(tag_ref, em), options);
+        prt_tag_ref(CAST(tag_ref, em), options);
       else
-	assert(0);
+        assert(0);
       break;
     }
   return TRUE;
@@ -1203,11 +1203,11 @@ void prt_gcc_attribute(gcc_attribute a)
       output("__attribute((");
       prt_word(a->word1);
       if (a->args)
-	{
-	  output("(");
-	  prt_expressions(a->args, TRUE);
-	  output(")");
-	}
+        {
+          output("(");
+          prt_expressions(a->args, TRUE);
+          output(")");
+        }
       output("))");
     }
 }
@@ -1240,35 +1240,35 @@ void prt_nesc_attribute(nesc_attribute a)
       field_declaration field;
 
       /* This code checks that the attribute can be printed as a
-	 macro call, i.e., that complex initializers are not used
-	 and that all fields have an initializer - this is done here
-	 because it seems easier than enforcing these rules elsewhere
+         macro call, i.e., that complex initializers are not used
+         and that all fields have an initializer - this is done here
+         because it seems easier than enforcing these rules elsewhere
       */
       set_location(a->location);
       output("%s(", a->tdecl->macro_name);
 
       /* Like prt_expressions, but check that we can rewrite what was
-	 a structure initializer as arguments to a macro */
+         a structure initializer as arguments to a macro */
       scan_expression (e, args->args)
-	{
-	  if (count > 0) output(", ");
-	  count++;
-	  if (is_init_list(e) || is_init_specific(e))
-	    error_with_location(e->location, "complex initializers not allowed with @macro() attributes");
-	  prt_expression(e, P_ASSIGN); /* priority is that of assignment */
-	}
+        {
+          if (count > 0) output(", ");
+          count++;
+          if (is_init_list(e) || is_init_specific(e))
+            error_with_location(e->location, "complex initializers not allowed with @macro() attributes");
+          prt_expression(e, P_ASSIGN); /* priority is that of assignment */
+        }
 
       output(")");
 
       /* Check that all arguments are specified, so that the macro
-	 gets the same argument count on all uses. Could extend to
-	 "at least enough" arguments to allow the case of a variably-sized
-	 array at the end of the attribute, and a variable-argument macro
+         gets the same argument count on all uses. Could extend to
+         "at least enough" arguments to allow the case of a variably-sized
+         array at the end of the attribute, and a variable-argument macro
       */
       for (field = a->tdecl->fieldlist; field; field = field->next)
-	field_count++;
+        field_count++;
       if (field_count != count)
-	error_with_location(a->location, "incorrect argument count to @macro() attribute");
+        error_with_location(a->location, "incorrect argument count to @macro() attribute");
     }
 }
 
@@ -1280,13 +1280,13 @@ void prt_rid(rid r, psd_options options)
     case RID_NORACE:
       // show these in documenation mode, but not otherwise
       if (documentation_mode && !(options & psd_skip_command_event)) 
-	output("%s", rid_name(r));
+        output("%s", rid_name(r));
       break;
     case RID_DEFAULT:
       break;
     case RID_EXTERN:
       if (options & psd_noextern)
-	return;
+        return;
       /* FALLTHROUGH */
     default:
       set_location(r->location);
@@ -1322,9 +1322,9 @@ void prt_tag_ref(tag_ref tr, psd_options options)
   if (tr->word1)
     {
       if (tr->tdecl && tr->tdecl->container && !tr->tdecl->Cname)
-	prt_container(tr->tdecl->container);
+        prt_container(tr->tdecl->container);
       if (tr->kind == kind_attribute_ref)
-	output("__nesc_attr_");
+        output("__nesc_attr_");
       prt_word(tr->word1);
     }
   if (!(options & psd_duplicate) && tr->defined)
@@ -1332,9 +1332,9 @@ void prt_tag_ref(tag_ref tr, psd_options options)
       if (tr->kind == kind_enum_ref)
         prt_enumerators(tr->fields, tr->tdecl);
       else if (type_network(make_tagged_type(tr->tdecl)))
-	prt_network_fields(tr);
+        prt_network_fields(tr);
       else
-	prt_fields(tr->fields);
+        prt_fields(tr->fields);
     }
   if (tr->attributes)
     {
@@ -1354,7 +1354,7 @@ void prt_enumerators(declaration elist, tag_declaration tdecl)
     {
       prt_enumerator(CAST(enumerator, d), tdecl);
       if (d->next)
-	output(", ");
+        output(", ");
     }
   unindent();
   startline();
@@ -1400,7 +1400,7 @@ void prt_field_data_decl(data_decl d)
     {
       prt_field_decl(CAST(field_decl, fd));
       if (fd->next)
-	output(", ");
+        output(", ");
     }
   outputln(";");
 }
@@ -1452,54 +1452,54 @@ void prt_parameters(declaration gparms, declaration parms, psd_options options)
   if (!(gparms && is_void_parms(parms)))
     scan_declaration (d, parms)
       {
-	forward = prt_parameter(d, first, forward, 0);
-	first = FALSE;
+        forward = prt_parameter(d, first, forward, 0);
+        first = FALSE;
       }
   output(")");
 }
 
 bool prt_parameter(declaration parm, bool first, bool lastforward,
-		   psd_options options)
+                   psd_options options)
 {
   switch (parm->kind)
     {
     case kind_oldidentifier_decl:
       if (!first)
-	output(", ");
+        output(", ");
       set_location(parm->location);
       output_stripped_cstring(CAST(oldidentifier_decl, parm)->cstring);
       return FALSE;
     case kind_ellipsis_decl:
       if (!first)
-	output(", ");
+        output(", ");
       set_location(parm->location);
       output("...");
       return FALSE;
     case kind_data_decl:
       {
-	data_decl dd = CAST(data_decl, parm);
-	variable_decl vd = CAST(variable_decl, dd->decls);
+        data_decl dd = CAST(data_decl, parm);
+        variable_decl vd = CAST(variable_decl, dd->decls);
 
-	if (lastforward && !vd->forward)
-	  output("; ");
-	else if (!first)
-	  output(", ");
-	if (vd->ddecl && type_network_base_type(vd->ddecl->type))
-	  {
-	    options |= psd_rewrite_nxbase;
-	    /* If addressed, we need a real network type copy. This is
-	       added by prt_network_parameter_copies, so we rename
-	       the actual parameter */
-	    if (vd->ddecl->use_summary & c_addressed)
-	      options |= psd_prefix_nxbase;
-	  }
-	/* Force a name for the parameter when none is given */
-	if (vd->ddecl && !vd->ddecl->name)
-	  options |= psd_rename_identifier;
-	prt_declarator(vd->declarator, dd->modifiers, vd->attributes,
-		       vd->ddecl, options);
+        if (lastforward && !vd->forward)
+          output("; ");
+        else if (!first)
+          output(", ");
+        if (vd->ddecl && type_network_base_type(vd->ddecl->type))
+          {
+            options |= psd_rewrite_nxbase;
+            /* If addressed, we need a real network type copy. This is
+               added by prt_network_parameter_copies, so we rename
+               the actual parameter */
+            if (vd->ddecl->use_summary & c_addressed)
+              options |= psd_prefix_nxbase;
+          }
+        /* Force a name for the parameter when none is given */
+        if (vd->ddecl && !vd->ddecl->name)
+          options |= psd_rename_identifier;
+        prt_declarator(vd->declarator, dd->modifiers, vd->attributes,
+                       vd->ddecl, options);
 
-	return vd->forward;
+        return vd->forward;
       }
     default: assert(0); return FALSE;
     }
@@ -1567,10 +1567,10 @@ void prt_expression_helper(expression e, int context_priority)
       PRTEXPR(string, e);
     default: 
       if (is_unary(e))
-	{
-	  prt_unary(CAST(unary, e), context_priority);
-	  return;
-	}
+        {
+          prt_unary(CAST(unary, e), context_priority);
+          return;
+        }
       assert(is_binary(e));
       prt_binary(CAST(binary, e), context_priority);
       return;
@@ -1630,8 +1630,8 @@ void prt_asttype_cast(asttype t)
       declarator d;
       type_element qualifiers;
       type2ast(unparse_region, t->location, 
-	       qualify_type1(type_network_platform_type(t->type), t->type),
-	       NULL, &d, &qualifiers);
+               qualify_type1(type_network_platform_type(t->type), t->type),
+               NULL, &d, &qualifiers);
 
       t = new_asttype(unparse_region, t->location, d, qualifiers);
     }
@@ -1711,31 +1711,31 @@ void prt_function_call(function_call e, int context_priority)
       break;
     default:
       if (e->va_arg_call)
-	{
-	  /* The extra parentheses are added because gcc 2.96 (aka redhat 7's
-	     gcc) has a broken syntax for __builtin_va_arg */
-	  output("(__builtin_va_arg(");
-	  prt_expression(e->args, P_ASSIGN);
-	  output(", ");
-	  prt_asttype(e->va_arg_call);
-	  output("))");
-	}
+        {
+          /* The extra parentheses are added because gcc 2.96 (aka redhat 7's
+             gcc) has a broken syntax for __builtin_va_arg */
+          output("(__builtin_va_arg(");
+          prt_expression(e->args, P_ASSIGN);
+          output(", ");
+          prt_asttype(e->va_arg_call);
+          output("))");
+        }
       else if (get_magic(e))
-	output_constant(e->cst);
+        output_constant(e->cst);
       else
-	{
-	  prt_expression(e->arg1, P_CALL);
-	  /* Generic calls have already started the argument list.
-	     See prt_generic_call */
-	  if (is_generic_call(e->arg1))
-	    prt_expressions(e->args, FALSE);
-	  else
-	    {
-	      output("(");
-	      prt_expressions(e->args, TRUE);
-	    }
-	  output(")");
-	}
+        {
+          prt_expression(e->arg1, P_CALL);
+          /* Generic calls have already started the argument list.
+             See prt_generic_call */
+          if (is_generic_call(e->arg1))
+            prt_expressions(e->args, FALSE);
+          else
+            {
+              output("(");
+              prt_expressions(e->args, TRUE);
+            }
+          output(")");
+        }
       break;
     }
 }
@@ -1783,8 +1783,8 @@ void prt_interface_deref(interface_deref e, int context_priority)
 
   if (decl->kind == decl_function && decl->uncallable)
     error_with_location(e->location, "%s.%s not connected",
-			CAST(identifier, e->arg1)->cstring.data,
-			e->cstring.data);
+                        CAST(identifier, e->arg1)->cstring.data,
+                        e->cstring.data);
 
   prt_expression(e->arg1, P_CALL);
   output_string(function_separator);
@@ -1805,10 +1805,10 @@ void prt_unary(unary e, int context_priority)
       plus derefed = CAST(plus, e->arg1);
 
       if (type_array(derefed->arg1->type))
-	{
-	  prt_array_ref(derefed, context_priority);
-	  return;
-	}
+        {
+          prt_array_ref(derefed, context_priority);
+          return;
+        }
     }
 
   set_location(e->location);
@@ -1818,8 +1818,8 @@ void prt_unary(unary e, int context_priority)
     case kind_dereference: op = "*"; break;
     case kind_extension_expr: op = "__extension__ "; break;
       /* Higher priority for sizeof/alignof expr because we must
-	 add parens around sizeof cast_expr (e.g. sizeof((char)x), not
-	 sizeof (char)x */
+         add parens around sizeof cast_expr (e.g. sizeof((char)x), not
+         sizeof (char)x */
     case kind_sizeof_expr: op = "sizeof "; pri = P_CALL; break;
     case kind_alignof_expr: op = "__alignof__ "; pri = P_CALL; break;
     case kind_realpart: op = "__real__ "; break;
@@ -1844,9 +1844,9 @@ void prt_unary(unary e, int context_priority)
     {
       output_string(op);
       if (is_unary(e->arg1))
-	output(" "); /* Catch weirdness such as - - x */
+        output(" "); /* Catch weirdness such as - - x */
       if (!pri)
-	pri = P_CAST;
+        pri = P_CAST;
     }
   prt_expression(e->arg1, pri ? pri : P_CALL);
   if (postop)
@@ -1905,68 +1905,68 @@ void prt_binary(binary e, int context_priority)
     case kind_lshift: case kind_rshift:
       pri = P_SHIFT;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_TIMES;
+        lpri = rpri = P_TIMES;
       else
-	{
-	  lpri = P_SHIFT; rpri = P_PLUS; 
-	}
+        {
+          lpri = P_SHIFT; rpri = P_PLUS; 
+        }
       break;
     case kind_leq: case kind_geq: case kind_lt: case kind_gt:
       pri = P_REL;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_PLUS;
+        lpri = rpri = P_PLUS;
       else 
-	{
-	  lpri = P_REL; rpri = P_SHIFT; 
-	}
+        {
+          lpri = P_REL; rpri = P_SHIFT; 
+        }
       break;
     case kind_eq: case kind_ne:
       pri = P_EQUALS; 
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_PLUS;
+        lpri = rpri = P_PLUS;
       else 
-	{
-	  lpri = P_EQUALS; 
-	  rpri = P_REL; 
-	}
+        {
+          lpri = P_EQUALS; 
+          rpri = P_REL; 
+        }
       break;
     case kind_bitand:
       pri = P_BITAND;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_TIMES;
+        lpri = rpri = P_TIMES;
       else
-	{
-	  lpri = P_BITAND; rpri = P_EQUALS; 
-	}
+        {
+          lpri = P_BITAND; rpri = P_EQUALS; 
+        }
       break;
     case kind_bitxor:
       pri = P_BITXOR;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_TIMES;
+        lpri = rpri = P_TIMES;
       else
-	{
-	  lpri = P_BITXOR; rpri = P_BITAND;
-	}
+        {
+          lpri = P_BITXOR; rpri = P_BITAND;
+        }
       break;
     case kind_bitor:
       pri = P_BITOR;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_TIMES;
+        lpri = rpri = P_TIMES;
       else
-	{
-	  lpri = P_BITOR; rpri = P_BITXOR;
-	}
+        {
+          lpri = P_BITOR; rpri = P_BITXOR;
+        }
       break;
     case kind_andand:
       lpri = P_AND; pri = P_AND; rpri = P_BITOR; break;
     case kind_oror:
       pri = P_OR;
       if (CONSERVATIVE_PARENS)
-	lpri = rpri = P_BITOR;
+        lpri = rpri = P_BITOR;
       else
-	{
-	  lpri = P_OR; rpri = P_AND; 
-	}
+        {
+          lpri = P_OR; rpri = P_AND; 
+        }
       break;
     case kind_assign: case kind_plus_assign: case kind_minus_assign: 
     case kind_times_assign: case kind_divide_assign: case kind_modulo_assign:
@@ -2014,24 +2014,24 @@ void prt_designator(designator dl)
     switch (d->kind)
       {
       case kind_designate_field: {
-	designate_field df = CAST(designate_field, d);
+        designate_field df = CAST(designate_field, d);
 
-	output(".");
-	output_cstring(df->cstring);
-	break;
+        output(".");
+        output_cstring(df->cstring);
+        break;
       }
       case kind_designate_index: {
-	designate_index di = CAST(designate_index, d);
+        designate_index di = CAST(designate_index, d);
 
-	output("[");
-	prt_expression(di->arg1, P_ASSIGN);
-	if (di->arg2)
-	  {
-	    output(" ... ");
-	    prt_expression(di->arg2, P_ASSIGN);
-	  }
-	output("] ");
-	break;
+        output("[");
+        prt_expression(di->arg1, P_ASSIGN);
+        if (di->arg2)
+          {
+            output(" ... ");
+            prt_expression(di->arg2, P_ASSIGN);
+          }
+        output("] ");
+        break;
       }
       default: assert(0);
       }
@@ -2100,11 +2100,11 @@ void prt_compound_stmt(compound_stmt s, bool trusted)
 
       output("__label__ ");
       scan_id_label (l, s->id_labels)
-	{
-	  prt_id_label(l);
-	  if (l->next) 
-	    output(", ");
-	}
+        {
+          prt_id_label(l);
+          if (l->next) 
+            output(", ");
+        }
       outputln(";");
     }
   if (s->decls)
@@ -2160,16 +2160,16 @@ void prt_asm_stmt_plain(asm_stmt s)
       prt_asm_operands(s->asm_operands1);
 
       if (s->asm_operands2 || s->asm_clobbers)
-	{
-	  output(" : ");
-	  prt_asm_operands(s->asm_operands2);
+        {
+          output(" : ");
+          prt_asm_operands(s->asm_operands2);
 
-	  if (s->asm_clobbers)
-	    {
-	      output(" : ");
-	      prt_expressions(CAST(expression, s->asm_clobbers), TRUE);
-	    }
-	}
+          if (s->asm_clobbers)
+            {
+              output(" : ");
+              prt_expressions(CAST(expression, s->asm_clobbers), TRUE);
+            }
+        }
     }
   output(")");
 }
@@ -2182,7 +2182,7 @@ void prt_asm_operands(asm_operand olist)
     {
       prt_asm_operand(o);
       if (o->next)
-	output(", ");
+        output(", ");
     }
 }
 
@@ -2208,11 +2208,11 @@ void prt_if_stmt(if_stmt s)
   if (s->condition->cst && constant_knownbool(s->condition->cst))
     {
       if (constant_boolvalue(s->condition->cst))
-	prt_statement(s->stmt1);
+        prt_statement(s->stmt1);
       else if (s->stmt2)
-	prt_statement(s->stmt2);
+        prt_statement(s->stmt2);
       else
-	outputln(";");
+        outputln(";");
       return;
     }
 #endif
@@ -2338,15 +2338,15 @@ void prt_return_stmt(return_stmt s)
       current.function_decl->ddecl->call_contexts != c_call_atomic)
     {
       /* We rewrote return statemnts within atomic to return a local
-	 variable in stmt.c. So we can just end the atomic section now. */
+         variable in stmt.c. So we can just end the atomic section now. */
       outputln("{");
       indent();
       set_location(s->location);
       if (current.function_decl->ddecl->call_contexts == c_call_nonatomic &&
-	  nesc_optimise_atomic)
-	outputln("__nesc_enable_interrupt(); ");
+          nesc_optimise_atomic)
+        outputln("__nesc_enable_interrupt(); ");
       else
-	outputln("__nesc_atomic_end(__nesc_atomic); ");
+        outputln("__nesc_atomic_end(__nesc_atomic); ");
       inatomic = TRUE;
     }
 
@@ -2405,8 +2405,8 @@ void prt_atomic_stmt(atomic_stmt s)
   if (s->isatomic != NOT_ATOMIC)
     {
       outputln("/* atomic removed: %s */",
-	       s->isatomic == ATOMIC_ANY ? "no shared variable access" :
-	       "single single-byte shared variable access");
+               s->isatomic == ATOMIC_ANY ? "no shared variable access" :
+               "single single-byte shared variable access");
       prt_statement(s->stmt);
       return;
     }

--- a/src/unparse.h
+++ b/src/unparse.h
@@ -111,11 +111,11 @@ void prt_attribute_elements(type_element elements);
 void prt_interesting_elements(type_element elements, psd_options options);
 
 void prt_variable_decl(type_element modifiers, variable_decl d, 
-		       psd_options dopts);
+                       psd_options dopts);
 void prt_declarator(declarator d, type_element elements, attribute attributes,
-		    data_declaration ddecl, psd_options options);
+                    data_declaration ddecl, psd_options options);
 bool prt_simple_declarator(declarator d, data_declaration ddecl,
-			   psd_options options);
+                           psd_options options);
 void prt_parameters(declaration gparms, declaration parms, psd_options options);
 bool prt_parameter(declaration parm, bool first, bool lastforward, psd_options options);
 void prt_ddecl_full_name(data_declaration ddecl, psd_options options);

--- a/src/utils.c
+++ b/src/utils.c
@@ -174,7 +174,7 @@ unsigned long gcd(unsigned long x, unsigned long y)
   for (;;)
     {
       if (y == 0)
-	return x;
+        return x;
       
       z = x % y; x = y; y = z;
     }
@@ -197,7 +197,7 @@ int ilog2(largest_uint x)
       v <<= 1;
       log2++;
       if (!v)
-	return -1;
+        return -1;
     }
 
   return v == x ? log2 : -1;
@@ -222,7 +222,7 @@ int wcs_mb_size(const wchar_t *wstr)
       int mblen = wctomb(tmp, *wstr++);
 
       if (mblen < 0)
-	return -1;
+        return -1;
       len += mblen;
     }
 
@@ -315,25 +315,25 @@ char *realpath(const char *path, char *resolved_path)
   if (isalpha(path[0]) && path[1] == ':')
     if (path[2] == '/' || path[2] == '\\')
       {
-	if (strlen(path) >= PATH_MAX - 1)
-	  return NULL;
-	strcpy(resolved_path, path); /* absolute path */
+        if (strlen(path) >= PATH_MAX - 1)
+          return NULL;
+        strcpy(resolved_path, path); /* absolute path */
       }
     else
       {
-	/* drive relative path */
-	if (!_getdcwd(tolower(path[0] - 'a' + 1), resolved_path, PATH_MAX))
-	  return NULL;
-	if (!pathcat(resolved_path, path + 2))
-	  return NULL;
+        /* drive relative path */
+        if (!_getdcwd(tolower(path[0] - 'a' + 1), resolved_path, PATH_MAX))
+          return NULL;
+        if (!pathcat(resolved_path, path + 2))
+          return NULL;
       }
   else
     {
       /* fully relative path */
       if (!getcwd(resolved_path, PATH_MAX))
-	return NULL;
+        return NULL;
       if (!pathcat(resolved_path, path))
-	return NULL;
+        return NULL;
     }
 
   if (!absolute_path(resolved_path))
@@ -349,21 +349,21 @@ char *realpath(const char *path, char *resolved_path)
       /* Find next slash or end of path */
       slash = last + 1;
       while (*slash != '/' && *slash)
-	slash++;
+        slash++;
 
       if (slash == last + 1 || /* empty dir spec */
-	  (slash == last + 2 && last[1] == '.')) /* or . */
-	memmove(last, slash, strlen(slash) + 1);
+          (slash == last + 2 && last[1] == '.')) /* or . */
+        memmove(last, slash, strlen(slash) + 1);
       else if (slash == last + 3 &&
-	       last[1] == '.' && last[2] == '.') /* .. */
-	{
-	  /* look backwards for directory to squash */
-	  while (last >= resolved_path + 2 && *--last != '/')
-	    ;
-	  memmove(last, slash, strlen(slash) + 1);
-	}
+               last[1] == '.' && last[2] == '.') /* .. */
+        {
+          /* look backwards for directory to squash */
+          while (last >= resolved_path + 2 && *--last != '/')
+            ;
+          memmove(last, slash, strlen(slash) + 1);
+        }
       else
-	last = slash;
+        last = slash;
     }
   while (*last);
 


### PR DESCRIPTION
Many 8-wide tab characters were mixed in with spaces for indents. This changes all of the tabs to spaces so the formatting is consistent across text editors.

Not sure if anyone cares, but this makes it easier for me to look at the code.
