### PR TITLE
Added more nesc options to the man page

### DIFF
--- a/doc/nescc.1
+++ b/doc/nescc.1
@@ -1,19 +1,23 @@
-.TH nescc 1 "April 27, 2004"
+.TH nescc 1 "May 22, 2013"
 .LO 1
 .SH NAME
 nescc - nesC compiler
 .SH SYNOPSIS
 
-\fBnescc\fR [\fB-gcc=\fIgcc-name\fR] [\fB-mingw-gcc\fR] [\fB-fnesc-target=\fIarchitecture\fR]
-    [\fB-docdir=\fIdir\fR] [\fB-topdir=\fIdir\fR] [\fB-graphviz=y\fI|\fBn\fR]
-    [\fB-fnesc-simulate\fR] 
+\fBnescc\fR [\fB-gcc=\fIgcc-name\fR] [\fB-fnesc-gcc=\fIgcc-name\fR] [\fB-fnesc-mingw-gcc\fR]
+    [\fB-fnesc-target=\fIarchitecture\fR] [\fB-fnesc-docdir=\fIdir\fR]
+    [\fB-fnesc-topdir=\fIdir\fR] [\fB-fnesc-docs-use-graphviz\fR] [\fB-fnesc-is-app\fR]
+    [\fB-fnesc-simulate\fR]
     [\fB-fnesc-nido-tosnodes=\fIn\fR] [\fB-fnesc-nido-motenumber=\fIexpression\fR]
     [\fB-conly\fR] [\fB-fnesc-cfile=\fIfile\fR] [\fB-fnesc-gccize\fR]
     [\fB-fnesc-cppdir=\fIdirectory\fR] [\fB-fnesc-separator=\fIseparator\fR]
     [\fB-fnesc-no-inline\fR] [\fB-fnesc-optimize-atomic\fR]
-    [\fB--version\fR] [\fB-fnesc-verbose\fR] [\fB-Wnesc-\fI...\fR]
+    [\fB--version\fR] [\fB-fnesc-include=\fIfile\fR] [\fB-fnesc-verbose\fR] [\fB-Wnesc-\fI...\fR]
     [\fB-fnesc-dump=\fIspecification\fR] [\fB-fnesc-dumpfile=\fIfile\fR]
-    [\fB-fnesc-scheduler=\fIspecification\fR]
+    [\fB-fnesc-scheduler=\fIspecification\fR] [\fB-fnesc-path=\fIpath\fR]
+    [\fB-fnesc-no-debug\fR]
+    [\fB-fnesc-deputy\fR] [\fB-fnesc-no-deputy\fR]
+    [\fB-fnesc-default-safe\fR] [\fB-fnesc-default-unsafe\fR]
     [any gcc option] \fIfiles\fR...
 .SH DESCRIPTION
 
@@ -28,13 +32,13 @@ with the other files specified on the command line.
 \fBnescc\fR accepts all \fBgcc\fR options, and some additional nesC
 specific options:
 .TP
-\fB-gcc=\fIgcc-name\fR
+\fB-gcc=\fIgcc-name\fR -fnesc-gcc=\fIgcc-name\fR
 Specify which gcc compiler to use to compile and link any C files, either
 explicitly specified, or generated as the output of the nesC-to-C compiler.
 This option supports cross-compilation of nesC code (the usual mode of
 operation...).
 .TP
-\fB-mingw-gcc\fR
+\fB-fnesc-mingw-gcc\fR
 Pass this option if the gcc version specified with \fB-gcc=...\fR was
 compiled for Window's mingw environment, and hence expects Windows-style
 rather than Unix-style paths.
@@ -47,19 +51,22 @@ If you use the \fBenv\fR target, the architecture details are read from
 the \fBNESC_MACHINE\fR environment variable. See the separate env target
 documentation for details.
 .TP
-\fB-docdir=\fIdir\fR 
+\fB-fnesc-docdir=\fIdir\fR
 Generate documentation for the compiled component in directory \fIdir\fR.
 .TP
-\fB-topdir=\fIdir\fR 
+\fB-fnesc-topdir=\fIdir\fR
 Specify directory paths that should be stripped from the source file names
 when generating "package names" for the documentation files.
 .TP
-\fB-graphviz=y\fR|\fBn\fR 
+\fB-fnesc-docs-use-graphviz\fR
 Explicitly enable or disable the use of the graphviz tool in the generated
 documentation. Without this option, graphviz is enabled iff the \fBdot\fR
 program is found in the current path. Use of graphviz requires \fBdot\fR.  The
 documentation generation tool checks the version of \fBdot\fR, and enables
 client-side image maps, if supported.
+.TP
+\fB-fnesc-is-app\fR
+Tell nescc that the source being compiled is an application, and to generate an app description page for the entire application.
 .TP
 \fB-fnesc-simulate\fR
 Compile for a simulation environment.
@@ -76,7 +83,7 @@ Just compile to C, leaving the generated source code for top-level-component
 \fIcomp.nc\fR in C file \fIcomp.c\fR (except if the \fB-fnesc-cfile\fR
 option is specified).
 .TP
-\fB-fnesc-cfile=\fIfile\fR 
+\fB-fnesc-cfile=\fIfile\fR
 Specify a file in which to save the C code generated when compiling a
 component. Note: if you specify two components on the command line, then
 the C code from the second one will overwrite the C code from the first.
@@ -98,11 +105,11 @@ preprocessed as part of the current compilation.
 Set separator used to create symbol names in the generated C code (default $).
 The compiler needs to generate unique names to denote, e.g., a module
 variable. It does this by concatenating various symbol names to ensure that
-it generates unique names. For instance, variable \fBbar\fR in module 
+it generates unique names. For instance, variable \fBbar\fR in module
 \fBMaz\fR becomes a global C variable \fBMaz$bar\fR in the compiler output.
-Some C compilers do not like $ in symbol names, so you can specify a 
+Some C compilers do not like $ in symbol names, so you can specify a
 different separator, e.g., \fB__\fR (leading to generated symbols like
-\fBMaz__bar\fR). 
+\fBMaz__bar\fR).
 
 You will get a compile-time warning if any symbol in the program being
 compiled contains the separator you specify (the presence of the
@@ -141,7 +148,7 @@ Be more verbose than \fB-v\fR.
 \fB-fnesc-scheduler=\fIcomponent\fR,\fIunique-string\fR,\fIinterface-name\fR,\fIinterface-definition\fR,\fIrun-event\fR,\fIpost-command\fR
 By default, nesC compiles uses of \fBtask void \fItaskname\fB() ...\fR to
 \fBvoid \fItaskname\fB()\fR, and \fBpost \fItaskname()\fR to
-\fBTOS_post(\fItaskname\fB)\fR. 
+\fBTOS_post(\fItaskname\fB)\fR.
 
 With this option, each task gets its own \fIinterface-definition\fR
 interface, the task implementation is transformed into a \fIrun-event\fR
@@ -150,6 +157,24 @@ per-task interface is automatically connected to the parameterised
 \fIinterface-name\fR interface of scheduler component \fIcomponent\fR. The
 parameter id for the connection is chosen with
 \fBunique("\fIunique-string\fB")\fR.
+.TP
+\fB-fnesc-path=\fIpath\fR
+Add colon separated directories to the nescc search path.
+.TP
+\fB-fnesc-no-debug\fR
+Remove the functions \fBdbg()\fR, \fBdbg_clear()\fR, \fBdbg_active()\fR from the source code.
+.TP
+\fB-fnesc-deputy\fR
+Compile with the deputy compiler.
+.TP
+\fB-fnesc-no-deputy\fR
+Do not use the deputy compiler. This is the default.
+.TP
+\fB-fnesc-default-safe\fR
+Make modules default to having the \fB@safe()\fR attribute. Has no effect if \fB-fnesc-deputy\fR is not set.
+.TP
+\fB-fnesc-default-unsafe\fR
+Make modules default to having the \fB@unsafe()\fR attribute. Has no effect if \fB-fnesc-deputy\fR is not set.
 .PP
 There are a number of warnings specific to nesC, specified with
 \fB-Wnesc-\fR (all these warnings are off by
@@ -159,7 +184,7 @@ default):
 Warn when function pointers are used (use of function pointers is
 deprecated in nesC and leads to inaccurate data race detection).
 .TP
-\fB-Wnesc-async\fR 
+\fB-Wnesc-async\fR
 Warn when interrupt handlers call commands or events not annotated with
 \fBasync\fR.
 .TP
@@ -178,7 +203,7 @@ seen.
 Warn when implicit connections between components are used.
 .TP
 \fB-Wnesc-all\fR
-Turns on \fB-Wnesc-fnptr\fR, \fB-Wnesc-async\fR, \fB-Wnesc-combine\fR 
+Turns on \fB-Wnesc-fnptr\fR, \fB-Wnesc-async\fR, \fB-Wnesc-combine\fR
 and\fB-Wnesc-data-race\fR.
 .TP
 \fB-Wnesc-error\fR
@@ -200,12 +225,12 @@ nescc -c -o /dev/null -fnesc-cfile=Bar.c Bar.nc
 
 \fBnescc\fR defines the following preprocessor symbol:
 .TP
-\fBNESC\fR (since v1.1) 
+\fBNESC\fR (since v1.1)
 set to XYZ where x.yz is the nesC version
 .SH ENVIRONMENT VARIABLES
 
 .TP
-.B NESCPATH 
+.B NESCPATH
 A colon separated list of additional search directories for
 nesC components.
 .SH SEE ALSO

--- a/src/flags.c
+++ b/src/flags.c
@@ -205,12 +205,9 @@ char *cmdline_nesc_path;
    varargs functions */
 int flag_no_debug;
 
-/* Nonzero to suppress automatic addition of inline keywords 
+/* Nonzero to suppress automatic addition of inline keywords
    (but the "wiring" functions are still marked inline) */
 int flag_no_inline;
-
-/* Nonzero means to output macro defs in the generated C file */
-int flag_save_macros;
 
 /* Nonzero means modify identifier and declaration output during code
    generation to accomodate nido */
@@ -247,7 +244,7 @@ int warn_implicit_connection;
    are treated as errors */
 int nesc_error;
 
-/* diff processing enabled if diff_output is not NULL 
+/* diff processing enabled if diff_output is not NULL
    (diff_input is NULL for orignal program, non-NULL to reduce diff size) */\
 char *diff_input, *diff_output;
 

--- a/src/flags.h
+++ b/src/flags.h
@@ -202,12 +202,9 @@ extern int flag_parse_only;
    varargs functions */
 extern int flag_no_debug;
 
-/* Nonzero to suppress automatic addition of inline keywords 
+/* Nonzero to suppress automatic addition of inline keywords
    (but the "wiring" functions are still marked inline) */
 extern int flag_no_inline;
-
-/* Nonzero means to output macro defs in the generated C file (a la -dD) */
-extern int flag_save_macros;
 
 /* Nonzero means modify identifier and declaration output during code
    generation to accomodate nido */
@@ -244,7 +241,7 @@ extern int warn_implicit_connection;
    are treated as errors */
 extern int nesc_error;
 
-/* diff processing enabled if diff_output is not NULL 
+/* diff processing enabled if diff_output is not NULL
    (diff_input is NULL for orignal program, non-NULL to reduce diff size) */\
 extern char *diff_input, *diff_output;
 

--- a/src/nesc-compile
+++ b/src/nesc-compile
@@ -1,16 +1,16 @@
 #!/usr/bin/perl
 # This file is part of the nesC compiler.
 #    Copyright (C) 2002 Intel Corporation
-# 
+#
 # The attached "nesC" software is provided to you under the terms and
 # conditions of the GNU General Public License Version 2 as published by the
 # Free Software Foundation.
-# 
+#
 # nesC is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
 # the Free Software Foundation, 59 Temple Place - Suite 330,

--- a/src/nesc-main.c
+++ b/src/nesc-main.c
@@ -107,7 +107,7 @@ static void connect(location loc, nesc_declaration cdecl, cgraph cg,
 
   if ((loop = abstract_recursion()))
     {
-      /* We can help the programmer find the loop by showing the 
+      /* We can help the programmer find the loop by showing the
 	 instantiation path that causes it. loop's instance name is a prefix
 	 of cdecl's, the looping path is loop's abstract component name
 	 followed by the difference between loop's and cdecl's instance name.
@@ -172,92 +172,53 @@ int nesc_option(char *p)
 
   /* Yes, using here strlen is evil. But who *really* cares? */
   if (!strncmp (p, "fnesc-nido-tosnodes=", strlen("fnesc-nido-tosnodes=")))
-    {
-      nido_num_nodes = p + strlen("fnesc-nido-tosnodes=");
-    }
+    nido_num_nodes = p + strlen("fnesc-nido-tosnodes=");
   else if (!strncmp (p, "fnesc-nido-motenumber=", strlen("fnesc-nido-motenumber=")))
-    {
-      nido_mote_number = p + strlen("fnesc-nido-motenumber=");
-    }
+    nido_mote_number = p + strlen("fnesc-nido-motenumber=");
   else if (!strncmp (p, "fnesc-include=", strlen("fnesc-include=")))
-    {
-      add_nesc_include(p + strlen("fnesc-include="), FALSE);
-    }
+    add_nesc_include(p + strlen("fnesc-include="), FALSE);
   else if (!strncmp (p, "fnesc-path=", strlen("fnesc-path=")))
-    {
-      add_nesc_path(p + strlen("fnesc-path="), CHAIN_BRACKET);
-    }
+    add_nesc_path(p + strlen("fnesc-path="), CHAIN_BRACKET);
   else if (!strncmp (p, "fnesc-msg=", strlen("fnesc-msg=")))
-    {
-      select_nesc_msg(p + strlen("fnesc-msg="));
-    }
+    /* Internal use only option. - for nescc-mig */
+    select_nesc_msg(p + strlen("fnesc-msg="));
   else if (!strcmp (p, "fnesc-csts"))
-    {
-      select_nesc_csts();
-    }
+    /* Internal use only option. - for nescc-ncg */
+    select_nesc_csts();
   else if (!strncmp (p, "fnesc-dump=", strlen("fnesc-dump=")))
-    {
-      select_dump(p + strlen("fnesc-dump="));
-    }
+    select_dump(p + strlen("fnesc-dump="));
   else if (!strncmp (p, "fnesc-dumpfile=", strlen("fnesc-dumpfile=")))
-    {
-      select_dumpfile(p + strlen("fnesc-dumpfile="));
-    }
+    select_dumpfile(p + strlen("fnesc-dumpfile="));
   else if (!strncmp (p, "fnesc-target=", strlen("fnesc-target=")))
-    {
-      select_target(p + strlen("fnesc-target="));
-    }
+    select_target(p + strlen("fnesc-target="));
   else if (!strcmp (p, "fnesc-simulate"))
-    {
-      use_nido = TRUE;
-    }
+    use_nido = TRUE;
   else if (!strncmp (p, "fnesc-gcc=", strlen("fnesc-gcc=")))
-    {
-      target_compiler = p + strlen("fnesc-gcc=");
-    }
+    target_compiler = p + strlen("fnesc-gcc=");
   else if (!strcmp (p, "fnesc-mingw-gcc"))
-    {
-      flag_mingw_gcc = 1;
-    }
+    flag_mingw_gcc = 1;
   else if (!strcmp (p, "fnesc-no-debug"))
-    {
-      flag_no_debug = 1;
-    }
+    flag_no_debug = 1;
   else if (!strcmp (p, "fnesc-no-inline"))
-    {
-      flag_no_inline++;
-    }
+    flag_no_inline++;
   else if (!strcmp (p, "fnesc-verbose"))
-    {
-      flag_verbose = 2;
-    }
+    flag_verbose = 2;
   else if (!strcmp (p, "fnesc-save-macros"))
-    {
-      flag_save_macros = 1;
-    }
+    warning("option -fnesc-save-macros is deprecated and should not be used.");
   else if (!strncmp (p, "fnesc-scheduler=", strlen("fnesc-scheduler=")))
-    {
-      set_scheduler(p + strlen("fnesc-scheduler="));
-    }
+    set_scheduler(p + strlen("fnesc-scheduler="));
   else if (!strncmp (p, "fnesc-docdir=", strlen("fnesc-docdir=")))
-    {
-      doc_set_outdir(p + strlen("fnesc-docdir="));
-    }
+    doc_set_outdir(p + strlen("fnesc-docdir="));
   else if (!strncmp (p, "fnesc-topdir=", strlen("fnesc-topdir=")))
-    {
-      doc_add_topdir(p + strlen("fnesc-topdir="));
-    }
+    doc_add_topdir(p + strlen("fnesc-topdir="));
   else if (!strncmp (p, "fnesc-is-app", strlen("fnesc-is-app")))
-    {
-      doc_is_app(TRUE);
-    }
+    doc_is_app(TRUE);
   else if (!strncmp (p, "fnesc-docs-use-graphviz", strlen("fnesc-docs-use-graphviz")))
-    {
-      doc_use_graphviz(TRUE);
-    }
+    doc_use_graphviz(TRUE);
   else if (!strcmp (p, "fnesc-optimize-atomic"))
     nesc_optimise_atomic = 1;
   else if (!strncmp (p, "fnesc-genprefix=", strlen("fnesc-genprefix=")))
+    /* Internal use only option. - for deputy (see nesc-compile) */
     unparse_prefix(p + strlen("fnesc-genprefix="));
   else if (!strcmp (p, "fnesc-deputy"))
     flag_deputy = 1;
@@ -298,6 +259,8 @@ int nesc_option(char *p)
   else if (!strcmp (p, "Wnesc-error"))
     nesc_error = TRUE;
   else if (!strncmp(p, "fnesc-diff=", strlen("fnesc-diff=")))
+    /* Internal use only option. - for nescc-diff */
+    /* As of version 1.3.4 this feature is not complete. */
     {
       char *dirs = p + 11, *comma = strchr(dirs, ',');
 
@@ -405,7 +368,7 @@ void nesc_compile(const char *filename, const char *target_name)
       fold_program(program, scheduler);
       gencode = TRUE;
     }
-  else 
+  else
     /* The "program" is a C file, interface or abstract component */
     fold_program(NULL, NULL);
 

--- a/tools/nescc.in
+++ b/tools/nescc.in
@@ -2,21 +2,21 @@
 # -*- perl -*-
 
 # This file is part of the nesC compiler.
-# 
+#
 # This file is derived from the RC Compiler. It is thus
 #    Copyright (C) 2000-2001 The Regents of the University of California.
 # Changes for nesC are
 #    Copyright (C) 2002 Intel Corporation
-# 
+#
 # The attached "nesC" software is provided to you under the terms and
 # conditions of the GNU General Public License Version 2 as published by the
 # Free Software Foundation.
-# 
+#
 # nesC is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
 # the Free Software Foundation, 59 Temple Place - Suite 330,
@@ -49,9 +49,9 @@ for ($i = 0; $i <= $#ARGV; $i++) {
 	    $verbose = 1;
 	}
 
-	if (/^-docdir=(.*)/) {
+	if (/^-(fnesc-)?docdir=(.*)/) {
             $docdir = $1;
-	} elsif (/^-topdir=(.*)/) {
+	} elsif (/^-(fnesc-)?topdir=(.*)/) {
             push @topdirs, $1;
 	} elsif (/^-graphviz=(.*)/) {
             if($1 =~ /^y/i) {
@@ -59,11 +59,13 @@ for ($i = 0; $i <= $#ARGV; $i++) {
             } else {
                 $use_graphviz = 0;
             }
+        } elsif (/^-fnesc-docs-use-graphviz$/) {
+            $use_graphviz = 1;
 	} elsif (/^--version$/) {
 	    $print_version = 1;
 	} elsif (/^-(fnesc-)?gcc=(.*)/) {
 	    $gcc = $2;
-	} elsif (/^-mingw-gcc$/) {
+	} elsif (/^-(fnesc-)?mingw-gcc$/) {
 	    $mingw_gcc = 1;
 	    push @nescc_args, "-fnesc-mingw-gcc";
 	} elsif (/^-conly$/) {
@@ -139,7 +141,7 @@ unshift @nescc_args, "-fnesc-include=nesc_nx";
 if (defined($docdir)) {
     # add the doc output dir
     push @nescc_args, "-fnesc-docdir=$docdir";
-    
+
     # add top level dirs, to strip out of package names
     foreach my $dir (@topdirs) {
         push @nescc_args, "-fnesc-topdir=$dir";
@@ -204,7 +206,7 @@ foreach (@nescc_args) {
     $_ = quotemeta $_;
     s/\\([-=,\.\/])/\1/g;
 }
-    
+
 $ENV{NESCC_ARGS} = join(' ', @nescc_args);
 $ENV{NESCC_GCC} = $gcc;
 


### PR DESCRIPTION
This is a little tricky as there are two perl scripts involved as well as the actual compiler.

There are a couple flags that I can't tell what they do:
- -fnesc-msg=message
- -fnesc-csts
- -fnesc-genprefix=prefix

Fixes issue #18
