### PR TITLE
Added more special options to mig/ncg

### DIFF
--- a/tools/nescc-mig.in
+++ b/tools/nescc-mig.in
@@ -2,16 +2,16 @@
 
 # This file is part of the nesC compiler.
 #    Copyright (C) 2002 Intel Corporation
-# 
+#
 # The attached "nesC" software is provided to you under the terms and
 # conditions of the GNU General Public License Version 2 as published by the
 # Free Software Foundation.
-# 
+#
 # nesC is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
 # the Free Software Foundation, 59 Temple Place - Suite 330,
@@ -64,9 +64,10 @@ for ($i = 0; $i <= $#ARGV; $i++) {
 	    push @args, "-$opt$arg";
 	}
 	elsif ($i < $#ARGV &&
-	       (/^-idirafter$/ || /^-include$/ || /^-imacros$/ ||
+	       (/^--param$/ || /^-idirafter$/ || /^-include$/ || /^-imacros$/ ||
 		/^-iprefix$/ || /^-iwithprefix$/ || /^-iwithprefixbefore$/ ||
-		/^-isystem$/ || /^-Xlinker$/)) {
+		/^-isystem$/ || /^-imultilib$/ || /^-isysroot$/ ||
+		/^-Xpreprocessor$/ || /^-Xlinker$/)) {
 	    # convert argument filename which is in next arg
 	    push @args, $_;
 	    push @args, $ARGV[++$i];

--- a/tools/nescc-ncg.in
+++ b/tools/nescc-ncg.in
@@ -2,16 +2,16 @@
 
 # This file is part of the nesC compiler.
 #    Copyright (C) 2002 Intel Corporation
-# 
+#
 # The attached "nesC" software is provided to you under the terms and
 # conditions of the GNU General Public License Version 2 as published by the
 # Free Software Foundation.
-# 
+#
 # nesC is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
 # the Free Software Foundation, 59 Temple Place - Suite 330,
@@ -58,9 +58,10 @@ for ($i = 0; $i <= $#ARGV; $i++) {
 	    push @args, "-$opt$arg";
 	}
 	elsif ($i < $#ARGV &&
-	       (/^-idirafter$/ || /^-include$/ || /^-imacros$/ ||
+	       (/^--param$/ || /^-idirafter$/ || /^-include$/ || /^-imacros$/ ||
 		/^-iprefix$/ || /^-iwithprefix$/ || /^-iwithprefixbefore$/ ||
-		/^-isystem$/ || /^-Xlinker$/)) {
+		/^-isystem$/ || /^-imultilib$/ || /^-isysroot$/ ||
+		/^-Xpreprocessor$/ || /^-Xlinker$/)) {
 	    # convert argument filename which is in next arg
 	    push @args, $_;
 	    push @args, $ARGV[++$i];


### PR DESCRIPTION
I found some more gcc options that have a space in them and added them
to mig/ncg. In particular the --param option was giving me trouble with
TinyOS.
