### PR TITLE
Use specified version of gcc for nesc

### DIFF
--- a/tools/nescc.in
+++ b/tools/nescc.in
@@ -33,7 +33,7 @@ $ENV{"NCDIR"} = $NCDIR;
 
 # Have fun with the arguments
 
-$gcc = "gcc";
+$gcc = "@CC@";
 
 undef $ENV{NESCC_ARGS};
 undef $ENV{NESCC_CFILE};


### PR DESCRIPTION
Before nescc was hardcoding gcc as "gcc". This change sets it to whichever gcc
configure was using so that doing something like:

```
./configure CC=/usr/local/bin/gcc
```

will work when it comes time to use nescc.
