### PR TITLE
Update FSF address and GPLv2 text

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,12 +1,12 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -15,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
@@ -55,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -110,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -168,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -225,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -255,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -277,9 +277,9 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
-	    How to Apply These Terms to Your New Programs
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -291,7 +291,7 @@ convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 19yy  <name of author>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -303,17 +303,16 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision version 69, Copyright (C) year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -336,5 +335,5 @@ necessary.  Here is a sample; alter the names:
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Library General
+library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -14,8 +14,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.
 
 --
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 dnl -*- m4 -*-
 

--- a/src/AST.c
+++ b/src/AST.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "semantics.h"

--- a/src/AST.h
+++ b/src/AST.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef AST_H
 #define AST_H

--- a/src/AST_utils.c
+++ b/src/AST_utils.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "AST_utils.h"

--- a/src/AST_utils.h
+++ b/src/AST_utils.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef AST_UTILS_H
 #define AST_UTILS_H

--- a/src/AST_walk.c
+++ b/src/AST_walk.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "AST_walk.h"

--- a/src/AST_walk.h
+++ b/src/AST_walk.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef AST_WALK_H
 #define AST_WALK_H

--- a/src/COPYING
+++ b/src/COPYING
@@ -1,12 +1,12 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -15,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
@@ -55,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -110,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -168,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -225,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -255,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -277,9 +277,9 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
-	    How to Apply These Terms to Your New Programs
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -291,7 +291,7 @@ convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 19yy  <name of author>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -303,17 +303,16 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision version 69, Copyright (C) year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -336,5 +335,5 @@ necessary.  Here is a sample; alter the names:
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Library General
+library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.

--- a/src/COPYRIGHT
+++ b/src/COPYRIGHT
@@ -14,5 +14,5 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,8 +18,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 
 AUTOMAKE_OPTIONS = foreign

--- a/src/array.c
+++ b/src/array.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <regions.h>
 #include <assert.h>

--- a/src/array.h
+++ b/src/array.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef ARRAY_H
 #define ARRAY_H

--- a/src/build-basics.el
+++ b/src/build-basics.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 ; Utility functions
 (defun ins (&rest args)

--- a/src/build-list.el
+++ b/src/build-list.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 (load-file "build-basics.el")
 

--- a/src/build-parent.el
+++ b/src/build-parent.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 ;; Build a function to set the parent and parent_ptr nodes in a tree
 

--- a/src/build-print.el
+++ b/src/build-print.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 ;; Build a function to set the parent and parent_ptr nodes in a tree
 

--- a/src/build-types.el
+++ b/src/build-types.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 (load-file "build-basics.el")
 

--- a/src/build-walk.el
+++ b/src/build-walk.el
@@ -16,8 +16,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 ;; Build a function to set the parent and parent_ptr nodes in a tree
 

--- a/src/c-lex-int.h
+++ b/src/c-lex-int.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef C_LEX_INT_H
 #define C_LEX_INT_H

--- a/src/c-lex.c
+++ b/src/c-lex.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include <stdio.h>

--- a/src/c-lex.h
+++ b/src/c-lex.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef C_LEX_H
 #define C_LEX_H

--- a/src/c-parse.gperf
+++ b/src/c-parse.gperf
@@ -18,8 +18,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 /* Command-line: gperf -p -j1 -i 1 -g -o -t -N is_reserved_word -k1,3,$ c-parse.gperf  */ 
 %}

--- a/src/c-parse.h
+++ b/src/c-parse.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef C_PARSE_H
 #define C_PARSE_H

--- a/src/c-parse.y
+++ b/src/c-parse.y
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 /* This is a version of c-parse.y with two conflicts and supporting the gcc3
    attribute syntax. It is a partial merge of the gcc 3 grammar */

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -16,8 +16,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 dnl -*- m4 -*-
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 /* ASSUME: (float)(long double)f == f
            (double)(long double)d == d

--- a/src/constants.h
+++ b/src/constants.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 /* Constants come in three kinds:
    - "unknown": value is completely unknown (constant_unknown)

--- a/src/cstring.h
+++ b/src/cstring.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef CSTRING_H
 #define CSTRING_H

--- a/src/cval.c
+++ b/src/cval.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 /* SAME: There's a lot of assumptions about floating point here, and behaviour
    of operations when performed on wider types. I believe them to be valid for

--- a/src/cval.h
+++ b/src/cval.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef CVAL_H
 #define CVAL_H

--- a/src/dd_list.c
+++ b/src/dd_list.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <regions.h>
 #include "dd_list.h"

--- a/src/dd_list.h
+++ b/src/dd_list.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef DD_LIST_H
 #define DD_LIST_H

--- a/src/decls.h
+++ b/src/decls.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef DECLS_H
 #define DECLS_H

--- a/src/edit.c
+++ b/src/edit.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "edit.h"

--- a/src/edit.h
+++ b/src/edit.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef EDIT_H
 #define EDIT_H

--- a/src/env.c
+++ b/src/env.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "env.h"

--- a/src/env.h
+++ b/src/env.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef ENV_H
 #define ENV_H

--- a/src/errors.c
+++ b/src/errors.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <stdarg.h>
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef ERRORS_H
 #define ERRORS_H

--- a/src/expr.c
+++ b/src/expr.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "expr.h"

--- a/src/expr.h
+++ b/src/expr.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef EXPR_H
 #define EXPR_H

--- a/src/flags.c
+++ b/src/flags.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 

--- a/src/flags.h
+++ b/src/flags.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef FLAGS_H
 #define FLAGS_H

--- a/src/graph.c
+++ b/src/graph.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <regions.h>
 #include "parser.h"

--- a/src/graph.h
+++ b/src/graph.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef GRAPH_H
 #define GRAPH_H

--- a/src/init.c
+++ b/src/init.c
@@ -22,8 +22,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "c-parse.h"

--- a/src/init.h
+++ b/src/init.h
@@ -18,8 +18,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef INIT_H
 #define INIT_H

--- a/src/libcompat/Makefile.am
+++ b/src/libcompat/Makefile.am
@@ -14,9 +14,9 @@
 # GNU General Public License for more details.
 # 
 # You should have received a copy of the GNU General Public License
-# along with RC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# along with nesC; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 AM_CPPFLAGS = -DNMEMDEBUG -DNDEBUG -O2
 

--- a/src/libcompat/fnmatch.c
+++ b/src/libcompat/fnmatch.c
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with this library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301 USA.  */
 
 #if HAVE_CONFIG_H
 # include <config.h>

--- a/src/libcompat/fnmatch/fnmatch.h
+++ b/src/libcompat/fnmatch/fnmatch.h
@@ -13,8 +13,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the GNU C Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301 USA.  */
 
 #ifndef	_FNMATCH_H
 #define	_FNMATCH_H	1

--- a/src/libcompat/fnmatch_loop.c
+++ b/src/libcompat/fnmatch_loop.c
@@ -11,10 +11,10 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Library General Public License for more details.
 
-   You should have received a copy of the GNU Library General Public
-   License along with this library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   You should have received a copy of the GNU General Public License
+   along with nesC; see the file COPYING.  If not, write to
+   the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301 USA. */
 
 /* Match STRING against the filename pattern PATTERN, returning zero if
    it matches, nonzero if not.  */

--- a/src/libcompat/regex.c
+++ b/src/libcompat/regex.c
@@ -16,8 +16,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the GNU C Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301 USA.  */
 
 /* AIX requires this to be the first thing in the file. */
 #if defined _AIX && !defined REGEX_MALLOC

--- a/src/libcompat/regex/regex.h
+++ b/src/libcompat/regex/regex.h
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Library General Public
    License along with the GNU C Library; see the file COPYING.LIB.  If not,
-   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301 USA.  */
 
 #ifndef _REGEX_H
 #define _REGEX_H 1

--- a/src/machine.c
+++ b/src/machine.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "machine.h"

--- a/src/machine/env_machine.c
+++ b/src/machine/env_machine.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 //$Id$
 //@author Cory Sharp <cssharp@eecs.berkeley.edu>

--- a/src/machine/keil.gperf
+++ b/src/machine/keil.gperf
@@ -13,8 +13,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 
 %}

--- a/src/machine/sdcc.gperf
+++ b/src/machine/sdcc.gperf
@@ -13,8 +13,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 
 %}

--- a/src/nconfig.h
+++ b/src/nconfig.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef NCONFIG_H
 #define NCONFIG_H

--- a/src/nesc-abstract.c
+++ b/src/nesc-abstract.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-cg.h"

--- a/src/nesc-abstract.h
+++ b/src/nesc-abstract.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_ABSTRACT_H
 #define NESC_ABSTRACT_H

--- a/src/nesc-atomic.c
+++ b/src/nesc-atomic.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "AST_walk.h"

--- a/src/nesc-atomic.h
+++ b/src/nesc-atomic.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef NESC_ATOMIC_H
 #define NESC_ATOMIC_H

--- a/src/nesc-c.c
+++ b/src/nesc-c.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-c.h"

--- a/src/nesc-c.h
+++ b/src/nesc-c.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_C_H
 #define NESC_C_H

--- a/src/nesc-cg.c
+++ b/src/nesc-cg.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 /* A connection graph */
 #include "parser.h"

--- a/src/nesc-cg.h
+++ b/src/nesc-cg.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_CG_H
 #define NESC_CG_H

--- a/src/nesc-compile
+++ b/src/nesc-compile
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 use File::Basename;
 

--- a/src/nesc-component.c
+++ b/src/nesc-component.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-component.h"

--- a/src/nesc-component.h
+++ b/src/nesc-component.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_COMPONENT_H
 

--- a/src/nesc-concurrency.c
+++ b/src/nesc-concurrency.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-cg.h"

--- a/src/nesc-concurrency.h
+++ b/src/nesc-concurrency.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_CONCURRENCY_H
 

--- a/src/nesc-configuration.c
+++ b/src/nesc-configuration.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-configuration.h"

--- a/src/nesc-configuration.h
+++ b/src/nesc-configuration.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_CONFIGURATION_H
 #define NESC_CONFIGURATION_H

--- a/src/nesc-constants.c
+++ b/src/nesc-constants.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-cg.h"

--- a/src/nesc-cpp.c
+++ b/src/nesc-cpp.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-cpp.h"

--- a/src/nesc-cpp.h
+++ b/src/nesc-cpp.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_CPP_H
 #define NESC_CPP_H

--- a/src/nesc-decls.h
+++ b/src/nesc-decls.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DECLS_H
 #define NESC_DECLS_H

--- a/src/nesc-deputy.c
+++ b/src/nesc-deputy.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-deputy.h"

--- a/src/nesc-deputy.h
+++ b/src/nesc-deputy.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DEPUTY_H
 #define NESC_DEPUTY_H

--- a/src/nesc-dfilter.c
+++ b/src/nesc-dfilter.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include <sys/types.h>
 #include <regex.h>

--- a/src/nesc-dfilter.h
+++ b/src/nesc-dfilter.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DFILTER_H
 #define NESC_DFILTER_H

--- a/src/nesc-doc.c
+++ b/src/nesc-doc.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 /*
   Author:   J. Robert von Behren <jrvb@cs.berkeley.edu>

--- a/src/nesc-doc.h
+++ b/src/nesc-doc.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DOC_H
 #define NESC_DOC_H

--- a/src/nesc-dspec-int.h
+++ b/src/nesc-dspec-int.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DSPEC_INT_H
 #define NESC_DSPEC_INT_H

--- a/src/nesc-dspec.def
+++ b/src/nesc-dspec.def
@@ -14,8 +14,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 (deffield name "const char *" (init))
 (deffield str "const char *" (init))

--- a/src/nesc-dspec.h
+++ b/src/nesc-dspec.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DSPEC_H
 #define NESC_DSPEC_H

--- a/src/nesc-dspec.l
+++ b/src/nesc-dspec.l
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 /* Lexer for -fnesc-dump arguments (tokens are numbers, names (can be
    arbitrary strings in "") and boolean operators */

--- a/src/nesc-dspec.y
+++ b/src/nesc-dspec.y
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 /* Parser for -fnesc-dump option arguments. General forms are:
      NAME

--- a/src/nesc-dump.c
+++ b/src/nesc-dump.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 /* The internal nesC dump information system.
    Current allowable requests:

--- a/src/nesc-dump.h
+++ b/src/nesc-dump.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_DUMP_H
 #define NESC_DUMP_H

--- a/src/nesc-env.c
+++ b/src/nesc-env.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-env.h"

--- a/src/nesc-env.h
+++ b/src/nesc-env.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_ENV_H
 #define NESC_ENV_H

--- a/src/nesc-gcc.c
+++ b/src/nesc-gcc.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-cpp.h"

--- a/src/nesc-gcc.h
+++ b/src/nesc-gcc.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_GCC_H
 #define NESC_GCC_H

--- a/src/nesc-generate.c
+++ b/src/nesc-generate.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "c-parse.h"

--- a/src/nesc-generate.h
+++ b/src/nesc-generate.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_GENERATE_H
 #define NESC_GENERATE_H

--- a/src/nesc-inline.c
+++ b/src/nesc-inline.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-inline.h"

--- a/src/nesc-inline.h
+++ b/src/nesc-inline.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_INLINE_H
 #define NESC_INLINE_H

--- a/src/nesc-interface.c
+++ b/src/nesc-interface.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-interface.h"

--- a/src/nesc-interface.h
+++ b/src/nesc-interface.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_INTERFACE_H
 #define NESC_INTERFACE_H

--- a/src/nesc-main.c
+++ b/src/nesc-main.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include <fcntl.h>
 #include <errno.h>

--- a/src/nesc-main.h
+++ b/src/nesc-main.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_MAIN_H
 #define NESC_MAIN_H

--- a/src/nesc-module.c
+++ b/src/nesc-module.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-module.h"

--- a/src/nesc-module.h
+++ b/src/nesc-module.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_MODULE_H
 #define NESC_MODULE_H

--- a/src/nesc-msg.c
+++ b/src/nesc-msg.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include <ctype.h>
 

--- a/src/nesc-msg.h
+++ b/src/nesc-msg.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_MSG_H
 #define NESC_MSG_H

--- a/src/nesc-ndoc.h
+++ b/src/nesc-ndoc.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_NDOC_H
 #define NESC_NDOC_H

--- a/src/nesc-network.c
+++ b/src/nesc-network.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "constants.h"

--- a/src/nesc-network.h
+++ b/src/nesc-network.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef NESC_NETWORK_H
 

--- a/src/nesc-paths.c
+++ b/src/nesc-paths.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include <sys/stat.h>

--- a/src/nesc-paths.h
+++ b/src/nesc-paths.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_PATHS_H
 #define NESC_PATHS_H

--- a/src/nesc-semantics.c
+++ b/src/nesc-semantics.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include "parser.h"
 #include "nesc-semantics.h"

--- a/src/nesc-semantics.h
+++ b/src/nesc-semantics.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #ifndef NESC_SEMANTICS_H
 #define NESC_SEMANTICS_H

--- a/src/nesc-task.c
+++ b/src/nesc-task.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "constants.h"

--- a/src/nesc-task.h
+++ b/src/nesc-task.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef NESC_TASK_H
 #define NESC_TASK_H

--- a/src/nesc-uses.c
+++ b/src/nesc-uses.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "constants.h"

--- a/src/nesc-uses.h
+++ b/src/nesc-uses.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef NESC_USES_H
 #define NESC_USES_H

--- a/src/nesc-xml.c
+++ b/src/nesc-xml.c
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 
 #include <ctype.h>
 #include "parser.h"

--- a/src/nesc-xml.h
+++ b/src/nesc-xml.h
@@ -12,8 +12,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA.  */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA.  */
 #ifndef NESC_XML_H
 #define NESC_XML_H
 

--- a/src/nodetypes.def
+++ b/src/nodetypes.def
@@ -18,8 +18,8 @@
 ; 
 ; You should have received a copy of the GNU General Public License
 ; along with nesC; see the file COPYING.  If not, write to
-; the Free Software Foundation, 59 Temple Place - Suite 330,
-; Boston, MA 02111-1307, USA.
+; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+; Boston, MA 02110-1301 USA.
 
 ;; AST definition
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef PARSER_H
 #define PARSER_H

--- a/src/sd_list.c
+++ b/src/sd_list.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <regions.h>
 #include "sd_list.h"

--- a/src/sd_list.h
+++ b/src/sd_list.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef SD_LIST_H
 #define SD_LIST_H

--- a/src/semantics.c
+++ b/src/semantics.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "semantics.h"

--- a/src/semantics.h
+++ b/src/semantics.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef SEMANTICS_H
 #define SEMANTICS_H

--- a/src/stmt.c
+++ b/src/stmt.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "stmt.h"

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef STMT_H
 #define STMT_H

--- a/src/toplev.c
+++ b/src/toplev.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <signal.h>
 #include <unistd.h>

--- a/src/types.c
+++ b/src/types.c
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "types.h"

--- a/src/types.h
+++ b/src/types.h
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef TYPES_H
 #define TYPES_H

--- a/src/unparse.c
+++ b/src/unparse.c
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.	If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include <stdarg.h>
 #include <stdlib.h>

--- a/src/unparse.h
+++ b/src/unparse.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef UNPARSE_H
 #define UNPARSE_H

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,8 +20,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #include "parser.h"
 #include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,8 +16,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with nesC; see the file COPYING.  If not, write to
-the Free Software Foundation, 59 Temple Place - Suite 330,
-Boston, MA 02111-1307, USA. */
+the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+Boston, MA 02110-1301 USA. */
 
 #ifndef UTILS_H
 #define UTILS_H

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 AUTOMAKE_OPTIONS = foreign
 

--- a/tools/editor-modes/emacs/nesc.el
+++ b/tools/editor-modes/emacs/nesc.el
@@ -14,8 +14,8 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
-;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA.
+;; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+;; Boston, MA 02110-1301 USA.
 
 (require 'cc-mode)
 

--- a/tools/editor-modes/emacs/new-nesc.el
+++ b/tools/editor-modes/emacs/new-nesc.el
@@ -18,8 +18,8 @@
 ;; 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program; see the file COPYING.  If not, write to
-;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA.
+;; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+;; Boston, MA 02110-1301 USA.
 
 ;;; Code:
 

--- a/tools/editor-modes/emacs/old-nesc.el
+++ b/tools/editor-modes/emacs/old-nesc.el
@@ -19,8 +19,8 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
-;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA.
+;; the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+;; Boston, MA 02110-1301 USA.
 
 ;;; Commentary:
 

--- a/tools/editor-modes/gedit/ncc.lang
+++ b/tools/editor-modes/gedit/ncc.lang
@@ -17,8 +17,8 @@
 
  You should have received a copy of the GNU Library General Public
  License along with this library; if not, write to the
- Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- Boston, MA 02111-1307, USA.
+ Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA 02110-1301 USA.
 
 -->
 <language id="nc" _name="NesC" version="2.0" _section="Sources">

--- a/tools/genc.pm
+++ b/tools/genc.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/gencsharp.pm
+++ b/tools/gencsharp.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/gencstc.pm
+++ b/tools/gencstc.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/gencstjava.pm
+++ b/tools/gencstjava.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/gencstpython.pm
+++ b/tools/gencstpython.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 #
 # Modified by Geoffrey Mainland <mainland@eecs.harvard.edu>

--- a/tools/genjava.pm
+++ b/tools/genjava.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/genpython.pm
+++ b/tools/genpython.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 # Modified by Philip Levis <pal@cs.stanford.edu> to include support
 #   for network types. [1/4/2006]

--- a/tools/migdecode.pm
+++ b/tools/migdecode.pm
@@ -12,8 +12,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 true;
 

--- a/tools/nescc-diff.in
+++ b/tools/nescc-diff.in
@@ -15,8 +15,8 @@
 # 
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 # Configuration
 $prefix = "@prefix@";

--- a/tools/nescc-mig.in
+++ b/tools/nescc-mig.in
@@ -14,8 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 $prefix = "@prefix@";
 $exec_prefix = "@exec_prefix@";

--- a/tools/nescc-ncg.in
+++ b/tools/nescc-ncg.in
@@ -14,8 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 $prefix = "@prefix@";
 $exec_prefix = "@exec_prefix@";

--- a/tools/nescc.in
+++ b/tools/nescc.in
@@ -19,8 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with nesC; see the file COPYING.  If not, write to
-# the Free Software Foundation, 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+# Boston, MA 02110-1301 USA.
 
 # Configuration
 $prefix = "@prefix@";


### PR DESCRIPTION
Use GPLv2 text from http://www.gnu.org/licenses/gpl-2.0.txt and update
FSF address. Based on a patch by Shakthi Kannan
shakthimaan@fedoraproject.org.
