### PR TITLE
Bug in mig's python class generation

### DIFF
--- a/tools/genpython.pm
+++ b/tools/genpython.pm
@@ -380,9 +380,9 @@ sub gen() {
 	      print "    def getString_$pythonfield(self):\n";
 	      print "        carr = \"\";\n";
 	      print "        for i in range(0, 4000):\n";
-	      print "            if self.getElement_$pythonfield(i) == chr(0):\n";
+	      print "            if self.getElement_$pythonfield(i) == 0:\n";
 	      print "                break\n";
-	      print "            carr += self.getElement_$pythonfield(i)\n";
+	      print "            carr += chr(self.getElement_$pythonfield(i))\n";
               print "        return carr\n";
 	      print "    \n";
 	  }


### PR DESCRIPTION
When an array of uint8_t or int8_t is considered as a String in Python, the method setString_$pythonfield adds a trailing 0 to terminate the string.
The method getString_$pythonfield should check every array element against 0, to recognize the end of the string. But on line 383 the test is against chr(0), a string.
Moreover, on line 385 the method adds a number to the output string.

Therefore I moved the chr() function call from line 383 to line 385 so that the method looks for the actual end of the string and it adds a character to the output string.