### PR TITLE
Fix building with -Werror=format-security

### DIFF
--- a/libcpp/macro.c
+++ b/libcpp/macro.c
@@ -1573,7 +1573,7 @@ create_iso_definition (cpp_reader *pfile, cpp_macro *macro)
 	     function-like macros, but not at the end.  */
 	  if (following_paste_op)
 	    {
-	      cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
+	      cpp_error (pfile, CPP_DL_ERROR, "%s", paste_op_error_msg);
 	      return false;
 	    }
 	  break;
@@ -1586,7 +1586,7 @@ create_iso_definition (cpp_reader *pfile, cpp_macro *macro)
 	     function-like macros, but not at the beginning.  */
 	  if (macro->count == 1)
 	    {
-	      cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
+	      cpp_error (pfile, CPP_DL_ERROR, "%s", paste_op_error_msg);
 	      return false;
 	    }
 

--- a/src/nesc-generate.c
+++ b/src/nesc-generate.c
@@ -190,7 +190,7 @@ static bool prt_arguments(declaration parms, bool first, bool rename)
       if (rename || !vd->ddecl->name)
 	output("arg_%p", vd->ddecl);
       else
-	output((char *)vd->ddecl->name);
+	output("%s", (char *)vd->ddecl->name);
     }
   return first;
 }


### PR DESCRIPTION
When buildling with -Wall -Werror=format-security, fatal warnings
arise like this:

gcc  -I. -I. -I./../include -I./include  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D
_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord
-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -W -Wall -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wold-style-definition -Wmissing-format-attribute -pedantic -Wno-long-long  -I. -I. -I./../include -I./include  -c -o macro.o -MT macro.o -MMD -MP -MF .deps/macro.Po macro.c
[...]
macro.c: In function ‘create_iso_definition’:
macro.c:1576:8: error: format not a string literal and no format arguments [-Werror=format-security]
	cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
	^~~~~~~~~
macro.c:1589:8: error: format not a string literal and no format arguments [-Werror=format-security]
	cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
	^~~~~~~~~

This patch fixes them.